### PR TITLE
av_test.c: track change to timeout return for fi_eq_sread()

### DIFF
--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -940,7 +940,7 @@ av_goodbad_2vector_async()
 		}
 	}
 	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), 1000, 0);
-	if (ret != -FI_EAGAIN) {
+	if (ret != -FI_ETIMEDOUT) {
 		sprintf(err_buf, "too many events");
 		goto fail;
 	}


### PR DESCRIPTION
Signed-off-by: Reese Faucette rfaucett@cisco.com
