### PR TITLE
build fixes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-if test ! -d .git && test ! -f src/fabric.c; then
+if test ! -d .git && test ! -f simple/info.c; then
     echo You really need to run this script in the top-level fabtests directory
     exit 1
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,6 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
 AC_INIT([fabtests], [0.0.1], [linux-rdma@vger.kernel.org])
-AC_CONFIG_AUX_DIR(config)
-AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])


### PR DESCRIPTION
Remove AC_CONFIG_MACRO_DIR(config), since we didn't have any
additional macros in directory 'config'.

Check for an existing file simple/info.c instead of src/fabric.c,
which seems to be a result of copy/paste for libfabric.

Fixes issue #125.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>