### PR TITLE
Bugfixes and misc changes

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -172,7 +172,11 @@ int wait_for_completion(struct fid_cq *cq, int num_completions)
 		if (ret > 0) {
 			num_completions--;
 		} else if (ret < 0) {
-			FI_PRINTERR("fi_cq_read", ret);
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(cq, "cq");
+			} else {
+				FI_PRINTERR("fi_cq_read", ret);
+			}
 			return ret;
 		}
 	}

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -472,7 +472,7 @@ static int client_connect(void)
 		printf("Unexpected CM event %d fid %p (ep %p)\n",
 			event, entry.fid, ep);
 		ret = -FI_EOTHER;
-		goto err1;
+		goto err5;
 	}
 
 	if (hints.src_addr)

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -205,9 +205,9 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc, g_argv);
+		show_perf_mr(transfer_size, iterations, &start, &end, 1, g_argc, g_argv);
 	else
-		show_perf(test_name, transfer_size, iterations, &start, &end, 2);
+		show_perf(test_name, transfer_size, iterations, &start, &end, 1);
 
 	return 0;
 }

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -151,11 +151,11 @@ static int send_msg(int size)
 	return ret;
 }
 
-static int recv_msg(int size) 
+static int recv_msg(void) 
 {
 	int ret;
 
-	ret = fi_recv(ep, buf, size, fi_mr_desc(mr), 0, &fi_ctx_recv);
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
 		FI_PRINTERR("fi_recv", ret);
 		return ret;
@@ -411,7 +411,7 @@ static int init_av(void)
 			FI_PRINTERR("fi_getname", ret);
 			return ret;
 		}
-		
+
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
@@ -425,37 +425,38 @@ static int init_av(void)
 			return ret;
 		}
 
-		/* Send local addr size */
+		/* Send local addr size and local addr */
 		memcpy(buf, &addrlen, sizeof(size_t));
-		ret = send_msg(sizeof(size_t));
+		memcpy(buf + sizeof(size_t), local_addr, addrlen);
+		ret = send_msg(sizeof(size_t) + addrlen);
 		if (ret)
 			return ret;
-		
-		/* Send local addr */
-		memcpy(buf, local_addr, addrlen);
-		ret = send_msg(addrlen);
+
+		/* Receive ACK from server */
+		ret = recv_msg();
 		if (ret)
 			return ret;
 
 	} else {
-		/* Get the size of remote address */
-		ret = recv_msg(sizeof(size_t));
+		/* Post a recv to get the remote address */
+		ret = recv_msg();
 		if (ret)
 			return ret;
-		memcpy(&addrlen, buf, sizeof(size_t));
 
-		/* Get remote address */
+		memcpy(&addrlen, buf, sizeof(size_t));
 		remote_addr = malloc(addrlen);
-		ret = recv_msg(addrlen);
-		if (ret)
-			return ret;
-		memcpy(remote_addr, buf, addrlen);
+		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
 		if (ret) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
+
+		/* Send ACK */
+		ret = send_msg(16);
+		if (ret)
+			return ret;
 	}
 
 	/* Post first recv */

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -165,11 +165,11 @@ static int send_msg(int size)
 	return ret;
 }
 
-static int recv_msg(int size)
+static int recv_msg(void)
 {
 	int ret;
 
-	ret = fi_trecv(ep, buf, size, fi_mr_desc(mr), tag_control, 0,
+	ret = fi_trecv(ep, buf, buffer_size, fi_mr_desc(mr), tag_control, 0,
 			0, &fi_ctx_recv);
 	if (ret) {
 		FI_PRINTERR("fi_trecv", ret);
@@ -445,37 +445,38 @@ static int init_av(void)
 			return ret;
 		}
 
-		/* Send local addr size */
+		/* Send local addr size and local addr */
 		memcpy(buf, &addrlen, sizeof(size_t));
-		ret = send_msg(sizeof(size_t));
+		memcpy(buf + sizeof(size_t), local_addr, addrlen);
+		ret = send_msg(sizeof(size_t) + addrlen);
 		if (ret)
 			return ret;
-		
-		/* Send local addr */
-		memcpy(buf, local_addr, addrlen);
-		ret = send_msg(addrlen);
+
+		/* Receive ACK from server */
+		ret = recv_msg();
 		if (ret)
 			return ret;
 
 	} else {
-		/* Get the size of remote address */
-		ret = recv_msg(sizeof(size_t));
+		/* Post a recv to get the remote address */
+		ret = recv_msg();
 		if (ret)
 			return ret;
-		memcpy(&addrlen, buf, sizeof(size_t));
 
-		/* Get remote address */
+		memcpy(&addrlen, buf, sizeof(size_t));
 		remote_addr = malloc(addrlen);
-		ret = recv_msg(addrlen);
-		if (ret)
-			return ret;
-		memcpy(remote_addr, buf, addrlen);
+		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
 		if (ret) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
+
+		/* Send ACK */
+		ret = send_msg(16);
+		if (ret)
+			return ret;
 	}
 
 	/* Post first recv */


### PR DESCRIPTION
1. Correct latency calculation in RMA examples.(Fixes #73 )
2. Prevent race condition in rdm examples.
3. Print CQ error info when fi_cq_read returns -EAVAIL.

Signed-off-by: Arun C Ilango arun.ilango@intel.com
