### PR TITLE
fabtests: add "()" to error printfs when describing a C function

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -74,7 +74,7 @@ void show_perf_mr(int tsize, int iters, struct timespec *start,
 		  struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
 
 #define FI_PRINTERR(call, retv) \
-	do { fprintf(stderr, call ": %d (%s)\n", retv, fi_strerror(-retv)); } while (0)
+	do { fprintf(stderr, call "(): %d (%s)\n", retv, fi_strerror(-retv)); } while (0)
 
 #define FI_DEBUG(fmt, ...) \
 	do { fprintf(stderr, "%s:%d: " fmt, __FILE__, __LINE__, ##__VA_ARGS__); } while (0)

--- a/simple/imm_data.c
+++ b/simple/imm_data.c
@@ -73,7 +73,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		printf("fi_eq_open cm %s\n", fi_strerror(-ret));
+		printf("fi_eq_open() cm %s\n", fi_strerror(-ret));
 
 	return ret;
 }
@@ -104,20 +104,20 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		printf("fi_cq_open send comp %s\n", fi_strerror(-ret));
+		printf("fi_cq_open() send comp %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		printf("fi_cq_open recv comp %s\n", fi_strerror(-ret));
+		printf("fi_cq_open() recv comp %s\n", fi_strerror(-ret));
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		printf("fi_mr_reg %s\n", fi_strerror(-ret));
+		printf("fi_mr_reg() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
@@ -146,19 +146,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		printf("fi_ep_bind %s\n", fi_strerror(-ret));
+		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		printf("fi_ep_bind %s\n", fi_strerror(-ret));
+		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		printf("fi_ep_bind %s\n", fi_strerror(-ret));
+		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
 		return ret;
 	}
 
@@ -168,7 +168,7 @@ static int bind_ep_res(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		printf("fi_recv %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
 
 	return ret;
 }
@@ -180,7 +180,7 @@ static int server_listen(void)
 
 	ret = fi_getinfo(FI_VERSION(1, 0), src_addr, port, FI_SOURCE, &hints, &fi);
 	if (ret) {
-		printf("fi_getinfo %s\n", strerror(-ret));
+		printf("fi_getinfo() %s\n", strerror(-ret));
 		return ret;
 	}
 
@@ -188,13 +188,13 @@ static int server_listen(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		printf("fi_fabric %s\n", fi_strerror(-ret));
+		printf("fi_fabric() %s\n", fi_strerror(-ret));
 		goto err0;
 	}
 
 	ret = fi_passive_ep(fab, fi, &pep, NULL);
 	if (ret) {
-		printf("fi_passive_ep %s\n", fi_strerror(-ret));
+		printf("fi_passive_ep() %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
@@ -204,13 +204,13 @@ static int server_listen(void)
 
 	ret = fi_pep_bind(pep, &cmeq->fid, 0);
 	if (ret) {
-		printf("fi_pep_bind %s\n", fi_strerror(-ret));
+		printf("fi_pep_bind() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
 	ret = fi_listen(pep);
 	if (ret) {
-		printf("fi_listen %s\n", fi_strerror(-ret));
+		printf("fi_listen() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
@@ -237,7 +237,7 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		printf("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		printf("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
@@ -250,13 +250,13 @@ static int server_connect(void)
 	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
-		printf("fi_domain %s\n", fi_strerror(-ret));
+		printf("fi_domain() %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
-		printf("fi_endpoint for req %s\n", fi_strerror(-ret));
+		printf("fi_endpoint() for req %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
@@ -270,13 +270,13 @@ static int server_connect(void)
 
 	ret = fi_accept(ep, NULL, 0);
 	if (ret) {
-		printf("fi_accept %s\n", fi_strerror(-ret));
+		printf("fi_accept() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		printf("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		printf("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		goto err3;
 	}
 
@@ -319,7 +319,7 @@ static int client_connect(void)
 
 	ret = fi_getinfo(FI_VERSION(1, 0), dst_addr, port, 0, &hints, &fi);
 	if (ret) {
-		printf("fi_getinfo %s\n", strerror(-ret));
+		printf("fi_getinfo() %s\n", strerror(-ret));
 		goto err0;
 	}
 
@@ -327,20 +327,20 @@ static int client_connect(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		printf("fi_fabric %s\n", fi_strerror(-ret));
+		printf("fi_fabric() %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		printf("fi_domain %s %s\n", fi_strerror(-ret),
+		printf("fi_domain() %s %s\n", fi_strerror(-ret),
 			fi->domain_attr->name);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		printf("fi_endpoint %s\n", fi_strerror(-ret));
+		printf("fi_endpoint() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
@@ -354,13 +354,13 @@ static int client_connect(void)
 
 	ret = fi_connect(ep, fi->dest_addr, NULL, 0);
 	if (ret) {
-		printf("fi_connect %s\n", fi_strerror(-ret));
+		printf("fi_connect() %s\n", fi_strerror(-ret));
 		goto err5;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		printf("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		printf("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 

--- a/simple/info.c
+++ b/simple/info.c
@@ -154,7 +154,7 @@ static int run(struct fi_info *hints, char *node, char *port)
 
 	ret = fi_getinfo(FI_VERSION(1, 0), node, port, 0, hints, &info);
 	if (ret) {
-		printf("fi_getinfo %s\n", strerror(-ret));
+		printf("fi_getinfo() %s\n", strerror(-ret));
 		return ret;
 	}
 

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -226,7 +226,7 @@ static int server_connect(void)
 	/* Wait for connection request from client */
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		fprintf(stderr, "fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		fprintf(stderr, "fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
@@ -270,7 +270,7 @@ static int server_connect(void)
 	/* Wait for the connection to be established */
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		printf("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		printf("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		goto err3;
 	}
 
@@ -355,7 +355,7 @@ static int client_connect(void)
 	/* Wait for the connection to be established */
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		printf("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		printf("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -343,7 +343,7 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
@@ -382,7 +382,7 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		goto err3;
 	}
 
@@ -460,13 +460,13 @@ static int client_connect(void)
 		if (rd == -FI_EAVAIL) {
 			rd = fi_eq_readerr(cmeq, &err, 0);
 			if (rd != sizeof(err)) {
-				FI_DEBUG("fi_eq_readerr %zd %s\n", rd, fi_strerror((int) -rd));
+				FI_DEBUG("fi_eq_readerr() %zd %s\n", rd, fi_strerror((int) -rd));
 			} else {
 				FI_DEBUG("EQ report error %d %s\n", err.err,
 						fi_strerror(err.err));
 			}
 		} else {
-			FI_DEBUG("fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+			FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		}
 		return (int) rd;
 	}

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -106,7 +106,7 @@ static int send_xfer(int size)
 post:
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), 0, NULL);
 	if (ret)
-		printf("fi_send %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_send() %d (%s)\n", ret, fi_strerror(-ret));
 
 	return ret;
 }
@@ -130,7 +130,7 @@ static int recv_xfer(int size)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		printf("fi_recv %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
 
 	return ret;
 }
@@ -142,7 +142,7 @@ static int read_data(size_t size)
 	ret = fi_read(ep, buf, size, fi_mr_desc(mr), 
 		      0, remote.addr, remote.key, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_read %d (%s)\n", ret, fi_strerror(-ret));
+		fprintf(stderr, "fi_read() %d (%s)\n", ret, fi_strerror(-ret));
 		return ret;
 	}
 
@@ -156,7 +156,7 @@ static int write_data(size_t size)
 	ret = fi_write(ep, buf, size, fi_mr_desc(mr),  
 		       0, remote.addr, remote.key, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_write %d (%s)\n", ret, fi_strerror(-ret));
+		fprintf(stderr, "fi_write() %d (%s)\n", ret, fi_strerror(-ret));
 		return ret;
 	}
 	return 0;
@@ -225,7 +225,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		fprintf(stderr, "fi_eq_open cm %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_eq_open() cm %s\n", fi_strerror(-ret));
 
 	return ret;
 }
@@ -256,20 +256,20 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_cq_open send comp %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_cq_open() send comp %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_cq_open recv comp %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_cq_open() recv comp %s\n", fi_strerror(-ret));
 		goto err2;
 	}
 	
 	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)), 
 			op_type, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_mr_reg %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_mr_reg() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
@@ -298,19 +298,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		printf("fi_ep_bind %s\n", fi_strerror(-ret));
+		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		printf("fi_ep_bind %s\n", fi_strerror(-ret));
+		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		printf("fi_ep_bind %s\n", fi_strerror(-ret));
+		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
 		return ret;
 	}
 
@@ -320,7 +320,7 @@ static int bind_ep_res(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		printf("fi_recv %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
 
 	return ret;
 }
@@ -332,19 +332,19 @@ static int server_listen(void)
 
 	ret = fi_getinfo(FI_VERSION(1, 0), src_addr, port, FI_SOURCE, &hints, &fi);
 	if (ret) {
-		fprintf(stderr, "fi_getinfo %s\n", strerror(-ret));
+		fprintf(stderr, "fi_getinfo() %s\n", strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_fabric %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_fabric() %s\n", fi_strerror(-ret));
 		goto err0;
 	}
 
 	ret = fi_passive_ep(fab, fi, &pep, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_passive_ep %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_passive_ep() %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
@@ -354,13 +354,13 @@ static int server_listen(void)
 
 	ret = fi_pep_bind(pep, &cmeq->fid, 0);
 	if (ret) {
-		printf("fi_pep_bind %s\n", fi_strerror(-ret));
+		printf("fi_pep_bind() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
 	ret = fi_listen(pep);
 	if (ret) {
-		fprintf(stderr, "fi_listen %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_listen() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
@@ -387,7 +387,7 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		fprintf(stderr, "fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		fprintf(stderr, "fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
@@ -400,14 +400,14 @@ static int server_connect(void)
 	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_domain %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_domain() %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
 
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_endpoint for req %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_endpoint() for req %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
@@ -421,13 +421,13 @@ static int server_connect(void)
 
 	ret = fi_accept(ep, NULL, 0);
 	if (ret) {
-		fprintf(stderr, "fi_accept %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_accept() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
  	if (rd != sizeof entry) {
-		fprintf(stderr, "fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		fprintf(stderr, "fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		goto err3;
  	}
 
@@ -469,26 +469,26 @@ static int client_connect(void)
 
 	ret = fi_getinfo(FI_VERSION(1, 0), dst_addr, port, 0, &hints, &fi);
 	if (ret) {
-		fprintf(stderr, "fi_getinfo %s\n", strerror(-ret));
+		fprintf(stderr, "fi_getinfo() %s\n", strerror(-ret));
 		goto err0;
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_fabric %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_fabric() %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
  	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_domain %s %s\n", fi_strerror(-ret),
+		fprintf(stderr, "fi_domain() %s %s\n", fi_strerror(-ret),
 			fi->domain_attr->name);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_endpoint %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_endpoint() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
@@ -502,13 +502,13 @@ static int client_connect(void)
 
 	ret = fi_connect(ep, fi->dest_addr, NULL, 0);
 	if (ret) {
-		fprintf(stderr, "fi_connect %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_connect() %s\n", fi_strerror(-ret));
 		goto err5;
 	}
 
  	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		fprintf(stderr, "fi_eq_sread %zd %s\n", rd, fi_strerror((int) -rd));
+		fprintf(stderr, "fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -154,7 +154,7 @@ static int post_recv()
 	
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret){
-		fprintf(stderr, "fi_recv %d (%s)\n", ret, fi_strerror(-ret));
+		fprintf(stderr, "fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
 		return ret;
 	}
 	
@@ -168,7 +168,7 @@ static int send_msg(int size)
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr, 
 			&fi_ctx_send);
 	if (ret)
-		fprintf(stderr, "fi_send %d (%s)\n", ret, fi_strerror(-ret));
+		fprintf(stderr, "fi_send() %d (%s)\n", ret, fi_strerror(-ret));
 
 	return wait_for_completion(scq, 1);
 }
@@ -234,7 +234,7 @@ static int execute_base_atomic_op(enum fi_op op)
 	ret = fi_atomic(ep, buf, 1, fi_mr_desc(mr), remote_fi_addr, remote.addr,
 		       	remote.key, datatype, op, &fi_ctx_atomic);
 	if (ret) {
-		fprintf(stderr, "fi_atomic %d (%s)\n", ret, fi_strerror(-ret));
+		fprintf(stderr, "fi_atomic() %d (%s)\n", ret, fi_strerror(-ret));
 	} else {						
 		ret = wait_for_completion(scq, 1);
 	}
@@ -250,7 +250,7 @@ static int execute_fetch_atomic_op(enum fi_op op)
 			fi_mr_desc(mr_result), remote_fi_addr, remote.addr, 
 			remote.key, datatype, op, &fi_ctx_atomic);
 	if (ret) {
-		fprintf(stderr, "fi_fetch_atomic %d (%s)\n", ret, 
+		fprintf(stderr, "fi_fetch_atomic() %d (%s)\n", ret, 
 				fi_strerror(-ret));
 	} else {						
 		ret = wait_for_completion(scq, 1);
@@ -268,7 +268,7 @@ static int execute_compare_atomic_op(enum fi_op op)
 			remote_fi_addr, remote.addr, remote.key, datatype, op, 
 			&fi_ctx_atomic);
 	if (ret) {
-		fprintf(stderr, "fi_compare_atomic %d (%s)\n", ret, 
+		fprintf(stderr, "fi_compare_atomic() %d (%s)\n", ret, 
 				fi_strerror(-ret));
 	} else {			
 		ret = wait_for_completion(scq, 1);
@@ -416,13 +416,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = 128;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_cq_open send comp %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_cq_open() send comp %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_cq_open recv comp %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_cq_open() recv comp %s\n", fi_strerror(-ret));
 		goto err2;
 	}
 	
@@ -431,7 +431,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)), 
 		FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_mr_reg %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_mr_reg() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
@@ -440,7 +440,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	ret = fi_mr_reg(dom, result, MAX(buffer_size, sizeof(uint64_t)), 
 		FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0, 0, &mr_result, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_mr_reg %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_mr_reg() %s\n", fi_strerror(-ret));
 		goto err4;
 	}
 	
@@ -448,7 +448,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	ret = fi_mr_reg(dom, compare, MAX(buffer_size, sizeof(uint64_t)), 
 		FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0, 0, &mr_compare, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_mr_reg %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_mr_reg() %s\n", fi_strerror(-ret));
 		goto err5;
 	}
 
@@ -489,19 +489,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND | FI_READ | FI_WRITE);
 	if (ret) {
-		fprintf(stderr, "fi_ep_bind %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_ep_bind() %s\n", fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		fprintf(stderr, "fi_ep_bind %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_ep_bind() %s\n", fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, FI_RECV);
 	if (ret) {
-		fprintf(stderr, "fi_ep_bind %s\n", fi_strerror(-ret));
+		fprintf(stderr, "fi_ep_bind() %s\n", fi_strerror(-ret));
 		return ret;
 	}
 

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -232,19 +232,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		printf("fi_cq_open send comp %s\n", fi_strerror(-ret));
+		printf("fi_cq_open() send comp %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		printf("fi_cq_open recv comp %s\n", fi_strerror(-ret));
+		printf("fi_cq_open() recv comp %s\n", fi_strerror(-ret));
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		printf("fi_mr_reg %s\n", fi_strerror(-ret));
+		printf("fi_mr_reg() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
@@ -254,7 +254,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.flags = 0;
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		printf("fi_av_open %s\n", fi_strerror(-ret));
+		printf("fi_av_open() %s\n", fi_strerror(-ret));
 		goto err4;
 	}
 
@@ -277,31 +277,31 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		printf("fi_ep_bind scq %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_ep_bind() scq %d (%s)\n", ret, fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		printf("fi_ep_bind rcq %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_ep_bind() rcq %d (%s)\n", ret, fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		printf("fi_ep_bind av %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_ep_bind() av %d (%s)\n", ret, fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		printf("fi_enable %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_enable() %d (%s)\n", ret, fi_strerror(-ret));
 		return ret;
 	}
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret) {
-		printf("fi_recv %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
 	}
 
 	return ret;
@@ -323,7 +323,7 @@ static int common_setup(void)
 
 	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
 	if (ret) {
-		printf("fi_getinfo %s\n", strerror(-ret));
+		printf("fi_getinfo() %s\n", strerror(-ret));
 		goto err0;
 	}
 	if (fi->ep_attr->max_msg_size) {
@@ -332,7 +332,7 @@ static int common_setup(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		printf("fi_fabric %s\n", fi_strerror(-ret));
+		printf("fi_fabric() %s\n", fi_strerror(-ret));
 		goto err1;
 	}
 	if (fi->mode & FI_MSG_PREFIX) {
@@ -341,26 +341,26 @@ static int common_setup(void)
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		printf("fi_domain %s %s\n", fi_strerror(-ret),
+		printf("fi_domain() %s %s\n", fi_strerror(-ret),
 			fi->domain_attr->name);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		printf("fi_endpoint %s\n", fi_strerror(-ret));
+		printf("fi_endpoint() %s\n", fi_strerror(-ret));
 		goto err3;
 	}
 
 	ret = alloc_ep_res(fi);
 	if (ret) {
-		printf("alloc_ep_res %s\n", fi_strerror(-ret));
+		printf("alloc_ep_res() %s\n", fi_strerror(-ret));
 		goto err4;
 	}
 
 	ret = bind_ep_res();
 	if (ret) {
-		printf("bind_ep_res %s\n", fi_strerror(-ret));
+		printf("bind_ep_res() %s\n", fi_strerror(-ret));
 		goto err5;
 	}
 
@@ -401,7 +401,7 @@ static int client_connect(void)
 
 	ret = fi_av_insert(av, sin, 1, &rem_addr, 0, NULL);
 	if (ret != 1) {
-		printf("fi_av_insert %s\n", fi_strerror(-ret));
+		printf("fi_av_insert() %s\n", fi_strerror(-ret));
 		goto err;
 	}
 
@@ -440,7 +440,7 @@ static int server_connect(void)
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
 		if (ret < 0) {
-			printf("fi_cq_read rcq %d (%s)\n", ret, fi_strerror(-ret));
+			printf("fi_cq_read() rcq %d (%s)\n", ret, fi_strerror(-ret));
 			return ret;
 		}
 	} while (ret == 0);
@@ -452,14 +452,14 @@ static int server_connect(void)
 					((uint32_t *)buf)[0], ((uint32_t *)buf)[1]);
 			ret = -FI_EINVAL;
 		} else {
-			printf("fi_insert_av %d (%s)\n", ret, fi_strerror(-ret));
+			printf("fi_insert_av() %d (%s)\n", ret, fi_strerror(-ret));
 		}
 		goto err;
 	}
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret != 0) {
-		printf("fi_recv %d (%s)\n", ret, fi_strerror(-ret));
+		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
 		goto err;
 	}
 


### PR DESCRIPTION
Users were getting confused by error messages that looked like this:

```shell
$ simple/fi_msg_pingpong
fi_getinfo: No such file or directory
```

The error message was referring to the C function fi_getinfo(), but there's also an fi_info Linux executable (users' eyes tend to gloss over the difference between fi_getinfo and fi_info).  This led to users getting very confused, because they thought that fi_msg_pingpong was trying to exec fi_info (which would be weird in itself), but then even though the fi_info exists and is in the user's path, it somehow wasn't being found.

Clarify the error messages to put "()" when a function is being discussed.  Technically, this probably was only relevant for the fi_getinfo() function, but I went ahead and applied it uniformly throughout the code -- just so that it's consistent everywhere.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>