### PR TITLE
Cleaned up simple dgram to match simple rdm example and fixed few minor issues

### DIFF
--- a/simple/poll.c
+++ b/simple/poll.c
@@ -82,6 +82,7 @@ static void usage(char *name)
 
 static void free_ep_res(void)
 {
+	fi_close(&av->fid);
 	fi_close(&mr->fid);
 	fi_close(&pollset->fid);
 	fi_close(&rcq->fid);
@@ -343,7 +344,7 @@ static int init_av(void)
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
@@ -372,7 +373,7 @@ static int init_av(void)
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
-		if (ret) {
+		if (ret != 1) {
 			FI_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
@@ -490,7 +491,7 @@ int main(int argc, char **argv)
 	hints.ep_attr = &ep_hints;
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG;
-	hints.mode = FI_LOCAL_MR | FI_PROV_MR_ATTR;
+	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;
 	hints.addr_format = FI_FORMAT_UNSPEC;
 
 	ret = init_fabric();

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -346,7 +346,6 @@ int main(int argc, char **argv)
 	ret = send_recv();
 
 	/* Tear down */
-	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -737,7 +737,6 @@ static int run(void)
 	sync_test();
 
 out:
-	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -112,6 +112,7 @@ static int recv_msg(void)
 
 static void free_ep_res(void)
 {
+	fi_close(&av->fid);
 	fi_close(&mr->fid);
 	FI_CLOSEV(rx_ep, ctx_cnt);
 	FI_CLOSEV(tx_ep, ctx_cnt);


### PR DESCRIPTION
- Cleaned up dgram.c code to match rdm.c code
- Added missing fi_close on av
- Removed fi_shutdown from unconnected examples
- Fixed a missing condition check on the return of av_insert call

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>