### PR TITLE
info.c: Fix missing return value in str2addr_format()

### DIFF
--- a/simple/info.c
+++ b/simple/info.c
@@ -134,6 +134,8 @@ uint32_t str2addr_format(char *inputstr)
 	ORCASE(FI_SOCKADDR_IN6);
 	ORCASE(FI_SOCKADDR_IB);
 	ORCASE(FI_ADDR_PSMX);
+
+	return FI_ADDR_UNSPEC;
 }
 
 uint64_t tokparse(char *caps, uint64_t (*str2flag) (char *inputstr))


### PR DESCRIPTION
Signed-off-by: Reese Faucette rfaucett@cisco.com
