### PR TITLE
fi_info should indicate support for all modes

### DIFF
--- a/simple/info.c
+++ b/simple/info.c
@@ -81,6 +81,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	hints.caps = FI_MSG;
+	hints.mode = ~0;		/* support all modes */
 
 	while ((op = getopt(argc, argv, "e:n:p:")) != -1) {
 		switch (op) {


### PR DESCRIPTION
set mode to all 1's so that no providers will exclude themselves based
on mode and so that every provider will report all suggested modes.

Signed-off-by: Reese Faucette rfaucett@cisco.com
