### PR TITLE
Fix incorrect return value check for av_insert in RDM* examples

### DIFF
--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -420,7 +420,7 @@ static int init_av(void)
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
@@ -448,7 +448,7 @@ static int init_av(void)
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -386,7 +386,7 @@ static int init_av(void)
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
@@ -414,7 +414,7 @@ static int init_av(void)
 		memcpy(remote_addr, recv_buf + sizeof(size_t), addrlen);
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -394,7 +394,7 @@ static int init_av(void)
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
@@ -423,7 +423,7 @@ static int init_av(void)
 
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -440,7 +440,7 @@ static int init_av(void)
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
@@ -468,7 +468,7 @@ static int init_av(void)
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}


### PR DESCRIPTION
Signed-off-by: Jithin Jose jithin.jose@intel.com
