### PR TITLE
Removed named AV from examples and fixed some formatting issues

### DIFF
--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -125,7 +125,7 @@ static int alloc_ep_res(void)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	/* Open address vector (AV) for mapping address */
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
@@ -260,8 +260,8 @@ static int send_recv()
 		/* Client */
 		fprintf(stdout, "Posting a send...\n");
 		sprintf(buf, "Hello from Client!"); 
-		ret = fi_send(ep, buf, sizeof("Hello from Client!"), fi_mr_desc(mr), 
-				remote_fi_addr, &fi_ctx_send);
+		ret = fi_send(ep, buf, sizeof("Hello from Client!"), 
+				fi_mr_desc(mr), remote_fi_addr, &fi_ctx_send);
 		if (ret) {
 			FI_PRINTERR("fi_send", ret);
 			return ret;
@@ -280,7 +280,8 @@ static int send_recv()
 	} else {
 		/* Server */
 		fprintf(stdout, "Posting a recv...\n");
-		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
+		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, 
+				&fi_ctx_recv);
 		if (ret) {
 			FI_PRINTERR("fi_recv", ret);
 			return ret;

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -153,7 +153,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	/* Open Address Vector */
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
@@ -248,10 +248,12 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = getaddr(src_addr, NULL, 
+				(struct sockaddr **) &hints.src_addr, 
+				(socklen_t *) &hints.src_addrlen);
 		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			fprintf(stderr, "source address error %s\n", 
+					gai_strerror(ret));
 			return ret;
 		}
 	}
@@ -339,7 +341,8 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -367,7 +370,8 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -125,7 +125,7 @@ static int alloc_ep_res(void)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	/* Open address vector (AV) for mapping address */
 	ret = fi_av_open(dom, &av_attr, &av, NULL);

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -232,8 +232,8 @@ static int execute_base_atomic_op(enum fi_op op)
 {
 	int ret;
 	
-	ret = fi_atomic(ep, buf, 1, fi_mr_desc(mr), remote_fi_addr, remote.addr, 
-			remote.key, datatype, op, &fi_ctx_atomic);
+	ret = fi_atomic(ep, buf, 1, fi_mr_desc(mr), remote_fi_addr, remote.addr,
+		       	remote.key, datatype, op, &fi_ctx_atomic);
 	if (ret) {
 		fprintf(stderr, "fi_atomic %d (%s)\n", ret, fi_strerror(-ret));
 	} else {						
@@ -248,10 +248,11 @@ static int execute_fetch_atomic_op(enum fi_op op)
 	int ret;
 		
 	ret = fi_fetch_atomic(ep, buf, 1, fi_mr_desc(mr), result, 
-			fi_mr_desc(mr_result), remote_fi_addr, remote.addr, remote.key, 
-			datatype, op, &fi_ctx_atomic);
+			fi_mr_desc(mr_result), remote_fi_addr, remote.addr, 
+			remote.key, datatype, op, &fi_ctx_atomic);
 	if (ret) {
-		fprintf(stderr, "fi_fetch_atomic %d (%s)\n", ret, fi_strerror(-ret));
+		fprintf(stderr, "fi_fetch_atomic %d (%s)\n", ret, 
+				fi_strerror(-ret));
 	} else {						
 		ret = wait_for_completion(scq, 1);
 	}
@@ -268,7 +269,8 @@ static int execute_compare_atomic_op(enum fi_op op)
 			remote_fi_addr, remote.addr, remote.key, datatype, op, 
 			&fi_ctx_atomic);
 	if (ret) {
-		fprintf(stderr, "fi_compare_atomic %d (%s)\n", ret, fi_strerror(-ret));
+		fprintf(stderr, "fi_compare_atomic %d (%s)\n", ret, 
+				fi_strerror(-ret));
 	} else {			
 		ret = wait_for_completion(scq, 1);
 	}
@@ -389,7 +391,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !run_all_sizes ? test_size[TEST_CNT - 1].size : transfer_size;
+	buffer_size = !run_all_sizes ? test_size[TEST_CNT - 1].size : 
+		transfer_size;
 	buf = malloc(MAX(buffer_size, sizeof(uint64_t)));
 	if (!buf) {
 		perror("malloc");
@@ -453,7 +456,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
@@ -521,10 +524,12 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
+		ret = getaddr(src_addr, NULL, 
+				(struct sockaddr **) &hints.src_addr,
 				(socklen_t *) &hints.src_addrlen);
 		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			fprintf(stderr, "source address error %s\n", 
+					gai_strerror(ret));
 			return ret;
 		}
 	}
@@ -605,8 +610,8 @@ static int init_av(void)
 	int ret;
 
 	if (dst_addr) {
-		// get local address blob. Find the addrlen first. We set addrlen as 0 
-		// and fi_getname will return the actual addrlen
+		// get local address blob. Find the addrlen first. We set 
+		// addrlen as 0 and fi_getname will return the actual addrlen
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
@@ -621,7 +626,8 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -648,7 +654,8 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -720,8 +727,9 @@ static int run(void)
 				  test_name, &transfer_size, &iterations);
 			ret = run_test();
 			if (ret) {
-				fprintf(stderr, "Test failed at iteration %d, msg size %d\n", 
-					i, transfer_size);
+				fprintf(stderr, "Test failed at iteration %d, "
+						"msg size %d\n", i, 
+						transfer_size);
 				goto out;
 			}
 		}

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -105,7 +105,8 @@ static int send_xfer(int size)
 	}
 
 	credits--;
-	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr, &fi_ctx_send);
+	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr, 
+			&fi_ctx_send);
 	if (ret) {
 		FI_PRINTERR("fi_send", ret);
 		return ret;
@@ -125,7 +126,8 @@ static int recv_xfer(int size)
 		return ret;
 	}
 
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr, &fi_ctx_recv);
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr, 
+			&fi_ctx_recv);
 	if (ret)
 		FI_PRINTERR("fi_recv", ret);
 	recv_outs++;
@@ -211,7 +213,8 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc, g_argv);
+		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc,
+			       	g_argv);
 	else
 		show_perf(test_name, transfer_size, iterations, &start, &end, 2);
 
@@ -267,7 +270,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
@@ -327,10 +330,12 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = getaddr(src_addr, NULL, 
+				(struct sockaddr **) &hints.src_addr, 
+				(socklen_t *) &hints.src_addrlen);
 		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			fprintf(stderr, "source address error %s\n", 
+					gai_strerror(ret));
 			return ret;
 		}
 	}
@@ -348,7 +353,8 @@ static int init_fabric(void)
 		return ret;
 	}
 
-	/* We use provider MR attributes and direct address (no offsets) for RMA calls */
+	/* We use provider MR attributes and direct address (no offsets) 
+	 * for RMA calls */
 	if (!(fi->mode & FI_PROV_MR_ATTR))
 		fi->mode |= FI_PROV_MR_ATTR;
 
@@ -422,7 +428,8 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -450,7 +457,8 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -488,7 +496,8 @@ static int run(void)
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > size_option)
 				continue;
-			init_test(test_size[i].size, test_name, &transfer_size, &iterations);
+			init_test(test_size[i].size, test_name, &transfer_size, 
+					&iterations);
 			run_test();
 		}
 	} else {

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -175,7 +175,8 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc, g_argv);
+		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc,
+			       	g_argv);
 	else
 		show_perf(test_name, transfer_size, iterations, &start, &end, 2);
 
@@ -237,7 +238,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
@@ -298,10 +299,12 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = getaddr(src_addr, NULL, 
+				(struct sockaddr **) &hints.src_addr, 
+				(socklen_t *) &hints.src_addrlen);
 		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			fprintf(stderr, "source address error %s\n", 
+					gai_strerror(ret));
 			return ret;
 		}
 	}
@@ -327,7 +330,8 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	/* We use provider MR attributes and direct address (no offsets) for RMA calls */
+	/* We use provider MR attributes and direct address (no offsets) 
+	 * for RMA calls */
 	if (!(fi->mode & FI_PROV_MR_ATTR))
 		fi->mode |= FI_PROV_MR_ATTR;
 
@@ -401,7 +405,8 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -429,7 +434,8 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, recv_buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -122,18 +122,21 @@ int wait_for_recv_completion(void **recv_data, enum data_type type,
 			buf_index = header->index;
 			// buffer is used up, post it again
 			if(comp.flags & FI_MULTI_RECV) {
-				ret = fi_recv(ep,
-					   	multi_recv_buf + (multi_buf_size/2) * buf_index, 
-						multi_buf_size/2, fi_mr_desc(mr_multi_recv), 
-						remote_fi_addr, &ctx_multi_recv[buf_index].context);
+				ret = fi_recv(ep, multi_recv_buf + 
+						(multi_buf_size/2) * buf_index, 
+						multi_buf_size/2, 
+						fi_mr_desc(mr_multi_recv), 
+						remote_fi_addr, 
+						&ctx_multi_recv[buf_index].context);
 				if (ret) { 
 					FI_PRINTERR("fi_recv", ret);
 					return ret;
 				} 
 			} else {			
 				num_completions--;
-				// check the completion event is for parameter exchanging
-				// otherwise, do nothing for sync data and multi_recv transfer
+				// check the completion event is for parameter 
+				// exchanging otherwise, do nothing for sync 
+				// data and multi_recv transfer
 				if(type == DATA) {
 					*recv_data = comp.buf;
 				}
@@ -151,8 +154,8 @@ static int send_msg(int size)
 	int ret;
 	ctx_send = (struct fi_ctx_multi_recv *) 
 		malloc(sizeof(struct fi_ctx_multi_recv));
-	ret = fi_send(ep, send_buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr, 
-			&ctx_send->context);
+	ret = fi_send(ep, send_buf, (size_t) size, fi_mr_desc(mr), 
+			remote_fi_addr, &ctx_send->context);
 	if (ret) {
 		FI_PRINTERR("fi_send", ret);
 		return ret;
@@ -189,8 +192,8 @@ static int post_multi_recv_buffer()
 		ctx_multi_recv[i].index = i;
 		// post buffers for active messages 
 		ret = fi_recv(ep, multi_recv_buf + (multi_buf_size/2) * i,
-			   	multi_buf_size/2, fi_mr_desc(mr_multi_recv), remote_fi_addr, 
-				&ctx_multi_recv[i].context);
+			   	multi_buf_size/2, fi_mr_desc(mr_multi_recv), 
+				remote_fi_addr, &ctx_multi_recv[i].context);
 		if (ret) { 
 			FI_PRINTERR("fi_recv", ret);
 			return ret;
@@ -208,8 +211,9 @@ static int send_multi_recv_msg()
 	for(i = 0; i < iterations; i++) {
 		ctx_send = (struct fi_ctx_multi_recv *) 
 			malloc(sizeof(struct fi_ctx_multi_recv));
-		ret = fi_send(ep, send_buf, (size_t) transfer_size, fi_mr_desc(mr), 
-				remote_fi_addr, &ctx_send->context);
+		ret = fi_send(ep, send_buf, (size_t) transfer_size, 
+				fi_mr_desc(mr), remote_fi_addr, 
+				&ctx_send->context);
 		if (ret) {
 			FI_PRINTERR("fi_send", ret);
 			return ret;
@@ -237,7 +241,8 @@ static int run_test(void)
 			goto out;
 		}
 	} else {
-		// wait for all the receive completion events for multi_recv transfer
+		// wait for all the receive completion events for 
+		// multi_recv transfer
 		ret = wait_for_recv_completion(NULL, CONTROL, iterations);
 		if(ret){
 		  fprintf(stderr, "wait_for_recv_completion failed\n");
@@ -280,8 +285,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	max_send_buf_size = MAX(MAX(data_size, SYNC_DATA_SIZE), transfer_size);
 	
 	if(max_send_buf_size > fi->ep_attr->max_msg_size) {
-		fprintf(stderr, "transfer size is larger than the maximum size of the" 
-				"data transfer supported by the provider\n");
+		fprintf(stderr, "transfer size is larger than the maximum size "
+				"of the data transfer supported by the provider\n");
 		return -1;		
 	}
 
@@ -333,7 +338,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
@@ -406,10 +411,12 @@ static int init_fabric(void)
 	char *node;
 	int ret;
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = getaddr(src_addr, NULL, 
+				(struct sockaddr **) &hints.src_addr, 
+				(socklen_t *) &hints.src_addrlen);
 		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			fprintf(stderr, "source address error %s\n", 
+					gai_strerror(ret));
 			return ret;
 		}
 	}
@@ -458,8 +465,9 @@ static int init_fabric(void)
 	if (ret)
 		goto err4;
 	
-	// set the value of FI_OPT_MIN_MULTI_RECV which defines the minimum receive 
-	// buffer space available when the receive buffer is automatically freed
+	// set the value of FI_OPT_MIN_MULTI_RECV which defines the minimum 
+	// receive buffer space available when the receive buffer is 
+	// automatically freed
 	set_min_multi_recv();	
 
 	// post the initial receive buffers to get MULTI_RECV data
@@ -489,8 +497,8 @@ static int init_av(void)
 	void *recv_buf = NULL;
 	
 	if (dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen 
-		 * as 0 and fi_getname will return the actual addrlen. */
+		// Get local address blob. Find the addrlen first. We set 
+		// addrlen as 0 and fi_getname will return the actual addrlen. 
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
@@ -505,19 +513,20 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
-		/* Send local addr size */
+		// Send local addr size 
 		memcpy(send_buf, &addrlen, sizeof(size_t));
 		ret = send_msg(sizeof(size_t));
 		if (ret)
 			return ret;
 		
-		/* Send local addr */
+		// Send local addr
 		memcpy(send_buf, local_addr, addrlen);
 		ret = send_msg(addrlen);
 		if (ret)
@@ -525,20 +534,21 @@ static int init_av(void)
 
 	} else {
 		
-		/* Get the size of remote address */
+		// Get the size of remote address
 		ret = wait_for_recv_completion(&recv_buf, DATA, 1);
 		if (ret)
 			return ret;
 		memcpy(&addrlen, recv_buf, sizeof(size_t));
 
-		/* Get remote address */
+		// Get remote address
 		remote_addr = malloc(addrlen);
 		ret = wait_for_recv_completion(&recv_buf, DATA, 1);
 		if (ret)
 			return ret;
 		memcpy(remote_addr, recv_buf, addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -256,7 +256,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
@@ -316,10 +316,12 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = getaddr(src_addr, NULL, 
+				(struct sockaddr **) &hints.src_addr, 
+				(socklen_t *) &hints.src_addrlen);
 		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			fprintf(stderr, "source address error %s\n", 
+					gai_strerror(ret));
 			return ret;
 		}
 	}
@@ -337,7 +339,8 @@ static int init_fabric(void)
 		return ret;
 	}
 
-	/* We use provider MR attributes and direct address (no offsets) for RMA calls */
+	/* We use provider MR attributes and direct address (no offsets) 
+	 * for RMA calls */
 	if (!(fi->mode & FI_PROV_MR_ATTR))
 		fi->mode |= FI_PROV_MR_ATTR;
 
@@ -399,8 +402,8 @@ static int init_av(void)
 	int ret;
 
 	if (dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen 
-		 * as 0 and fi_getname will return the actual addrlen. */
+		/* Get local address blob. Find the addrlen first. We set 
+		 * addrlen as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
@@ -415,7 +418,8 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -443,7 +447,8 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -184,7 +184,8 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 1, g_argc, g_argv);
+		show_perf_mr(transfer_size, iterations, &start, &end, 1, g_argc,
+			       	g_argv);
 	else
 		show_perf(test_name, transfer_size, iterations, &start, &end, 1);
 
@@ -239,7 +240,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
@@ -299,10 +300,12 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = getaddr(src_addr, NULL, 
+				(struct sockaddr **) &hints.src_addr, 
+				(socklen_t *) &hints.src_addrlen);
 		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			fprintf(stderr, "source address error %s\n", 
+					gai_strerror(ret));
 			return ret;
 		}
 	}
@@ -393,7 +396,8 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -422,7 +426,8 @@ static int init_av(void)
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -477,7 +482,8 @@ static int run(void)
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > size_option)
 				continue;
-			init_test(test_size[i].size, test_name, &transfer_size, &iterations);
+			init_test(test_size[i].size, test_name, &transfer_size, 
+					&iterations);
 			ret = run_test();
 			if(ret)
 				goto out;

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -227,7 +227,8 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc, g_argv);
+		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc,
+			       	g_argv);
 	else
 		show_perf(test_name, transfer_size, iterations, &start, &end, 2);
 
@@ -284,7 +285,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
@@ -344,10 +345,12 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = getaddr(src_addr, NULL, 
+				(struct sockaddr **) &hints.src_addr, 
+				(socklen_t *) &hints.src_addrlen);
 		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			fprintf(stderr, "source address error %s\n", 
+					gai_strerror(ret));
 			return ret;
 		}
 	}
@@ -365,7 +368,8 @@ static int init_fabric(void)
 		return ret;
 	}
 
-	/* We use provider MR attributes and direct address (no offsets) for RMA calls */
+	/* We use provider MR attributes and direct address (no offsets) 
+	 * for RMA calls */
 	if (!(fi->mode & FI_PROV_MR_ATTR))
 		fi->mode |= FI_PROV_MR_ATTR;
 
@@ -439,7 +443,8 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -467,7 +472,8 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -189,7 +189,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&av_attr, 0, sizeof av_attr);
 	av_attr.type = FI_AV_MAP;
 	av_attr.count = 1;
-	av_attr.name = "addr to fi_addr map";
+	av_attr.name = NULL;
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
@@ -249,10 +249,12 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = getaddr(src_addr, NULL, 
+				(struct sockaddr **) &hints.src_addr, 
+				(socklen_t *) &hints.src_addrlen);
 		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+			fprintf(stderr, "source address error %s\n", 
+					gai_strerror(ret));
 			return ret;
 		}
 	}
@@ -329,8 +331,8 @@ static int init_av(void)
 	int ret;
 
 	if (dst_addr) {
-		// get local address blob. Find the addrlen first. We set addrlen 
-		// as 0 and fi_getname will return the actual addrlen.
+		// get local address blob. Find the addrlen first. We set 
+		// addrlen as 0 and fi_getname will return the actual addrlen.
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
@@ -345,7 +347,8 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -373,7 +376,8 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
 		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
@@ -399,7 +403,8 @@ static int tagged_search(uint64_t tag)
 		else
 			FI_PRINTERR("fi_tsearch", ret);
 	} else if(ret == 0) {
-		// search was initiated asynchronously, so wait for the completion event
+		// search was initiated asynchronously, so wait for 
+		// the completion event
 		ret = wait_for_tagged_completion(scq, 1);
 	} else {
 		// search completes immediately
@@ -422,13 +427,14 @@ static int run(void)
 	
 	// Receiver
 	if(dst_addr) {
-		// search for initial tag, it should fail since the sender hasn't sent 
-		// anyting
-		fprintf(stdout, "[fi_tsearch] Searching msg with tag [%zu]\n", tag_data);
+		// search for initial tag, it should fail since the sender 
+		// hasn't sent anyting
+		fprintf(stdout, "[fi_tsearch] Searching msg with tag [%zu]\n", 
+				tag_data);
 		tagged_search(tag_data);
 		
-		fprintf(stdout, "[fi_trecv] Posting buffer for msg with tag [%zu]\n", 
-				tag_data + 1);
+		fprintf(stdout, "[fi_trecv] Posting buffer for msg with tag "
+				"[%zu]\n", tag_data + 1);
 		ret = post_recv(tag_data + 1);
 		if(ret)
 			goto out;
@@ -443,19 +449,21 @@ static int run(void)
 		ret = wait_for_tagged_completion(rcq, 1);
 		if(ret)
 			goto out;
-		fprintf(stdout, "[fi_cq_read] Received completion event for msg with " 
-				"tag [%zu]\n", tag_data + 1);
+		fprintf(stdout, "[fi_cq_read] Received completion event for msg"
+			       	" with tag [%zu]\n", tag_data + 1);
 		
 		// search again for the initial tag, it should be successful now
-		fprintf(stdout, "Searching msg with initial tag [%zu]\n", tag_data);
+		fprintf(stdout, "Searching msg with initial tag [%zu]\n", 
+				tag_data);
 		tagged_search(tag_data);
 		
 		// wait for the completion event of the initial tag
 		ret = recv_msg(tag_data);	
 		if(ret)
 			goto out;
-		fprintf(stdout, "[fi_trecv][fi_cq_read] Posted buffer and received "
-				"completion event for msg with tag [%zu]\n", tag_data);
+		fprintf(stdout, "[fi_trecv][fi_cq_read] Posted buffer and "
+				"received completion event for msg with tag "
+				"[%zu]\n", tag_data);
 
 	} else {
 		// Sender	
@@ -465,12 +473,14 @@ static int run(void)
 		if (ret)
 			goto out;
 
-		fprintf(stdout, "[fi_tsend] Sending msg with tag [%zu]\n", tag_data);
+		fprintf(stdout, "[fi_tsend] Sending msg with tag [%zu]\n", 
+				tag_data);
 		ret = send_msg(16, tag_data);
 		if(ret)
 			goto out;
 
-		fprintf(stdout, "[fi_tsend] Sending msg with tag [%zu]\n", tag_data + 1);
+		fprintf(stdout, "[fi_tsend] Sending msg with tag [%zu]\n", 
+				tag_data + 1);
 		ret = send_msg(16, tag_data + 1);
 		if(ret)
 			goto out;

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -177,7 +177,8 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc, g_argv);
+		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc,
+			       	g_argv);
 	else
 		show_perf(test_name, transfer_size, iterations, &start, &end, 2);
 
@@ -496,7 +497,8 @@ static int run(void)
 				(max_msg_size && test_size[i].size > max_msg_size)) {
 				continue;
 			}
-			init_test(test_size[i].size, test_name, &transfer_size, &iterations);
+			init_test(test_size[i].size, test_name, &transfer_size, 
+					&iterations);
 			run_test();
 		}
 	} else {


### PR DESCRIPTION
Named address vector (with a hard coded name) was being used in the examples which is not necessary and can cause problem while running multiple examples on the same machine. Since we are not using shared AV, I have removed them and fixed some minor formatting issues.

Signed-off-by: Shantonu Hossain shantonu.hossain@intel.com