### PR TITLE
Fix av_insert return value check for multi-recv example

### DIFF
--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -515,7 +515,7 @@ static int init_av(void)
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
@@ -549,10 +549,11 @@ static int init_av(void)
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
+		ret = 0;
 	}
 
 	return ret;


### PR DESCRIPTION
Signed-off-by: Jithin Jose <jithin.jose@intel.com>