### PR TITLE
Added default port number and set default transfer size to 1024

### DIFF
--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -44,7 +44,7 @@
 static int custom;
 static int size_option;
 static int iterations = 1000;
-static int transfer_size = 1000;
+static int transfer_size = 1024;
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -45,7 +45,7 @@ static uint64_t op_type = FI_REMOTE_WRITE;
 static int custom;
 static int size_option;
 static int iterations = 1000;
-static int transfer_size = 1000;
+static int transfer_size = 1024;
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -46,7 +46,7 @@
 static int custom;
 static int size_option;
 static int iterations = 1000;
-static int transfer_size = 1000;
+static int transfer_size = 1024;
 static int max_credits = 128;
 static int credits = 128;
 static int send_count = 0;
@@ -61,7 +61,7 @@ static struct fi_info hints;
 static struct fi_domain_attr domain_hints;
 static struct fi_ep_attr ep_hints;
 static char *dst_addr, *src_addr;
-static char *port = NULL;
+static char *port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -44,7 +44,7 @@
 static int custom;
 static int size_option;
 static int iterations = 1000;
-static int transfer_size = 1000;
+static int transfer_size = 1024;
 static int max_inject_size;
 static int max_credits = 128;
 static char test_name[10] = "custom";
@@ -58,7 +58,7 @@ static struct fi_info hints;
 static struct fi_domain_attr domain_hints;
 static struct fi_ep_attr ep_hints;
 static char *dst_addr, *src_addr;
-static char *port = NULL;
+static char *port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -44,7 +44,7 @@
 static int custom;
 static int size_option;
 static int iterations = 1000;
-static int transfer_size = 1000;
+static int transfer_size = 1024;
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";
@@ -59,7 +59,7 @@ static struct fi_domain_attr domain_hints;
 static struct fi_fabric_attr fabric_hints;
 static struct fi_ep_attr ep_hints;
 static char *dst_addr, *src_addr;
-static char *port = NULL;
+static char *port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -46,7 +46,7 @@ static uint64_t op_type = FI_REMOTE_WRITE;
 static int custom;
 static int size_option;
 static int iterations = 1000;
-static int transfer_size = 1000;
+static int transfer_size = 1024;
 static int max_credits = 128;
 static char test_name[10] = "custom";
 static struct timespec start, end;
@@ -60,7 +60,7 @@ static struct fi_info hints;
 static struct fi_domain_attr domain_hints;
 static struct fi_ep_attr ep_hints;
 static char *dst_addr, *src_addr;
-static char *port = NULL;
+static char *port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -45,7 +45,7 @@
 static int custom;
 static int size_option;
 static int iterations = 1000;
-static int transfer_size = 1000;
+static int transfer_size = 1024;
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";
@@ -59,7 +59,7 @@ static struct fi_info hints;
 static struct fi_domain_attr domain_hints;
 static struct fi_ep_attr ep_hints;
 static char *dst_addr, *src_addr;
-static char *port = NULL;
+static char *port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -49,7 +49,7 @@
 static int custom;
 static int size_option;
 static int iterations = 1000;
-static int transfer_size = 1000;
+static int transfer_size = 1024;
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";


### PR DESCRIPTION
- Some provider requires port number to be specified. So added a default port number in case user doesn't specify it in the parameter.
- Set the default transfer size to 1024
