### PR TITLE
simple: fi_inject and fi_senddata examples.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,8 @@ bin_PROGRAMS = \
 	simple/fi_rdm_cntr_pingpong \
 	simple/fi_rdm_rma \
 	simple/fi_ud_pingpong \
+	simple/fi_imm_data \
+	simple/fi_rdm_inject_pingpong \
 	unit/fi_eq_test \
 	unit/fi_av_test \
 	ported/libibverbs/fi_rc_pingpong
@@ -43,6 +45,14 @@ simple_fi_rdm_rma_SOURCES = \
 
 simple_fi_ud_pingpong_SOURCES = \
 	simple/ud_pingpong.c \
+	common/shared.c
+
+simple_fi_rdm_inject_pingpong_SOURCES = \
+	simple/rdm_inject_pingpong.c \
+	common/shared.c
+
+simple_fi_imm_data_SOURCES = \
+	simple/imm_data.c \
 	common/shared.c
 
 unit_fi_eq_test_SOURCES = \

--- a/simple/imm_data.c
+++ b/simple/imm_data.c
@@ -1,0 +1,512 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the OpenIB.org BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <time.h>
+#include <netdb.h>
+#include <unistd.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <shared.h>
+
+static void *buf;
+static size_t buffer_size;
+static int rx_depth = 500;
+static size_t cq_data_size;
+
+static struct fi_info hints;
+static struct fi_domain_attr domain_hints;
+static struct fi_ep_attr ep_hints;
+static char *dst_addr, *src_addr;
+static char *port = "9228";
+
+static struct fid_fabric *fab;
+static struct fid_pep *pep;
+static struct fid_domain *dom;
+static struct fid_ep *ep;
+static struct fid_eq *cmeq;
+static struct fid_cq *rcq, *scq;
+static struct fid_mr *mr;
+
+static void free_lres(void)
+{
+	fi_close(&cmeq->fid);
+}
+
+static int alloc_cm_res(void)
+{
+	struct fi_eq_attr cm_attr;
+	int ret;
+
+	memset(&cm_attr, 0, sizeof cm_attr);
+	cm_attr.wait_obj = FI_WAIT_FD;
+	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
+	if (ret)
+		printf("fi_eq_open cm %s\n", fi_strerror(-ret));
+
+	return ret;
+}
+
+static void free_ep_res(void)
+{
+	fi_close(&mr->fid);
+	fi_close(&rcq->fid);
+	fi_close(&scq->fid);
+	free(buf);
+}
+
+static int alloc_ep_res(struct fi_info *fi)
+{
+	struct fi_cq_attr cq_attr;
+	int ret;
+
+	buffer_size = test_size[TEST_CNT - 1].size;
+	buf = malloc(buffer_size);
+	if (!buf) {
+		perror("malloc");
+		return -1;
+	}
+
+	memset(&cq_attr, 0, sizeof cq_attr);
+	cq_attr.format = FI_CQ_FORMAT_DATA;
+	cq_attr.wait_obj = FI_WAIT_NONE;
+	cq_attr.size = rx_depth;
+	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	if (ret) {
+		printf("fi_cq_open send comp %s\n", fi_strerror(-ret));
+		goto err1;
+	}
+
+	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
+	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	if (ret) {
+		printf("fi_cq_open recv comp %s\n", fi_strerror(-ret));
+		goto err2;
+	}
+
+	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	if (ret) {
+		printf("fi_mr_reg %s\n", fi_strerror(-ret));
+		goto err3;
+	}
+
+	if (!cmeq) {
+		ret = alloc_cm_res();
+		if (ret)
+			goto err4;
+	}
+
+	return 0;
+
+err4:
+	fi_close(&mr->fid);
+err3:
+	fi_close(&rcq->fid);
+err2:
+	fi_close(&scq->fid);
+err1:
+	free(buf);
+	return ret;
+}
+
+static int bind_ep_res(void)
+{
+	int ret;
+
+	ret = fi_bind(&ep->fid, &cmeq->fid, 0);
+	if (ret) {
+		printf("fi_bind %s\n", fi_strerror(-ret));
+		return ret;
+	}
+
+	ret = fi_bind(&ep->fid, &scq->fid, FI_SEND);
+	if (ret) {
+		printf("fi_bind %s\n", fi_strerror(-ret));
+		return ret;
+	}
+
+	ret = fi_bind(&ep->fid, &rcq->fid, FI_RECV);
+	if (ret) {
+		printf("fi_bind %s\n", fi_strerror(-ret));
+		return ret;
+	}
+
+	ret = fi_enable(ep);
+	if (ret)
+		return ret;
+
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
+	if (ret)
+		printf("fi_recv %d (%s)\n", ret, fi_strerror(-ret));
+
+	return ret;
+}
+
+static int server_listen(void)
+{
+	struct fi_info *fi;
+	int ret;
+
+	ret = fi_getinfo(FI_VERSION(1, 0), src_addr, port, FI_SOURCE, &hints, &fi);
+	if (ret) {
+		printf("fi_getinfo %s\n", strerror(-ret));
+		return ret;
+	}
+
+	cq_data_size = fi->domain_attr->cq_data_size;
+
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	if (ret) {
+		printf("fi_fabric %s\n", fi_strerror(-ret));
+		goto err0;
+	}
+
+	ret = fi_pendpoint(fab, fi, &pep, NULL);
+	if (ret) {
+		printf("fi_pendpoint %s\n", fi_strerror(-ret));
+		goto err1;
+	}
+
+	ret = alloc_cm_res();
+	if (ret)
+		goto err2;
+
+	ret = fi_bind(&pep->fid, &cmeq->fid, 0);
+	if (ret) {
+		printf("fi_bind %s\n", fi_strerror(-ret));
+		goto err3;
+	}
+
+	ret = fi_listen(pep);
+	if (ret) {
+		printf("fi_listen %s\n", fi_strerror(-ret));
+		goto err3;
+	}
+
+	fi_freeinfo(fi);
+	return 0;
+err3:
+	free_lres();
+err2:
+	fi_close(&pep->fid);
+err1:
+	fi_close(&fab->fid);
+err0:
+	fi_freeinfo(fi);
+	return ret;
+}
+
+static int server_connect(void)
+{
+	struct fi_eq_cm_entry entry;
+	uint32_t event;
+	struct fi_info *info = NULL;
+	ssize_t rd;
+	int ret;
+
+	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	if (rd != sizeof entry) {
+		printf("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		return (int) rd;
+	}
+
+	if (event != FI_CONNREQ) {
+		printf("Unexpected CM event %d\n", event);
+		ret = -FI_EOTHER;
+		goto err1;
+	}
+
+	info = entry.info;
+	ret = fi_domain(fab, info, &dom, NULL);
+	if (ret) {
+		printf("fi_domain %s\n", fi_strerror(-ret));
+		goto err1;
+	}
+
+	ret = fi_endpoint(dom, info, &ep, NULL);
+	if (ret) {
+		printf("fi_endpoint for req %s\n", fi_strerror(-ret));
+		goto err1;
+	}
+
+	ret = alloc_ep_res(info);
+	if (ret)
+		 goto err2;
+
+	ret = bind_ep_res();
+	if (ret)
+		goto err3;
+
+	ret = fi_accept(ep, NULL, 0);
+	if (ret) {
+		printf("fi_accept %s\n", fi_strerror(-ret));
+		goto err3;
+	}
+
+	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	if (rd != sizeof entry) {
+		printf("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		goto err3;
+	}
+
+	if (event != FI_COMPLETE || entry.fid != &ep->fid) {
+		printf("Unexpected CM event %d fid %p (ep %p)\n",
+			event, entry.fid, ep);
+		ret = -FI_EOTHER;
+		goto err3;
+	}
+
+	fi_freeinfo(info);
+	return 0;
+
+err3:
+	free_ep_res();
+err2:
+	fi_close(&ep->fid);
+err1:
+	fi_reject(pep, info->connreq, NULL, 0);
+	fi_freeinfo(info);
+	return ret;
+}
+
+static int client_connect(void)
+{
+	struct fi_eq_cm_entry entry;
+	uint32_t event;
+	struct fi_info *fi;
+	ssize_t rd;
+	int ret;
+
+	if (src_addr) {
+		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
+			      (socklen_t *) &hints.src_addrlen);
+		if (ret) {
+			printf("source address error %s\n", gai_strerror(ret));
+			return ret;
+		}
+	}
+
+	ret = fi_getinfo(FI_VERSION(1, 0), dst_addr, port, 0, &hints, &fi);
+	if (ret) {
+		printf("fi_getinfo %s\n", strerror(-ret));
+		goto err0;
+	}
+
+	cq_data_size = fi->domain_attr->cq_data_size;
+
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	if (ret) {
+		printf("fi_fabric %s\n", fi_strerror(-ret));
+		goto err1;
+	}
+
+	ret = fi_domain(fab, fi, &dom, NULL);
+	if (ret) {
+		printf("fi_domain %s %s\n", fi_strerror(-ret),
+			fi->domain_attr->name);
+		goto err2;
+	}
+
+	ret = fi_endpoint(dom, fi, &ep, NULL);
+	if (ret) {
+		printf("fi_endpoint %s\n", fi_strerror(-ret));
+		goto err3;
+	}
+
+	ret = alloc_ep_res(fi);
+	if (ret)
+		goto err4;
+
+	ret = bind_ep_res();
+	if (ret)
+		goto err5;
+
+	ret = fi_connect(ep, fi->dest_addr, NULL, 0);
+	if (ret) {
+		printf("fi_connect %s\n", fi_strerror(-ret));
+		goto err5;
+	}
+
+	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	if (rd != sizeof entry) {
+		printf("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		return (int) rd;
+	}
+
+	if (event != FI_COMPLETE || entry.fid != &ep->fid) {
+		printf("Unexpected CM event %d fid %p (ep %p)\n",
+			event, entry.fid, ep);
+		ret = -FI_EOTHER;
+		goto err5;
+	}
+
+	if (hints.src_addr)
+		free(hints.src_addr);
+	fi_freeinfo(fi);
+	return 0;
+
+err5:
+	free_ep_res();
+err4:
+	fi_close(&ep->fid);
+err3:
+	fi_close(&dom->fid);
+err2:
+	fi_close(&fab->fid);
+err1:
+	fi_freeinfo(fi);
+err0:
+	if (hints.src_addr)
+		free(hints.src_addr);
+	return ret;
+}
+
+static int run_test()
+{
+	int ret;
+	size_t size = 1000;
+	uint64_t remote_cq_data;
+	struct fi_cq_data_entry comp;
+	
+	/* Set remote_cq_data based on the cq_data_size we got from fi_getinfo */
+	remote_cq_data = 0x0123456789abcdef & ((0x1ULL << (cq_data_size * 8)) - 1);
+
+	if (dst_addr) {
+		fprintf(stdout, "Posting send with immediate data: %lx\n", remote_cq_data);
+		ret = fi_senddata(ep, buf, size, fi_mr_desc(mr), remote_cq_data, 
+				0, buf);
+		if (ret) {
+			FI_PRINTERR("fi_send", ret);
+			return ret;
+		}
+
+		wait_for_completion(scq, 1);
+		fprintf(stdout, "Done\n");
+	} else {
+		ret = fi_recv(ep, buf, size, fi_mr_desc(mr), 0, buf);
+		if (ret) {
+			FI_PRINTERR("fi_recv", ret);
+			return ret;
+		}
+
+		// TODO sread will not work right now due to a libfabric bug. Check back later.
+		fprintf(stdout, "Waiting for immediate data from client\n");
+		ret = fi_cq_sread(rcq, &comp, 1, NULL, -1);
+		if (ret < 0) {
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(rcq, "rcq");
+			} else {
+				FI_PRINTERR("fi_cq_read: rcq", ret);
+			}
+			return ret;
+		}
+
+		/* Verify completion data */
+		if (comp.data == remote_cq_data)
+			fprintf(stdout, "remote_cq_data: success\n");
+		else
+			fprintf(stdout, "remote_cq_data: failure\n");
+
+		fprintf(stdout, "Expected data:0x%lx, Received data:0x%lx\n",
+				remote_cq_data, comp.data);
+	}
+	
+	return 0;
+}
+
+static int run(void)
+{
+	int ret = 0;
+
+	if (!dst_addr) {
+		ret = server_listen();
+		if (ret)
+			return ret;
+	}
+
+	ret = dst_addr ? client_connect() : server_connect();
+	if (ret) {
+		return ret;
+	}
+
+	run_test();
+
+	fi_shutdown(ep, 0);
+	fi_close(&ep->fid);
+	free_ep_res();
+	if (!dst_addr)
+		free_lres();
+	fi_close(&dom->fid);
+	fi_close(&fab->fid);
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	int op;
+
+	while ((op = getopt(argc, argv, "d:n:p:s:")) != -1) {
+		switch (op) {
+		case 'd':
+			dst_addr = optarg;
+			break;
+		case 'n':
+			domain_hints.name = optarg;
+			break;
+		case 'p':
+			port = optarg;
+			break;
+		case 's':
+			src_addr = optarg;
+			break;
+		default:
+			printf("usage: %s\n", argv[0]);
+			printf("\t[-d destination_address]\n");
+			printf("\t[-n domain_name]\n");
+			printf("\t[-p port_number]\n");
+			printf("\t[-s source_address]\n");
+			exit(1);
+		}
+	}
+
+	hints.domain_attr = &domain_hints;
+	hints.ep_attr = &ep_hints;
+	hints.ep_type = FI_EP_MSG;
+	hints.caps = FI_MSG | FI_REMOTE_CQ_DATA;
+	hints.mode = FI_LOCAL_MR | FI_PROV_MR_ATTR;
+	hints.addr_format = FI_SOCKADDR;
+
+	return run();
+}

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -1,0 +1,514 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <time.h>
+#include <netdb.h>
+#include <unistd.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <shared.h>
+
+static int custom;
+static int size_option;
+static int iterations = 1000;
+static int transfer_size = 1000;
+static int max_credits = 128;
+static char test_name[10] = "custom";
+static struct timespec start, end;
+static void *send_buf, *recv_buf;
+static size_t buffer_size;
+static int machr, g_argc;
+static char **g_argv;
+
+static struct fi_info hints;
+static struct fi_domain_attr domain_hints;
+static struct fi_ep_attr ep_hints;
+static char *dst_addr, *src_addr;
+static char *port = NULL;
+
+static struct fid_fabric *fab;
+static struct fid_domain *dom;
+static struct fid_ep *ep;
+static struct fid_cq *rcq;
+static struct fid_av *av;
+static struct fid_mr *mr;
+static void *local_addr, *remote_addr;
+static size_t addrlen = 0;
+static fi_addr_t remote_fi_addr;
+struct fi_context fi_ctx_send;
+struct fi_context fi_ctx_recv;
+struct fi_context fi_ctx_av;
+
+static int send_xfer(int size)
+{
+	int ret;
+
+	ret = fi_inject(ep, send_buf, (size_t) size, remote_fi_addr);
+	if (ret)
+		FI_PRINTERR("fi_inject", ret);
+
+	return ret;
+}
+
+static int recv_xfer(int size)
+{
+	struct fi_cq_entry comp;
+	int ret;
+
+	do {
+		ret = fi_cq_read(rcq, &comp, 1);
+		if (ret < 0) {
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(rcq, "rcq");
+			} else {
+				FI_PRINTERR("fi_cq_read: rcq", ret);
+			}
+			return ret;
+		}
+	} while (!ret);
+
+	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
+			&fi_ctx_recv);
+	if (ret)
+		FI_PRINTERR("fi_recv", ret);
+
+	return ret;
+}
+
+static int send_msg(int size)
+{
+	int ret;
+
+	ret = fi_inject(ep, send_buf, (size_t) size, remote_fi_addr);
+	if (ret) {
+		FI_PRINTERR("fi_inject", ret);
+		return ret;
+	}
+
+	return ret;
+}
+
+static int recv_msg(void)
+{
+	int ret;
+
+	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
+	if (ret) {
+		FI_PRINTERR("fi_recv", ret);
+		return ret;
+	}
+
+	ret = wait_for_completion(rcq, 1);
+
+	return ret;
+}
+
+static int sync_test(void)
+{
+	int ret;
+
+	ret = dst_addr ? send_xfer(16) : recv_xfer(16);
+	if (ret)
+		return ret;
+
+	return dst_addr ? recv_xfer(16) : send_xfer(16);
+}
+
+static int run_test(void)
+{
+	int ret, i;
+
+	ret = sync_test();
+	if (ret)
+		goto out;
+
+	clock_gettime(CLOCK_MONOTONIC, &start);
+	for (i = 0; i < iterations; i++) {
+		ret = dst_addr ? send_xfer(transfer_size) :
+				 recv_xfer(transfer_size);
+		if (ret)
+			goto out;
+
+		ret = dst_addr ? recv_xfer(transfer_size) :
+				 send_xfer(transfer_size);
+		if (ret)
+			goto out;
+	}
+	clock_gettime(CLOCK_MONOTONIC, &end);
+
+	if (machr)
+		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc, g_argv);
+	else
+		show_perf(test_name, transfer_size, iterations, &start, &end, 2);
+
+	ret = 0;
+
+out:
+	return ret;
+}
+
+static void free_ep_res(void)
+{
+	fi_close(&av->fid);
+	fi_close(&mr->fid);
+	fi_close(&rcq->fid);
+	free(send_buf);
+	free(recv_buf);
+}
+
+static int alloc_ep_res(struct fi_info *fi)
+{
+	struct fi_cq_attr cq_attr;
+	struct fi_av_attr av_attr;
+	int ret;
+
+	buffer_size = !custom ? test_size[TEST_CNT - 1].size : transfer_size;
+	send_buf = malloc(buffer_size);
+	recv_buf = malloc(buffer_size);
+	if (!send_buf || !recv_buf) {
+		perror("malloc");
+		return -1;
+	}
+
+	memset(&cq_attr, 0, sizeof cq_attr);
+	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
+	cq_attr.wait_obj = FI_WAIT_NONE;
+	cq_attr.size = max_credits << 1;
+
+	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	if (ret) {
+		FI_PRINTERR("fi_cq_open: rcq", ret);
+		goto err1;
+	}
+
+	/* Memory registration not required for send_buf since we use fi_inject.
+	 * fi_inject copies the buffer of data that needs to be sent. */
+	ret = fi_mr_reg(dom, recv_buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	if (ret) {
+		FI_PRINTERR("fi_cq_open: rcq", ret);
+		goto err2;
+	}
+
+	memset(&av_attr, 0, sizeof av_attr);
+	av_attr.type = FI_AV_MAP;
+	av_attr.count = 1;
+	av_attr.name = "addr to fi_addr map";
+
+	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	if (ret) {
+		FI_PRINTERR("fi_av_open", ret);
+		goto err3;
+	}
+
+	return 0;
+
+err3:
+	fi_close(&mr->fid);
+err2:
+	fi_close(&rcq->fid);
+err1:
+	free(send_buf);
+	free(recv_buf);
+	return ret;
+}
+
+static int bind_ep_res(void)
+{
+	int ret;
+
+	ret = fi_bind(&ep->fid, &rcq->fid, FI_RECV);
+	if (ret) {
+		FI_PRINTERR("fi_bind: rcq", ret);
+		return ret;
+	}
+
+	ret = fi_bind(&ep->fid, &av->fid, 0);
+	if (ret) {
+		FI_PRINTERR("fi_bind: av", ret);
+		return ret;
+	}
+
+	ret = fi_enable(ep);
+	if (ret) {
+		FI_PRINTERR("fi_enable", ret);
+		return ret;
+	}
+
+	return ret;
+}
+
+static int init_fabric(void)
+{
+	struct fi_info *fi;
+	char *node;
+	uint64_t flags = 0;
+	int ret;
+
+	if (src_addr) {
+		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
+			      (socklen_t *) &hints.src_addrlen);
+		if (ret) {
+			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			return ret;
+		}
+	}
+
+	if (dst_addr) {
+		node = dst_addr;
+	} else {
+		node = src_addr;
+		flags = FI_SOURCE;
+	}
+
+	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	if (ret) {
+		FI_PRINTERR("fi_getinfo", ret);
+		return ret;
+	}
+
+	/* We use provider MR attributes and direct address (no offsets) for RMA calls */
+	if (!(fi->mode & FI_PROV_MR_ATTR))
+		fi->mode |= FI_PROV_MR_ATTR;
+
+	/* Get remote address */
+	if (dst_addr) {
+		addrlen = fi->dest_addrlen;
+		remote_addr = malloc(addrlen);
+		memcpy(remote_addr, fi->dest_addr, addrlen);
+	}
+
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	if (ret) {
+		FI_PRINTERR("fi_fabric", ret);
+		goto err0;
+	}
+
+	ret = fi_domain(fab, fi, &dom, NULL);
+	if (ret) {
+		FI_PRINTERR("fi_domain", ret);
+		goto err1;
+	}
+
+	ret = fi_endpoint(dom, fi, &ep, NULL);
+	if (ret) {
+		FI_PRINTERR("fi_endpoint", ret);
+		goto err2;
+	}
+
+	ret = alloc_ep_res(fi);
+	if (ret)
+		goto err3;
+
+	ret = bind_ep_res();
+	if (ret)
+		goto err4;
+
+	return 0;
+
+err4:
+	free_ep_res();
+err3:
+	fi_close(&ep->fid);
+err2:
+	fi_close(&dom->fid);
+err1:
+	fi_close(&fab->fid);
+err0:
+	fi_freeinfo(fi);
+
+	return ret;
+}
+
+static int init_av(void)
+{
+	int ret;
+
+	if (dst_addr) {
+		/* Get local address blob. Find the addrlen first. We set addrlen 
+		 * as 0 and fi_getname will return the actual addrlen. */
+		addrlen = 0;
+		ret = fi_getname(&ep->fid, local_addr, &addrlen);
+		if (ret != -FI_ETOOSMALL) {
+			FI_PRINTERR("fi_getname", ret);
+			return ret;
+		}
+
+		local_addr = malloc(addrlen);
+		ret = fi_getname(&ep->fid, local_addr, &addrlen);
+		if (ret) {
+			FI_PRINTERR("fi_getname", ret);
+			return ret;
+		}
+
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		if (ret) {
+			FI_PRINTERR("fi_av_insert", ret);
+			return ret;
+		}
+
+		/* Send local addr size and local addr */
+		memcpy(send_buf, &addrlen, sizeof(size_t));
+		memcpy(send_buf + sizeof(size_t), local_addr, addrlen);
+		ret = send_msg(sizeof(size_t) + addrlen);
+		if (ret)
+			return ret;
+
+		/* Receive ACK from server */
+		ret = recv_msg();
+		if (ret)
+			return ret;
+
+	} else {
+		/* Post a recv to get the remote address */
+		ret = recv_msg();
+		if (ret)
+			return ret;
+
+		memcpy(&addrlen, recv_buf, sizeof(size_t));
+		remote_addr = malloc(addrlen);
+		memcpy(remote_addr, recv_buf + sizeof(size_t), addrlen);
+
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		if (ret) {
+			FI_PRINTERR("fi_av_insert", ret);
+			return ret;
+		}
+
+		/* Send ACK */
+		ret = send_msg(16);
+		if (ret)
+			return ret;
+	}
+
+	/* Post first recv */
+	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
+			&fi_ctx_recv);
+	if (ret)
+		FI_PRINTERR("fi_recv", ret);
+
+	return ret;
+}
+
+static int run(void)
+{
+	int i, ret = 0;
+
+	ret = init_fabric();
+	if (ret)
+		return ret;
+
+	ret = init_av();
+	if (ret)
+		goto out;
+
+	if (!custom) {
+		for (i = 0; i < TEST_CNT; i++) {
+			if (test_size[i].option > size_option)
+				continue;
+			init_test(test_size[i].size, test_name, &transfer_size, 
+					&iterations);
+			run_test();
+		}
+	} else {
+		ret = run_test();
+	}
+
+out:
+	fi_close(&ep->fid);
+	free_ep_res();
+	fi_close(&dom->fid);
+	fi_close(&fab->fid);
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	int op, ret;
+
+	while ((op = getopt(argc, argv, "d:n:p:s:I:S:m")) != -1) {
+		switch (op) {
+		case 'd':
+			dst_addr = optarg;
+			break;
+		case 'n':
+			domain_hints.name = optarg;
+			break;
+		case 'p':
+			port = optarg;
+			break;
+		case 's':
+			src_addr = optarg;
+			break;
+		case 'I':
+			custom = 1;
+			iterations = atoi(optarg);
+			break;
+		case 'S':
+			if (!strncasecmp("all", optarg, 3)) {
+				size_option = 1;
+			} else {
+				custom = 1;
+				transfer_size = atoi(optarg);
+			}
+			break;
+		case 'm':
+			machr = 1;
+			g_argc = argc;
+			g_argv = argv;
+			break;
+		default:
+			printf("usage: %s\n", argv[0]);
+			printf("\t[-d destination_address]\n");
+			printf("\t[-n domain_name]\n");
+			printf("\t[-p port_number]\n");
+			printf("\t[-s source_address]\n");
+			printf("\t[-I iterations]\n");
+			printf("\t[-S transfer_size or 'all']\n");
+			printf("\t[-m machine readable output]\n");
+			exit(1);
+		}
+	}
+
+	hints.domain_attr = &domain_hints;
+	hints.ep_attr = &ep_hints;
+	hints.ep_type = FI_EP_RDM;
+	hints.caps = FI_MSG | FI_INJECT;
+	hints.mode = FI_CONTEXT;
+	hints.addr_format = FI_ADDR_UNSPEC;
+
+	ret = run();
+	return ret;
+}


### PR DESCRIPTION
This patch adds examples for fi_inject and sending immediate data.
Also covers the usage for fi_cq_sread.

Signed-off-by: Arun C Ilango arun.ilango@intel.com
