### PR TITLE
Fix compilation warnings on OS X.

### DIFF
--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -45,7 +45,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <sys/time.h>
-#include <malloc.h>
 #include <getopt.h>
 #include <time.h>
 #include <rdma/fabric.h>
@@ -340,13 +339,12 @@ static struct pingpong_context *pp_init_ctx(struct fi_info *prov, int size,
 	if (!ctx)
 		return NULL;
 
-	ctx->prov 			= prov;
+	ctx->prov 		= prov;
 	ctx->size       	= size;
 	ctx->rx_depth   	= rx_depth;
 	ctx->use_event   	= use_event;
 
-	ctx->buf = memalign(page_size, size);
-	if (!ctx->buf) {
+	if (posix_memalign(&(ctx->buf), page_size, size)) {
 		fprintf(stderr, "Couldn't allocate work buf.\n");
 		goto clean_ctx;
 	}
@@ -495,7 +493,7 @@ int main(int argc, char *argv[])
 			break;
 
 		case 'd':
-			prov_name = strdupa(optarg);
+			prov_name = strdup(optarg);
 			break;
 
 		case 'i':
@@ -540,7 +538,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (optind == argc - 1)
-		servername = strdupa(argv[optind]);
+		servername = strdup(argv[optind]);
 	else if (optind < argc) {
 		usage(argv[0]);
 		return 1;
@@ -708,6 +706,7 @@ int main(int argc, char *argv[])
 	fi_freeinfo(prov_list);
 	free(service);
 	free(prov_name);
+	free(servername);
 
 	return 0;
 }

--- a/simple/imm_data.c
+++ b/simple/imm_data.c
@@ -33,6 +33,7 @@
 #include <time.h>
 #include <netdb.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
@@ -178,7 +179,8 @@ static int server_listen(void)
 	struct fi_info *fi;
 	int ret;
 
-	ret = fi_getinfo(FI_VERSION(1, 0), src_addr, port, FI_SOURCE, &hints, &fi);
+	ret = fi_getinfo(FI_VERSION(1, 0), src_addr, port, FI_SOURCE, &hints,
+			&fi);
 	if (ret) {
 		printf("fi_getinfo %s\n", strerror(-ret));
 		return ret;
@@ -403,8 +405,10 @@ static int run_test()
 	remote_cq_data = 0x0123456789abcdef & ((0x1ULL << (cq_data_size * 8)) - 1);
 
 	if (dst_addr) {
-		fprintf(stdout, "Posting send with immediate data: %lx\n", remote_cq_data);
-		ret = fi_senddata(ep, buf, size, fi_mr_desc(mr), remote_cq_data, 
+		fprintf(stdout,
+			"Posting send with immediate data: 0x%" PRIx64 "\n",
+			remote_cq_data);
+		ret = fi_senddata(ep, buf, size, fi_mr_desc(mr), remote_cq_data,
 				0, buf);
 		if (ret) {
 			FI_PRINTERR("fi_send", ret);
@@ -438,7 +442,8 @@ static int run_test()
 			else
 				fprintf(stdout, "remote_cq_data: failure\n");
 
-			fprintf(stdout, "Expected data:0x%lx, Received data:0x%lx\n",
+			fprintf(stdout, "Expected data:0x%" PRIx64
+				", Received data:0x%" PRIx64 "\n",
 				remote_cq_data, comp.data);
 		}
 	}

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -148,7 +148,7 @@ static enum fi_op get_fi_op(char *op) {
 	}
 }
 
-static int post_recv()
+static int post_recv(void)
 {
 	int ret;
 	

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -678,12 +678,12 @@ static int exchange_addr_key(void)
 		if(ret)
 			return ret;
 
-		ret = post_recv(len);
+		ret = post_recv();
 		if(ret)
 			return ret;
 		remote = *(struct addr_key *)buf;
 	} else {
-		ret = post_recv(len);
+		ret = post_recv();
 		if(ret)
 			return ret;
 		remote = *(struct addr_key *)buf;

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -288,7 +288,7 @@ static int run_test(void)
 	if(dst_addr) {	
 		/* Execute RMA write operation from Client */
 		fprintf(stdout, "RMA write from Client\n");
-		sprintf(buf, welcome_text);
+		sprintf(buf, "%s", welcome_text);
 		ret = write_data(sizeof(char *) * strlen(buf));
 		if (ret)
 			return ret;

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -124,7 +124,7 @@ static int alloc_ep_res(void)
 	struct fi_rx_attr rx_attr;
 	struct fi_tx_attr tx_attr;
 	struct fi_av_attr av_attr;
-	int ret;
+	int ret = 0;
 
 	buffer_size = test_size[TEST_CNT - 1].size;
 	buf = malloc(buffer_size);

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -42,6 +42,7 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <inttypes.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
@@ -94,7 +95,7 @@ check_eq_readerr(struct fid_eq *eq, fid_t fid, void *context, int index)
 		return -1;
 	}
 	if (err_entry.data != index) {
-		sprintf(err_buf, "fi_eq_readerr index = %ld, should be %d",
+		sprintf(err_buf, "fi_eq_readerr index = %" PRIu64 ", should be %d",
 				err_entry.data, index);
 		return -1;
 	}
@@ -132,7 +133,7 @@ check_eq_result(int ret, uint32_t event, struct fi_eq_entry *entry,
 		return -1;
 	}
 	if (count != ~0 && entry->data != count) {
-		sprintf(err_buf, "count = %lu, should be %u", entry->data, count);
+		sprintf(err_buf, "count = %" PRIu64 ", should be %u", entry->data, count);
 		return -1;
 	}
 	return 0;
@@ -388,7 +389,7 @@ av_bad_sync()
 	}
 	if (fi_addr != FI_ADDR_NOTAVAIL) {
 		sprintf(err_buf,
-				"fi_addr = 0x%lx, should be 0x%lx (FI_ADDR_NOTAVAIL)",
+				"fi_addr = 0x%" PRIx64 ", should be 0x%" PRIx64" (FI_ADDR_NOTAVAIL)",
 				fi_addr, FI_ADDR_NOTAVAIL);
 		goto fail;
 	}
@@ -693,7 +694,7 @@ av_good_2vector_async()
 			goto fail;
 		}
 		if (*(uint32_t *)(entry.context) != entry.data) {
-			sprintf(err_buf, "count = %lu, should be %d", entry.data,
+			sprintf(err_buf, "count = %" PRIu64 ", should be %d", entry.data,
 					*(uint32_t *)(entry.context));
 			goto fail;
 		}
@@ -932,7 +933,7 @@ av_goodbad_2vector_async()
 					goto fail;
 			}
 			if (*(uint32_t *)(entry.context) != entry.data) {
-				sprintf(err_buf, "count = %lu, should be %d", entry.data,
+				sprintf(err_buf, "count = %" PRIu64 ", should be %d", entry.data,
 						*(uint32_t *)(entry.context));
 				goto fail;
 			}

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -334,7 +334,7 @@ eq_wait_fd_sread()
 	}
 
 	/* timed sread on empty EQ, 2s timeout */
-	clock_gettime(CLOCK_MONOTONIC_RAW, &before);
+	clock_gettime(CLOCK_MONOTONIC, &before);
 	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), 2000, 0);
 	if (ret != -FI_ETIMEDOUT) {
 		sprintf(err_buf, "fi_eq_read of empty EQ returned %d", ret);
@@ -342,7 +342,7 @@ eq_wait_fd_sread()
 	}
 
 	/* check timeout accuracy */
-	clock_gettime(CLOCK_MONOTONIC_RAW, &after);
+	clock_gettime(CLOCK_MONOTONIC, &after);
 	elapsed = get_elapsed(&before, &after, MILLI);
 	if (elapsed < 1500 || elapsed > 2500) {
 		sprintf(err_buf, "fi_eq_sread slept %d ms, expected 2000",
@@ -360,7 +360,7 @@ eq_wait_fd_sread()
 	}
 
 	/* timed sread on EQ with event, 2s timeout */
-	clock_gettime(CLOCK_MONOTONIC_RAW, &before);
+	clock_gettime(CLOCK_MONOTONIC, &before);
 	event = ~0;
 	memset(&entry, 0, sizeof(entry));
 	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), 2000, 0);
@@ -370,7 +370,7 @@ eq_wait_fd_sread()
 	}
 
 	/* check that no undue waiting occurred */
-	clock_gettime(CLOCK_MONOTONIC_RAW, &after);
+	clock_gettime(CLOCK_MONOTONIC, &after);
 	elapsed = get_elapsed(&before, &after, MILLI);
 	if (elapsed > 5) {
 		sprintf(err_buf, "fi_eq_sread slept %d ms, expected immediate return",


### PR DESCRIPTION
Clang on OS X seems to be more verbose about warnings than GCC. This just fixes all of the issues it pointed out. Not sure if style is correct, but I figured I'd submit for a review. 

Signed-off-by: Ben Turrubiates <bturrubiates@lanl.gov>