### PR TITLE
Update client-server tests to use new refactored code.

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -83,24 +83,12 @@ int ft_getsrcaddr(char *node, char *service, struct fi_info *hints)
 	return ret;
 }
 
-int getaddr(char *node, char *service, struct sockaddr **addr, socklen_t *len)
+/* yaml version info */
+void ft_version(char *app)
 {
-	struct addrinfo *ai;
-	int ret;
-
-	ret = getaddrinfo(node, service, NULL, &ai);
-	if (ret)
-		return ret;
-
-	if ((*addr = malloc(ai->ai_addrlen))) {
-		memcpy(*addr, ai->ai_addr, ai->ai_addrlen);
-		*len = ai->ai_addrlen;
-	} else {
-		ret = EAI_MEMORY;
-	}
-
-	freeaddrinfo(ai);
-	return ret;
+	printf("%s: %s\n", app, PACKAGE_VERSION);
+	printf("libfabric: %s\n", fi_tostr("1", FI_TYPE_VERSION));
+	printf("libfabric api: %d.%d\n", FI_MAJOR(FT_FIVERSION), FI_MINOR(FT_FIVERSION));
 }
 
 char *size_str(char str[FI_STR_LEN], long long size)
@@ -284,7 +272,7 @@ void ft_csusage(char *name, char *desc)
 	fprintf(stderr, "\nOptions:\n");
 	fprintf(stderr, "  -n <domain>\tdomain name\n");
 	fprintf(stderr, "  -p <port>\tnon default port number\n");
-	fprintf(stderr, "  -f <provier>\tspecific provider name eg IP,verbs\n");
+	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP,verbs\n");
 	fprintf(stderr, "  -s <address>\tsource address\n");
 	fprintf(stderr, "  -I <number>\tnumber of iterations\n");
 	fprintf(stderr, "  -S <size>\tspecific transfer size or 'all'\n");

--- a/include/shared.h
+++ b/include/shared.h
@@ -76,6 +76,7 @@ struct cs_opts {
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
 void ft_parsecsopts(int op, char *optarg, struct cs_opts *opts);
 void ft_csusage(char *name, char *desc);
+void ft_version(char *app);
 #define INFO_OPTS "n:f:"
 #define CS_OPTS "p:I:S:s:mi"
 

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -232,9 +232,7 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, 
-				(struct sockaddr **) &hints.src_addr, 
-				(socklen_t *) &hints.src_addrlen);
+		ret = ft_getsrcaddr(src_addr, NULL, &hints);
 		if (ret) {
 			fprintf(stderr, "source address error %s\n", 
 					gai_strerror(ret));

--- a/simple/imm_data.c
+++ b/simple/imm_data.c
@@ -311,8 +311,7 @@ static int client_connect(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = ft_getsrcaddr(src_addr, NULL, &hints);
 		if (ret) {
 			printf("source address error %s\n", gai_strerror(ret));
 			return ret;

--- a/simple/info.c
+++ b/simple/info.c
@@ -33,6 +33,8 @@
 
 #include <rdma/fabric.h>
 
+#include "shared.h"
+
 static struct fi_info hints;
 static char *node, *port;
 
@@ -152,7 +154,7 @@ static int run(struct fi_info *hints, char *node, char *port)
 	struct fi_info *info;
 	int ret;
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, 0, hints, &info);
+	ret = fi_getinfo(FT_FIVERSION, node, port, 0, hints, &info);
 	if (ret) {
 		printf("fi_getinfo() %s\n", strerror(-ret));
 		return ret;

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -277,7 +277,7 @@ static int server_listen(void)
 	struct fi_info *fi;
 	int ret;
 
-	ret = fi_getinfo(FI_VERSION(1,0), opts.src_addr, opts.port, FI_SOURCE, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.port, FI_SOURCE, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -548,9 +548,7 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "vhg:" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		case 'v':
-			printf("%s: %s\n", argv[0], PACKAGE_VERSION);
-			printf("libfabric: %s\n", fi_tostr("1", FI_TYPE_VERSION));
-			printf("libfabric api: %d.%d\n", FI_MAJOR(FT_FIVERSION), FI_MINOR(FT_FIVERSION));
+			ft_version(argv[0]);
 			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -249,9 +249,7 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, 
-				(struct sockaddr **) &hints.src_addr, 
-				(socklen_t *) &hints.src_addrlen);
+		ret = ft_getsrcaddr(src_addr, NULL, &hints);
 		if (ret) {
 			fprintf(stderr, "source address error %s\n", 
 					gai_strerror(ret));

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -43,10 +43,7 @@
 
 #define CNTR_TIMEOUT 10000	// 10000 ms
 
-static int custom;
-static int size_option;
-static int iterations = 1000;
-static int transfer_size = 1024;
+static struct cs_opts opts;
 static int max_credits = 128;
 static int credits = 128;
 static int send_count = 0;
@@ -55,14 +52,8 @@ static char test_name[10] = "custom";
 static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
-static int machr, g_argc;
-static char **g_argv;
 
 static struct fi_info hints;
-static struct fi_domain_attr domain_hints;
-static struct fi_ep_attr ep_hints;
-static char *dst_addr, *src_addr;
-static char *port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -183,11 +174,11 @@ static int sync_test(void)
 	if (ret)
 		return ret;
 
-	ret = dst_addr ? send_xfer(16) : recv_xfer(16);
+	ret = opts.dst_addr ? send_xfer(16) : recv_xfer(16);
 	if (ret)
 		return ret;
 
-	return dst_addr ? recv_xfer(16) : send_xfer(16);
+	return opts.dst_addr ? recv_xfer(16) : send_xfer(16);
 }
 
 static int run_test(void)
@@ -199,24 +190,23 @@ static int run_test(void)
 		goto out;
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
-	for (i = 0; i < iterations; i++) {
-		ret = dst_addr ? send_xfer(transfer_size) :
-				 recv_xfer(transfer_size);
+	for (i = 0; i < opts.iterations; i++) {
+		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
+				 recv_xfer(opts.transfer_size);
 		if (ret)
 			goto out;
 
-		ret = dst_addr ? recv_xfer(transfer_size) :
-				 send_xfer(transfer_size);
+		ret = opts.dst_addr ? recv_xfer(opts.transfer_size) :
+				 send_xfer(opts.transfer_size);
 		if (ret)
 			goto out;
 	}
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
-	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc,
-			       	g_argv);
+	if (opts.machr)
+		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 2, opts.argc, opts.argv);
 	else
-		show_perf(test_name, transfer_size, iterations, &start, &end, 2);
+		show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 2);
 
 	ret = 0;
 
@@ -239,7 +229,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !custom ? test_size[TEST_CNT - 1].size : transfer_size;
+	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
 	buf = malloc(buffer_size);
 	if (!buf) {
 		perror("malloc");
@@ -329,25 +319,14 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int ret;
 
-	if (src_addr) {
-		ret = getaddr(src_addr, NULL, 
-				(struct sockaddr **) &hints.src_addr, 
-				(socklen_t *) &hints.src_addrlen);
-		if (ret) {
-			FI_DEBUG("source address error %s\n", 
-					gai_strerror(ret));
-			return ret;
-		}
-	}
-
-	if (dst_addr) {
-		node = dst_addr;
+	if (opts.dst_addr) {
+		node = opts.dst_addr;
 	} else {
-		node = src_addr;
+		node = opts.src_addr;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -359,7 +338,7 @@ static int init_fabric(void)
 		fi->mode |= FI_PROV_MR_ATTR;
 
 	/* Get remote address */
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		addrlen = fi->dest_addrlen;
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, fi->dest_addr, addrlen);
@@ -411,7 +390,7 @@ static int init_av(void)
 {
 	int ret;
 
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		/* Get local address blob. Find the addrlen first. We set addrlen 
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
@@ -492,13 +471,13 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!custom) {
+	if (!opts.custom) {
 		for (i = 0; i < TEST_CNT; i++) {
-			if (test_size[i].option > size_option)
+			if (test_size[i].option > opts.size_option)
 				continue;
 			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &transfer_size,
-					&iterations);
+					sizeof(test_name), &opts.transfer_size,
+					&opts.iterations);
 			run_test();
 		}
 	} else {
@@ -540,61 +519,48 @@ void print_usage(char *name)
 int main(int argc, char **argv)
 {
 	int op, ret;
-	int prhints = 0;
 
-	while ((op = getopt(argc, argv, "n:p:s:I:S:mivh")) != -1) {
+	/* default options for test */
+	opts.iterations = 1000;
+	opts.transfer_size = 1024;
+	opts.port = "9228";
+	opts.argc = argc;
+	opts.argv = argv;
+
+	while ((op = getopt(argc, argv, "vh" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'n':
-			domain_hints.name = optarg;
-			break;
-		case 'p':
-			port = optarg;
-			break;
-		case 's':
-			ret = getaddr(optarg, NULL,
-				      (struct sockaddr **) &hints.src_addr,
-				      (socklen_t *) &hints.src_addrlen);
-
-			src_addr = optarg;
-			if (ret) {
-				FI_DEBUG("source address error %s\n", gai_strerror(ret));
-				return EXIT_FAILURE;
-			}
-			break;
-		case 'I':
-			custom = 1;
-			iterations = atoi(optarg);
-			break;
-		case 'S':
-			if (!strncasecmp("all", optarg, 3)) {
-				size_option = 1;
-			} else {
-				custom = 1;
-				transfer_size = atoi(optarg);
-			}
-			break;
-		case 'm':
-			machr = 1;
-			g_argc = argc;
-			g_argv = argv;
-			break;
+		case 'v':
+			ft_version(argv[0]);
+			return EXIT_SUCCESS;
 		default:
-			print_usage(argv[0]);
+			ft_parseinfo(op, optarg, &hints);
+			ft_parsecsopts(op, optarg, &opts);
+			break;
+		case '?':
+		case 'h':
+			ft_csusage(argv[0], "Ping pong client and server using counters.");
 			return EXIT_FAILURE;
 		}
 	}
 
 	if (optind < argc)
-		dst_addr = argv[optind];
+		opts.dst_addr = argv[optind];
 
-	hints.domain_attr = &domain_hints;
-	hints.ep_attr = &ep_hints;
+	if (opts.src_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+
+		if (ret) {
+			FI_DEBUG("source address error %s\n", gai_strerror(ret));
+			return EXIT_FAILURE;
+		}
+	}
+
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG;
 	hints.mode = FI_CONTEXT;
 	hints.addr_format = FI_FORMAT_UNSPEC;
 
-	if (prhints) {
+	if (opts.prhints) {
 		printf("%s", fi_tostr(&hints, FI_TYPE_INFO));
 		return EXIT_SUCCESS;
 	}

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -42,25 +42,15 @@
 
 #include "shared.h"
 
-static int custom;
-static int size_option;
-static int iterations = 1000;
-static int transfer_size = 1024;
+static struct cs_opts opts;
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";
 static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
-static int machr, g_argc;
-static char **g_argv;
 
 static struct fi_info hints;
-static struct fi_domain_attr domain_hints;
-static struct fi_fabric_attr fabric_hints;
-static struct fi_ep_attr ep_hints;
-static char *dst_addr, *src_addr;
-static char *port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -170,11 +160,11 @@ static int sync_test(void)
 	}
 	credits = max_credits;
 
-	ret = dst_addr ? send_xfer(16) : recv_xfer(16);
+	ret = opts.dst_addr ? send_xfer(16) : recv_xfer(16);
 	if (ret)
 		return ret;
 
-	return dst_addr ? recv_xfer(16) : send_xfer(16);
+	return opts.dst_addr ? recv_xfer(16) : send_xfer(16);
 }
 
 static int run_test(void)
@@ -186,23 +176,23 @@ static int run_test(void)
 		goto out;
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
-	for (i = 0; i < iterations; i++) {
-		ret = dst_addr ? send_xfer(transfer_size) :
-				 recv_xfer(transfer_size);
+	for (i = 0; i < opts.iterations; i++) {
+		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
+				 recv_xfer(opts.transfer_size);
 		if (ret)
 			goto out;
 
-		ret = dst_addr ? recv_xfer(transfer_size) :
-				 send_xfer(transfer_size);
+		ret = opts.dst_addr ? recv_xfer(opts.transfer_size) :
+				 send_xfer(opts.transfer_size);
 		if (ret)
 			goto out;
 	}
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
-	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc, g_argv);
+	if (opts.machr)
+		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 2, opts.argc, opts.argv);
 	else
-		show_perf(test_name, transfer_size, iterations, &start, &end, 2);
+		show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 2);
 
 	ret = 0;
 
@@ -225,7 +215,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !custom ? test_size[TEST_CNT - 1].size : transfer_size;
+	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
 	buf = malloc(buffer_size);
 	if (!buf) {
 		perror("malloc");
@@ -316,14 +306,14 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int ret;
 
-	if (dst_addr) {
-		node = dst_addr;
+	if (opts.dst_addr) {
+		node = opts.dst_addr;
 	} else {
-		node = src_addr;
+		node = opts.src_addr;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -335,7 +325,7 @@ static int init_fabric(void)
 		fi->mode |= FI_PROV_MR_ATTR;
 
 	/* Get remote address */
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		addrlen = fi->dest_addrlen;
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, fi->dest_addr, addrlen);
@@ -359,7 +349,7 @@ static int init_fabric(void)
 		goto err2;
 	}
 
-	if (dst_addr == NULL) {
+	if (opts.dst_addr == NULL) {
 		FI_DEBUG("EP opened on fabric %s\n", fi->fabric_attr->name);
 	}
 
@@ -391,7 +381,7 @@ static int init_av(void)
 {
 	int ret;
 
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		/* Get local address blob. Find the addrlen first. We set 
 		 * addrlen as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
@@ -471,13 +461,13 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!custom) {
+	if (!opts.custom) {
 		for (i = 0; i < TEST_CNT; i++) {
-			if (test_size[i].option > size_option)
+			if (test_size[i].option > opts.size_option)
 				continue;
 			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &transfer_size,
-					&iterations);
+					sizeof(test_name), &opts.transfer_size,
+					&opts.iterations);
 			run_test();
 		}
 	} else {
@@ -498,93 +488,51 @@ out:
 	return ret;
 }
 
-void print_usage(char *name)
-{
-	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "  %s [OPTIONS]\t\tstart ping server\n", name);
-	fprintf(stderr, "  %s [OPTIONS] <host>\tpong given host\n", name);
-
-	fprintf(stderr, "\nOptions:\n");
-	fprintf(stderr, "  -n\tdomain name\n");
-	fprintf(stderr, "  -p\tport number\n");
-	fprintf(stderr, "  -s\tsource address\n");
-	fprintf(stderr, "  -I\tnumber of iterations\n");
-	fprintf(stderr, "  -S\tspecific transfer size or 'all'\n");
-	fprintf(stderr, "  -m\tmachine readable output\n");
-	fprintf(stderr, "  -i\tprint hints structure and exit\n");
-	fprintf(stderr, "  -v\tdisplay versions and exit\n");
-	fprintf(stderr, "  -h\tdisplay this help output\n");
-
-	return;
-}
-
 int main(int argc, char **argv)
 {
 	int op, ret;
-	int prhints = 0;
 
-	while ((op = getopt(argc, argv, "n:p:s:I:S:mivh")) != -1) {
+	/* default options for test */
+	opts.iterations = 1000;
+	opts.transfer_size = 1024;
+	opts.port = "9228";
+	opts.argc = argc;
+	opts.argv = argv;
+
+	while ((op = getopt(argc, argv, "vhg:" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'n':
-			domain_hints.name = optarg;
-			break;
-		case 'p':
-			port = optarg;
-			break;
-		case 's':
-			ret = getaddr(optarg, NULL,
-				      (struct sockaddr **) &hints.src_addr,
-				      (socklen_t *) &hints.src_addrlen);
-
-			src_addr = optarg;
-			if (ret) {
-				FI_DEBUG("source address error %s\n", gai_strerror(ret));
-				return EXIT_FAILURE;
-			}
-			break;
-		case 'I':
-			custom = 1;
-			iterations = atoi(optarg);
-			break;
-		case 'S':
-			if (!strncasecmp("all", optarg, 3)) {
-				size_option = 1;
-			} else {
-				custom = 1;
-				transfer_size = atoi(optarg);
-			}
-			break;
-		case 'm':
-			machr = 1;
-			g_argc = argc;
-			g_argv = argv;
-			break;
-		case 'i':
-			prhints = 1;
-			break;
 		case 'v':
-			printf("%s: 0.0.1\n", argv[0]);
-			printf("%s: %s\n", PACKAGE_NAME, PACKAGE_VERSION);
+			ft_version(argv[0]);
 			return EXIT_SUCCESS;
-		case 'h':
 		default:
-			print_usage(argv[0]);
+			ft_parseinfo(op, optarg, &hints);
+			ft_parsecsopts(op, optarg, &opts);
+			break;
+		case '?':
+		case 'h':
+			ft_csusage(argv[0], "Ping pong client and server using RDM.");
 			return EXIT_FAILURE;
 		}
 	}
 
 	if (optind < argc)
-		dst_addr = argv[optind];
+		opts.dst_addr = argv[optind];
 
-	hints.domain_attr = &domain_hints;
-	hints.fabric_attr = &fabric_hints;
-	hints.ep_attr = &ep_hints;
+	if (opts.src_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+
+		if (ret) {
+			FI_DEBUG("source address error %s\n", gai_strerror(ret));
+			return EXIT_FAILURE;
+		}
+	}
+
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG;
 	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;
 	hints.addr_format = FI_FORMAT_UNSPEC;
 
-	if (prhints) {
+	if (opts.prhints) {
 		printf("%s", fi_tostr(&hints, FI_TYPE_INFO));
 		return EXIT_SUCCESS;
 	}

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -299,9 +299,7 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, 
-				(struct sockaddr **) &hints.src_addr, 
-				(socklen_t *) &hints.src_addrlen);
+		ret = ft_getsrcaddr(src_addr, NULL, &hints);
 		if (ret) {
 			fprintf(stderr, "source address error %s\n", 
 					gai_strerror(ret));

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -309,8 +309,7 @@ static int init_fabric(void)
 	int i, ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = ft_getsrcaddr(src_addr, NULL, &hints);
 		if (ret) {
 			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
 			return ret;

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -43,24 +43,15 @@
 
 #include "shared.h"
 
-static int custom;
-static int size_option;
-static int iterations = 1000;
-static int transfer_size = 1024;
+static struct cs_opts opts;
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";
 static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
-static int machr, g_argc;
-static char **g_argv;
 
 static struct fi_info hints;
-static struct fi_domain_attr domain_hints;
-static struct fi_ep_attr ep_hints;
-static char *dst_addr, *src_addr;
-static char *port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -192,11 +183,11 @@ static int sync_test(void)
 	}
 	credits = max_credits;
 
-	ret = dst_addr ? send_xfer(16) : recv_xfer(16);
+	ret = opts.dst_addr ? send_xfer(16) : recv_xfer(16);
 	if (ret)
 		return ret;
 
-	ret = dst_addr ? recv_xfer(16) : send_xfer(16);
+	ret = opts.dst_addr ? recv_xfer(16) : send_xfer(16);
 
 	tag_data++;
 
@@ -212,14 +203,14 @@ static int run_test(void)
 		goto out;
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
-	for (i = 0; i < iterations; i++) {
-		ret = dst_addr ? send_xfer(transfer_size) :
-				 recv_xfer(transfer_size);
+	for (i = 0; i < opts.iterations; i++) {
+		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
+				 recv_xfer(opts.transfer_size);
 		if (ret)
 			goto out;
 
-		ret = dst_addr ? recv_xfer(transfer_size) :
-				 send_xfer(transfer_size);
+		ret = opts.dst_addr ? recv_xfer(opts.transfer_size) :
+				 send_xfer(opts.transfer_size);
 		if (ret)
 			goto out;
 
@@ -227,11 +218,10 @@ static int run_test(void)
 	}
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
-	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 2, g_argc,
-			       	g_argv);
+	if (opts.machr)
+		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 2, opts.argc, opts.argv);
 	else
-		show_perf(test_name, transfer_size, iterations, &start, &end, 2);
+		show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 2);
 
 	ret = 0;
 
@@ -254,7 +244,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !custom ? test_size[TEST_CNT - 1].size : transfer_size;
+	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
 	buf = malloc(buffer_size);
 	if (!buf) {
 		perror("malloc");
@@ -345,14 +335,14 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int ret;
 
-	if (dst_addr) {
-		node = dst_addr;
+	if (opts.dst_addr) {
+		node = opts.dst_addr;
 	} else {
-		node = src_addr;
+		node = opts.src_addr;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -364,7 +354,7 @@ static int init_fabric(void)
 		fi->mode |= FI_PROV_MR_ATTR;
 
 	/* Get remote address */
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		addrlen = fi->dest_addrlen;
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, fi->dest_addr, addrlen);
@@ -416,7 +406,7 @@ static int init_av(void)
 {
 	int ret;
 
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		/* Get local address blob. Find the addrlen first. We set addrlen 
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
@@ -496,13 +486,13 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!custom) {
+	if (!opts.custom) {
 		for (i = 0; i < TEST_CNT; i++) {
-			if (test_size[i].option > size_option)
+			if (test_size[i].option > opts.size_option)
 				continue;
 			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &transfer_size,
-					&iterations);
+					sizeof(test_name), &opts.transfer_size,
+					&opts.iterations);
 			run_test();
 		}
 	} else {
@@ -523,92 +513,51 @@ out:
 	return ret;
 }
 
-void print_usage(char *name)
-{
-	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "  %s [OPTIONS]\t\tstart ping server\n", name);
-	fprintf(stderr, "  %s [OPTIONS] <host>\tpong given host\n", name);
-
-	fprintf(stderr, "\nOptions:\n");
-	fprintf(stderr, "  -n\tdomain name\n");
-	fprintf(stderr, "  -p\tport number\n");
-	fprintf(stderr, "  -s\tsource address\n");
-	fprintf(stderr, "  -I\tnumber of iterations\n");
-	fprintf(stderr, "  -S\tspecific transfer size or 'all'\n");
-	fprintf(stderr, "  -m\tmachine readable output\n");
-	fprintf(stderr, "  -i\tprint hints structure and exit\n");
-	fprintf(stderr, "  -v\tdisplay versions and exit\n");
-	fprintf(stderr, "  -h\tdisplay this help output\n");
-
-	return;
-}
-
 int main(int argc, char **argv)
 {
 	int op, ret;
-	int prhints = 0;
 
-	while ((op = getopt(argc, argv, "n:p:s:I:S:mivh")) != -1) {
+	/* default options for test */
+	opts.iterations = 1000;
+	opts.transfer_size = 1024;
+	opts.port = "9228";
+	opts.argc = argc;
+	opts.argv = argv;
+
+	while ((op = getopt(argc, argv, "vhg:" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'n':
-			domain_hints.name = optarg;
-			break;
-		case 'p':
-			port = optarg;
-			break;
-		case 's':
-			ret = getaddr(optarg, NULL,
-				      (struct sockaddr **) &hints.src_addr,
-				      (socklen_t *) &hints.src_addrlen);
-
-			src_addr = optarg;
-			if (ret) {
-				FI_DEBUG("source address error %s\n", gai_strerror(ret));
-				return EXIT_FAILURE;
-			}
-			break;
-		case 'I':
-			custom = 1;
-			iterations = atoi(optarg);
-			break;
-		case 'S':
-			if (!strncasecmp("all", optarg, 3)) {
-				size_option = 1;
-			} else {
-				custom = 1;
-				transfer_size = atoi(optarg);
-			}
-			break;
-		case 'm':
-			machr = 1;
-			g_argc = argc;
-			g_argv = argv;
-			break;
-		case 'i':
-			prhints = 1;
-			break;
 		case 'v':
-			printf("%s: 0.0.1\n", argv[0]);
-			printf("%s: %s\n", PACKAGE_NAME, PACKAGE_VERSION);
+			ft_version(argv[0]);
 			return EXIT_SUCCESS;
-		case 'h':
 		default:
-			print_usage(argv[0]);
+			ft_parseinfo(op, optarg, &hints);
+			ft_parsecsopts(op, optarg, &opts);
+			break;
+		case '?':
+		case 'h':
+			ft_csusage(argv[0], "Ping pong client and server using tagged messages.");
 			return EXIT_FAILURE;
 		}
 	}
 
 	if (optind < argc)
-		dst_addr = argv[optind];
+		opts.dst_addr = argv[optind];
 
-	hints.domain_attr = &domain_hints;
-	hints.ep_attr = &ep_hints;
+	if (opts.src_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+
+		if (ret) {
+			FI_DEBUG("source address error %s\n", gai_strerror(ret));
+			return EXIT_FAILURE;
+		}
+	}
+
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_TAGGED;
 	hints.mode = FI_CONTEXT;
 	hints.addr_format = FI_FORMAT_UNSPEC;
 
-	if (prhints) {
+	if (opts.prhints) {
 		printf("%s", fi_tostr(&hints, FI_TYPE_INFO));
 		return EXIT_SUCCESS;
 	}

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -250,9 +250,7 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, 
-				(struct sockaddr **) &hints.src_addr,
-				(socklen_t *) &hints.src_addrlen);
+		ret = ft_getsrcaddr(src_addr, NULL, &hints);
 		if (ret) {
 			fprintf(stderr, "source address error %s\n",
 					gai_strerror(ret));

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -316,8 +316,7 @@ static int init_fabric(void)
 	int ret;
 
 	if (src_addr) {
-		ret = getaddr(src_addr, NULL, (struct sockaddr **) &hints.src_addr,
-			      (socklen_t *) &hints.src_addrlen);
+		ret = ft_getsrcaddr(src_addr, port, &hints);
 		if (ret) {
 			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
 			return ret;


### PR DESCRIPTION
Use ft_getsrcadd(...)
Use FT_FIVERSION for global libfabric version.
Use version printing function that prints test/libfabric/api info.

@shantonu @a-ilango @jsquyres : If any of you can take a peek at these changes it would be great, they are trivial but there are a lot of them touching everything.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>