### PR TITLE
Make fi_info a little more general:

### DIFF
--- a/simple/info.c
+++ b/simple/info.c
@@ -27,31 +27,121 @@
  * SOFTWARE.
  */
 
-#include <errno.h>
-#include <getopt.h>
-#include <netdb.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <sys/types.h>
+#include <getopt.h>
 
 #include <rdma/fabric.h>
-#include <rdma/fi_endpoint.h>
-#include <rdma/fi_domain.h>
-#include "shared.h"
 
-
-static struct fi_info hints, *info;
+static struct fi_info hints;
 static char *node, *port;
 
+/* options and matching help strings need to be kept in sync */
 
-static int run(void)
+static const struct option longopts[] = {
+	{"node", required_argument, NULL, 'n'},
+	{"port", required_argument, NULL, 'p'},
+	{"caps", required_argument, NULL, 'c'},
+	{"mode", required_argument, NULL, 'm'},
+	{"ep_type", required_argument, NULL, 'e'},
+	{0,0,0,0}
+};
+
+static const char *help_strings[][2] = {
+	{"NAME", "\t\tnode name or address"},
+	{"PNUM", "\t\tport number"},
+	{"CAP1|CAP2..", "\tone or more capabilities: FI_MSG|FI_RMA..."},
+	{"MOD1|MOD2..", "\tone or more modes, default all modes"},
+	{"EPTYPE", "\t\tspecify single endpoint type: FI_EP_MSG, FI_EP_DGRAM..."},
+	{"", ""}
+};
+
+void usage()
+{
+	int i = 0;
+	const struct option *ptr = longopts;
+
+	for (; ptr->name != NULL; ++i, ptr = &longopts[i])
+		printf("  -%c, --%s=%s%s\n", ptr->val, ptr->name,
+			help_strings[i][0], help_strings[i][1]);
+}
+
+#define ORCASE(SYM) \
+	do { if (strcmp(#SYM, inputstr) == 0) return SYM; } while (0);
+
+uint64_t str2cap(char *inputstr)
+{
+	ORCASE(FI_MSG);
+	ORCASE(FI_RMA);
+	ORCASE(FI_TAGGED);
+	ORCASE(FI_ATOMICS);
+	ORCASE(FI_MULTICAST);
+	ORCASE(FI_DYNAMIC_MR);
+	ORCASE(FI_NAMED_RX_CTX);
+	ORCASE(FI_BUFFERED_RECV);
+	ORCASE(FI_INJECT);
+	ORCASE(FI_MULTI_RECV);
+	ORCASE(FI_SOURCE);
+	ORCASE(FI_SYMMETRIC);
+	ORCASE(FI_READ);
+	ORCASE(FI_WRITE);
+	ORCASE(FI_RECV);
+	ORCASE(FI_SEND);
+	ORCASE(FI_REMOTE_READ);
+	ORCASE(FI_REMOTE_WRITE);
+	ORCASE(FI_REMOTE_CQ_DATA);
+	ORCASE(FI_EVENT);
+	ORCASE(FI_REMOTE_SIGNAL);
+	ORCASE(FI_REMOTE_COMPLETE);
+	ORCASE(FI_CANCEL);
+	ORCASE(FI_MORE);
+	ORCASE(FI_PEEK);
+	ORCASE(FI_TRIGGER);
+
+	return 0;
+}
+
+uint64_t str2mode(char *inputstr)
+{
+	ORCASE(FI_CONTEXT);
+	ORCASE(FI_LOCAL_MR);
+	ORCASE(FI_WRITE_NONCOHERENT);
+	ORCASE(FI_PROV_MR_KEY);
+	ORCASE(FI_MSG_PREFIX);
+
+	return 0;
+}
+
+enum fi_ep_type str2ep_type(char *inputstr)
+{
+	ORCASE(FI_EP_UNSPEC);
+	ORCASE(FI_EP_MSG);
+	ORCASE(FI_EP_DGRAM);
+	ORCASE(FI_EP_RDM);
+
+	/* probably not the right thing to do? */
+	return FI_EP_UNSPEC;
+}
+
+uint64_t tokparse(char *caps, uint64_t (*str2flag) (char *inputstr))
+{
+	uint64_t flags = 0;
+	char *tok;
+
+	for (tok = strtok(caps, "|"); tok != NULL; tok = strtok(NULL, "|"))
+		flags |= str2flag(tok);
+
+	return flags;
+}
+
+static int run(struct fi_info *hints, char *node, char *port)
 {
 	struct fi_info *cur;
+	struct fi_info *info;
 	int ret;
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, 0, &hints, &info);
+	ret = fi_getinfo(FI_VERSION(1, 0), node, port, 0, hints, &info);
 	if (ret) {
 		printf("fi_getinfo %s\n", strerror(-ret));
 		return ret;
@@ -61,49 +151,39 @@ static int run(void)
 		printf("%s\n", fi_tostr(cur, FI_TYPE_INFO));
 
 	fi_freeinfo(info);
-	return 0;
-}
-
-static uint64_t ep_type(char *arg)
-{
-	if (!strcasecmp(arg, "msg"))
-		return FI_EP_MSG;
-	else if (!strcasecmp(arg, "rdm"))
-		return FI_EP_RDM;
-	else if (!strcasecmp(arg, "dgram"))
-		return FI_EP_DGRAM;
-	else
-		return FI_EP_UNSPEC;
+	return EXIT_SUCCESS;
 }
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 
-	hints.caps = FI_MSG;
-	hints.mode = ~0;		/* support all modes */
+	hints.mode = ~0;
 
-	while ((op = getopt(argc, argv, "e:n:p:")) != -1) {
+	while ((op = getopt_long(argc, argv, "n:p:c:m:e:h", longopts, NULL)) != -1) {
 		switch (op) {
-		case 'e':
-			hints.ep_type = ep_type(optarg);
-			break;
 		case 'n':
 			node = optarg;
 			break;
-		case 's':
+		case 'p':
 			port = optarg;
 			break;
+		case 'c':
+			hints.caps = tokparse(optarg, str2cap);
+			break;
+		case 'm':
+			hints.mode = tokparse(optarg, str2mode);
+			break;
+		case 'e':
+			hints.ep_type = str2ep_type(optarg);
+			break;
+		case 'h':
 		default:
 			printf("usage: %s\n", argv[0]);
-			printf("\t[-e ep_type\n");
-			printf("\t    (msg, dgram, rdm)");
-			printf("\t[-n node]\n");
-			printf("\t[-p service_port]\n");
-			exit(1);
+			usage();
+			return (EXIT_FAILURE);
 		}
 	}
 
-	ret = run();
-	return ret;
+	return run(&hints, node, port);
 }


### PR DESCRIPTION
./simple/fi_info -h
usage: ./simple/fi_info
  -n, --node=NAME               node name or address
  -p, --port=PNUM               port number
  -c, --caps=CAP1|CAP2..        one or more capabilities: FI_MSG|FI_RMA...
  -m, --mode=MOD1|MOD2..        one or more modes, default all modes
  -e, --ep_type=EPTYPE          specify single endpoint type: FI_EP_MSG, FI_EP_DGRAM...

Use like:

$ # display proivders' fi_info structure which match criteria:
$ fi_info -e FI_EP_MSG -c "FI_MSG|FI_RMA"
...
