### PR TITLE
simple/poll: fix trivial uninit variable

### DIFF
--- a/simple/poll.c
+++ b/simple/poll.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under the OpenIB.org BSD license
  * below:
@@ -439,6 +440,7 @@ static int send_recv()
 				break;
 			default:
 				printf("Unknown completion received\n");
+				return -1;
 			}
 
 			/* Read the completion entry */


### PR DESCRIPTION
When we don't know what kind of completion it is, don't try to read from the cq (because it will be bogus).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@goodell please review