### PR TITLE
Convert fi_mr_unreg to fi_close

### DIFF
--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -371,22 +371,11 @@ clean_ctx:
 int pp_close_ctx(struct pingpong_context *ctx)
 {
 	FI_CLOSE(ctx->lep, "Couldn't destroy listener EP\n");
-
 	FI_CLOSE(ctx->ep, "Couldn't destroy EP\n");
-
 	FI_CLOSE(ctx->eq, "Couldn't destroy EQ\n");
-
 	FI_CLOSE(ctx->cq, "Couldn't destroy CQ\n");
-
-	if (ctx->mr) {
-		if (fi_mr_unreg(ctx->mr)) {
-			fprintf(stderr, "Couldn't deregister MR\n");
-			return 1;
-		}
-	}
-
+	FI_CLOSE(ctx->mr, "Couldn't destroy MR\n");
 	FI_CLOSE(ctx->dom, "Couldn't deallocate Domain\n");
-
 	FI_CLOSE(ctx->fabric, "Couldn't close fabric\n");
 
 	if (ctx->buf)

--- a/simple/pingpong.c
+++ b/simple/pingpong.c
@@ -262,7 +262,7 @@ static int alloc_cm_res(void)
 
 static void free_ep_res(void)
 {
-	fi_mr_unreg(mr);
+	fi_close(&mr->fid);
 	fi_close(&rcq->fid);
 	fi_close(&scq->fid);
 	free(buf);


### PR DESCRIPTION
Update to match changes to libfabric static inlines and use
direct call to fi_close.

Signed-off-by: Sean Hefty sean.hefty@intel.com
