### PR TITLE
ud_pingpong:  limit RX post to max_mag_size + msg_prefix_size

### DIFF
--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -242,6 +242,9 @@ static int alloc_ep_res(struct fi_info *fi)
 	int ret;
 
 	buffer_size = !custom ? test_size[TEST_CNT - 1].size : transfer_size;
+	if (max_msg_size > 0 && buffer_size > max_msg_size) {
+		buffer_size = max_msg_size;
+	}
 	buffer_size += prefix_len;
 	buf = malloc(buffer_size);
 	if (!buf) {


### PR DESCRIPTION
without this, ud_pingpong tries to post 8MB buffer which does not work

Signed-off-by: Reese Faucette rfaucett@cisco.com
