### PR TITLE
change "enum fi_eq_event" -> "uint32_t" since enum name removed

### DIFF
--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -170,7 +170,7 @@ err:
 static int pp_accept_ctx(struct pingpong_context *ctx)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	int rc = 0;
 	int rd = 0;
 
@@ -254,7 +254,7 @@ err:
 static int pp_connect_ctx(struct pingpong_context *ctx)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	int rc = 0;
 
 	/* Open domain */

--- a/simple/pingpong.c
+++ b/simple/pingpong.c
@@ -411,7 +411,7 @@ err0:
 static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
@@ -484,7 +484,7 @@ err1:
 static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *fi;
 	ssize_t rd;
 	int ret;

--- a/simple/read_bw.c
+++ b/simple/read_bw.c
@@ -421,7 +421,7 @@ err0:
 static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
@@ -496,7 +496,7 @@ err1:
 static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *fi;
 	ssize_t rd;
 	int ret;

--- a/simple/read_lat.c
+++ b/simple/read_lat.c
@@ -409,7 +409,7 @@ err0:
 static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
@@ -484,7 +484,7 @@ err1:
 static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *fi;
 	ssize_t rd;
 	int ret;

--- a/simple/write_bw.c
+++ b/simple/write_bw.c
@@ -419,7 +419,7 @@ err0:
 static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
@@ -494,7 +494,7 @@ err1:
 static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *fi;
 	ssize_t rd;
 	int ret;

--- a/simple/write_lat.c
+++ b/simple/write_lat.c
@@ -408,7 +408,7 @@ err0:
 static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
@@ -483,7 +483,7 @@ err1:
 static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	enum fi_eq_event event;
+	uint32_t event;
 	struct fi_info *fi;
 	ssize_t rd;
 	int ret;


### PR DESCRIPTION
Signed-off-by: Reese Faucette rfaucett@cisco.com
