### PR TITLE
Use fi_cq_readerr to read queue errors when fi_cq_read returns EAVAIL.

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -34,6 +34,9 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+
+#include <rdma/fi_errno.h>
+
 #include <shared.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_eq.h>
@@ -165,3 +168,16 @@ int wait_for_completion(struct fid_cq *cq, int num_completions)
 	return 0;
 }
 
+void cq_readerr(struct fid_cq *cq, char *cq_str)
+{ 
+	struct fi_cq_err_entry cq_err;
+	const char *err_str;
+	int ret;
+
+	ret = fi_cq_readerr(cq, &cq_err, sizeof(cq_err), 0);
+	if (ret)
+		printf("fi_cq_readerr %d (%s)\n", ret, fi_strerror(-ret));
+
+	err_str = fi_cq_strerror(cq, cq_err.err, cq_err.err_data, NULL, 0);
+	printf("%s fi_cq_readerr() %s (%d)\n", cq_str, err_str, cq_err.err);
+}

--- a/include/shared.h
+++ b/include/shared.h
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 
 #include <rdma/fabric.h>
+#include <rdma/fi_eq.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,6 +54,7 @@ void size_str(char *str, size_t ssize, long long size);
 void cnt_str(char *str, size_t ssize, long long cnt);
 int size_to_count(int size);
 int wait_for_completion(struct fid_cq *cq, int num_completions);
+void cq_readerr(struct fid_cq *cq, char *cq_str);
 
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))

--- a/simple/pingpong.c
+++ b/simple/pingpong.c
@@ -121,7 +121,11 @@ static int send_xfer(int size)
 		if (ret > 0) {
 			goto post;
 		} else if (ret < 0) {
-			printf("Event queue read %d (%s)\n", ret, fi_strerror(-ret));
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(scq, "scq");
+			} else {
+				printf("Completion queue read %d (%s)\n", ret, fi_strerror(-ret));
+			}
 			return ret;
 		}
 	}
@@ -143,7 +147,11 @@ static int recv_xfer(int size)
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
 		if (ret < 0) {
-			printf("Event queue read %d (%s)\n", ret, fi_strerror(-ret));
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(rcq, "rcq");
+			} else {
+				printf("Completion queue read %d (%s)\n", ret, fi_strerror(-ret));
+			}
 			return ret;
 		}
 	} while (!ret);


### PR DESCRIPTION
Currently we are not returning useful error when fi_cq_read returns EAVAIL. Make use of fi_cq_readerr to display error information from the provider to the user when there are queue errors.
