### PR TITLE
Simplified the basic RDM example

### DIFF
--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -45,7 +45,7 @@ static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;
 
-static char *dst_addr, *src_addr;
+static char *dst_addr = NULL;
 static char *port = "9228";
 static void *remote_addr;
 static size_t addrlen = 0;
@@ -62,17 +62,10 @@ struct fi_context fi_ctx_send;
 struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_av;
 
-static enum node_type {
-	SERVER = 1,
-	CLIENT
-} type;
-
 static void usage(char *name)
 {
 	printf("usage: %s\n", name);
 	printf("\t-d destination address\n");
-	printf("\t-s source address\n");
-	printf("\t-S or -C (server or client)\n");
 	exit(1);
 }
 
@@ -185,37 +178,26 @@ static int init_fabric(void)
 {
 	struct fi_info *fi;
 	int ret;
+	uint64_t flags = 0;
 	
-	if(type == CLIENT) {
-		/* Translate local network address */
-		/*ret = getaddr(src_addr, port, 
-				(struct sockaddr **) &hints.src_addr, 
-				(socklen_t *) &hints.src_addrlen);
-		if (ret) {
-			fprintf(stderr, "source address error %s\n", 
-					gai_strerror(ret));
-			return ret;
-		}*/
-		/* Get fabric info */
-		ret = fi_getinfo(FI_VERSION(1, 0), dst_addr, port, 0, 
-				&hints, &fi);
-		if (ret) {
-			FI_PRINTERR("fi_getinfo", ret);
-			goto err0;
-		}
-	} else {
-		/* Get fabric info */
-		ret = fi_getinfo(FI_VERSION(1, 0), src_addr, port, 
-				FI_SOURCE, &hints, &fi);
-		if (ret) {
-			FI_PRINTERR("fi_getinfo", ret);
-			goto err0;
-		}
+	/* Set FI_SOURCE flag to enforce the port number to be the local port 
+	 * the server will be bound to */
+	if(!dst_addr) 
+		flags = FI_SOURCE;
+	
+	/* Get fabric info */
+	ret = fi_getinfo(FI_VERSION(1, 0), dst_addr, port, flags, &hints, &fi);
+	if (ret) {
+		FI_PRINTERR("fi_getinfo", ret);
+		goto err0;
 	}
 	
-	addrlen = fi->dest_addrlen;
-	remote_addr = malloc(addrlen);
-	memcpy(remote_addr, fi->dest_addr, addrlen);
+	/* Get remote address of the server */
+	if(dst_addr){
+		addrlen = fi->dest_addrlen;
+		remote_addr = malloc(addrlen);
+		memcpy(remote_addr, fi->dest_addr, addrlen);
+	}
 
 	/* Open fabric */
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
@@ -248,11 +230,14 @@ static int init_fabric(void)
 	if (ret)
 		goto err5;
 	
-	/* Insert address to the AV and get the fabric address back */ 	
-	ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-	if (ret != 1) {
-		FI_PRINTERR("fi_av_insert", ret);
-		return ret;
+	if(dst_addr){
+		/* Insert address to the AV and get the fabric address back */ 	
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+				&fi_ctx_av);
+		if (ret != 1) {
+			FI_PRINTERR("fi_av_insert", ret);
+			return ret;
+		}
 	}
 
 	fi_freeinfo(fi);
@@ -277,7 +262,7 @@ static int send_recv()
 	struct fi_cq_entry comp;
 	int ret;
 
-	if (type == CLIENT) {
+	if (dst_addr) {
 		/* Client */
 		fprintf(stdout, "Posting a send...\n");
 		sprintf(buf, "Hello from Client!"); 
@@ -333,29 +318,16 @@ int main(int argc, char **argv)
 	memset(&domain_hints, 0, sizeof(struct fi_domain_attr));
 	memset(&ep_hints, 0, sizeof(struct fi_ep_attr));
 
-	while ((op = getopt(argc, argv, "d:s:SC")) != -1) {
+	while ((op = getopt(argc, argv, "d:")) != -1) {
 		switch (op) {
 		case 'd':
 			dst_addr = optarg;
-			break;
-		case 's':
-			src_addr = optarg;
-			break;
-		case 'S':
-			type = SERVER;
-			break;
-		case 'C':
-			type = CLIENT;
 			break;
 		default:
 			usage(argv[0]);
 		}
 	}
 	
-	/* Check if we got required args */
-	if (optind != 6)
-		usage(argv[0]);
-
 	hints.domain_attr	= &domain_hints;
 	hints.ep_attr		= &ep_hints;
 	hints.ep_type		= FI_EP_RDM;


### PR DESCRIPTION
Used FI_SOURCE flag and simplified the code to demonstrate one way client to server data transfer. Now the code structure matches rest of the rdm examples.

Signed-off-by: Shantonu Hossain shantonu.hossain@intel.com