### PR TITLE
More cleanups for fabtests.

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -68,6 +68,9 @@ int ft_getsrcaddr(char *node, char *service, struct fi_info *hints)
 	struct addrinfo *ai;
 	int ret;
 
+	if (!node)
+		return 0;
+
 	ret = getaddrinfo(node, service, NULL, &ai);
 	if (ret)
 		return ret;
@@ -81,14 +84,6 @@ int ft_getsrcaddr(char *node, char *service, struct fi_info *hints)
 
 	freeaddrinfo(ai);
 	return ret;
-}
-
-/* yaml version info */
-void ft_version(char *app)
-{
-	printf("%s: %s\n", app, PACKAGE_VERSION);
-	printf("libfabric: %s\n", fi_tostr("1", FI_TYPE_VERSION));
-	printf("libfabric api: %d.%d\n", FI_MAJOR(FT_FIVERSION), FI_MINOR(FT_FIVERSION));
 }
 
 char *size_str(char str[FI_STR_LEN], long long size)

--- a/include/shared.h
+++ b/include/shared.h
@@ -76,9 +76,13 @@ struct cs_opts {
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
 void ft_parsecsopts(int op, char *optarg, struct cs_opts *opts);
 void ft_csusage(char *name, char *desc);
-void ft_version(char *app);
 #define INFO_OPTS "n:f:"
 #define CS_OPTS "p:I:S:s:mi"
+
+#define INIT_OPTS (struct cs_opts) { .iterations = 1000, \
+				     .transfer_size = 1024, \
+				     .port = "9228", \
+				     .argc = argc, .argv = argv }
 
 extern struct test_size_param test_size[];
 const unsigned int test_cnt;

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -231,13 +231,11 @@ static int init_fabric(void)
 	char *node;
 	int ret;
 
-	if (src_addr) {
-		ret = ft_getsrcaddr(src_addr, NULL, &hints);
-		if (ret) {
-			fprintf(stderr, "source address error %s\n", 
-					gai_strerror(ret));
-			return ret;
-		}
+	ret = ft_getsrcaddr(src_addr, NULL, &hints);
+	if (ret) {
+		fprintf(stderr, "source address error %s\n", 
+				gai_strerror(ret));
+		return ret;
 	}
 
 	if (dst_addr) {

--- a/simple/imm_data.c
+++ b/simple/imm_data.c
@@ -310,12 +310,10 @@ static int client_connect(void)
 	ssize_t rd;
 	int ret;
 
-	if (src_addr) {
-		ret = ft_getsrcaddr(src_addr, NULL, &hints);
-		if (ret) {
-			printf("source address error %s\n", gai_strerror(ret));
-			return ret;
-		}
+	ret = ft_getsrcaddr(src_addr, NULL, &hints);
+	if (ret) {
+		printf("source address error %s\n", gai_strerror(ret));
+		return ret;
 	}
 
 	ret = fi_getinfo(FI_VERSION(1, 0), dst_addr, port, 0, &hints, &fi);

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -537,19 +537,10 @@ static int run(void)
 int main(int argc, char **argv)
 {
 	int op, ret;
+	opts = INIT_OPTS;
 
-	/* default options for test */
-	opts.iterations = 1000;
-	opts.transfer_size = 1024;
-	opts.port = "9228";
-	opts.argc = argc;
-	opts.argv = argv;
-
-	while ((op = getopt(argc, argv, "vhg:" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'v':
-			ft_version(argv[0]);
-			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);
 			ft_parsecsopts(op, optarg, &opts);
@@ -564,13 +555,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	if (opts.src_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
 
-		if (ret) {
-			FI_DEBUG("source address error %s\n", gai_strerror(ret));
-			return EXIT_FAILURE;
-		}
+	if (ret) {
+		FI_DEBUG("source address error %s\n", gai_strerror(ret));
+		return EXIT_FAILURE;
 	}
 
 	hints.ep_type = FI_EP_MSG;

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -579,17 +579,12 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+	opts = INIT_OPTS;
 
-	/* default options for test */
-	opts.iterations = 1000;
-	opts.transfer_size = 1024;
-	opts.port = "9228";
-	opts.argc = argc;
-	opts.argv = argv;
 
-	while ((op = getopt(argc, argv, "vho:" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-			case 'o':
+		case 'o':
 			if (!strcmp(optarg, "read"))
 				op_type = FI_REMOTE_READ;
 			else if (!strcmp(optarg, "write"))
@@ -599,9 +594,6 @@ int main(int argc, char **argv)
 				return EXIT_FAILURE;
 			}
 			break;
-		case 'v':
-			ft_version(argv[0]);
-			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);
 			ft_parsecsopts(op, optarg, &opts);
@@ -617,13 +609,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	if (opts.src_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
 
-		if (ret) {
-			FI_DEBUG("source address error %s\n", gai_strerror(ret));
-			return EXIT_FAILURE;
-		}
+	if (ret) {
+		FI_DEBUG("source address error %s\n", gai_strerror(ret));
+		return EXIT_FAILURE;
 	}
 
 	hints.ep_type = FI_EP_MSG;

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -248,13 +248,11 @@ static int init_fabric(void)
 	char *node;
 	int ret;
 
-	if (src_addr) {
-		ret = ft_getsrcaddr(src_addr, NULL, &hints);
-		if (ret) {
-			fprintf(stderr, "source address error %s\n", 
-					gai_strerror(ret));
-			return ret;
-		}
+	ret = ft_getsrcaddr(src_addr, NULL, &hints);
+	if (ret) {
+		fprintf(stderr, "source address error %s\n", 
+				gai_strerror(ret));
+		return ret;
 	}
 
 	if (dst_addr) {

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -724,15 +724,9 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+	opts = INIT_OPTS;
 
-	/* default options for test */
-	opts.iterations = 1000;
-	opts.transfer_size = 1024;
-	opts.port = "9228";
-	opts.argc = argc;
-	opts.argv = argv;
-
-	while ((op = getopt(argc, argv, "vho:" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		case 'o':
 			if (!strncasecmp("all", optarg, 3)) {
@@ -744,9 +738,6 @@ int main(int argc, char **argv)
 					ft_csusage(argv[0], NULL);
 			}
 			break;
-		case 'v':
-			ft_version(argv[0]);
-			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);
 			ft_parsecsopts(op, optarg, &opts);
@@ -762,13 +753,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	if (opts.src_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
 
-		if (ret) {
-			FI_DEBUG("source address error %s\n", gai_strerror(ret));
-			return EXIT_FAILURE;
-		}
+	if (ret) {
+		FI_DEBUG("source address error %s\n", gai_strerror(ret));
+		return EXIT_FAILURE;
 	}
 
 	hints.ep_type = FI_EP_RDM;

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -519,19 +519,10 @@ void print_usage(char *name)
 int main(int argc, char **argv)
 {
 	int op, ret;
+	opts = INIT_OPTS;
 
-	/* default options for test */
-	opts.iterations = 1000;
-	opts.transfer_size = 1024;
-	opts.port = "9228";
-	opts.argc = argc;
-	opts.argv = argv;
-
-	while ((op = getopt(argc, argv, "vh" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'v':
-			ft_version(argv[0]);
-			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);
 			ft_parsecsopts(op, optarg, &opts);
@@ -546,13 +537,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	if (opts.src_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
 
-		if (ret) {
-			FI_DEBUG("source address error %s\n", gai_strerror(ret));
-			return EXIT_FAILURE;
-		}
+	if (ret) {
+		FI_DEBUG("source address error %s\n", gai_strerror(ret));
+		return EXIT_FAILURE;
 	}
 
 	hints.ep_type = FI_EP_RDM;

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -472,19 +472,10 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+	opts = INIT_OPTS;
 
-	/* default options for test */
-	opts.iterations = 1000;
-	opts.transfer_size = 1024;
-	opts.port = "9228";
-	opts.argc = argc;
-	opts.argv = argv;
-
-	while ((op = getopt(argc, argv, "vhg:" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'v':
-			ft_version(argv[0]);
-			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);
 			ft_parsecsopts(op, optarg, &opts);
@@ -499,13 +490,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	if (opts.src_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
 
-		if (ret) {
-			FI_DEBUG("source address error %s\n", gai_strerror(ret));
-			return EXIT_FAILURE;
-		}
+	if (ret) {
+		FI_DEBUG("source address error %s\n", gai_strerror(ret));
+		return EXIT_FAILURE;
 	}
 
 	hints.ep_type = FI_EP_RDM;

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -574,19 +574,10 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+	opts = INIT_OPTS;
 
-	/* default options for test */
-	opts.iterations = 1000;
-	opts.transfer_size = 1024;
-	opts.port = "9228";
-	opts.argc = argc;
-	opts.argv = argv;
-
-	while ((op = getopt(argc, argv, "vhg:" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'v':
-			ft_version(argv[0]);
-			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);
 			ft_parsecsopts(op, optarg, &opts);
@@ -601,13 +592,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	if (opts.src_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
 
-		if (ret) {
-			FI_DEBUG("source address error %s\n", gai_strerror(ret));
-			return EXIT_FAILURE;
-		}
+	if (ret) {
+		FI_DEBUG("source address error %s\n", gai_strerror(ret));
+		return EXIT_FAILURE;
 	}
 
 	hints.ep_type = FI_EP_RDM;

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -491,19 +491,10 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+	opts = INIT_OPTS;
 
-	/* default options for test */
-	opts.iterations = 1000;
-	opts.transfer_size = 1024;
-	opts.port = "9228";
-	opts.argc = argc;
-	opts.argv = argv;
-
-	while ((op = getopt(argc, argv, "vhg:" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'v':
-			ft_version(argv[0]);
-			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);
 			ft_parsecsopts(op, optarg, &opts);
@@ -518,13 +509,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	if (opts.src_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
 
-		if (ret) {
-			FI_DEBUG("source address error %s\n", gai_strerror(ret));
-			return EXIT_FAILURE;
-		}
+	if (ret) {
+		FI_DEBUG("source address error %s\n", gai_strerror(ret));
+		return EXIT_FAILURE;
 	}
 
 	hints.ep_type = FI_EP_RDM;

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -298,13 +298,11 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int ret;
 
-	if (src_addr) {
-		ret = ft_getsrcaddr(src_addr, NULL, &hints);
-		if (ret) {
-			fprintf(stderr, "source address error %s\n", 
-					gai_strerror(ret));
-			return ret;
-		}
+	ret = ft_getsrcaddr(src_addr, NULL, &hints);
+	if (ret) {
+		fprintf(stderr, "source address error %s\n", 
+				gai_strerror(ret));
+		return ret;
 	}
 
 	if (dst_addr) {

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -308,12 +308,10 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int i, ret;
 
-	if (src_addr) {
-		ret = ft_getsrcaddr(src_addr, NULL, &hints);
-		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
-			return ret;
-		}
+	ret = ft_getsrcaddr(src_addr, NULL, &hints);
+	if (ret) {
+		fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+		return ret;
 	}
 
 	if (dst_addr) {

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -516,19 +516,10 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+	opts = INIT_OPTS;
 
-	/* default options for test */
-	opts.iterations = 1000;
-	opts.transfer_size = 1024;
-	opts.port = "9228";
-	opts.argc = argc;
-	opts.argv = argv;
-
-	while ((op = getopt(argc, argv, "vhg:" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'v':
-			ft_version(argv[0]);
-			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);
 			ft_parsecsopts(op, optarg, &opts);
@@ -543,13 +534,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	if (opts.src_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
 
-		if (ret) {
-			FI_DEBUG("source address error %s\n", gai_strerror(ret));
-			return EXIT_FAILURE;
-		}
+	if (ret) {
+		FI_DEBUG("source address error %s\n", gai_strerror(ret));
+		return EXIT_FAILURE;
 	}
 
 	hints.ep_type = FI_EP_RDM;

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -249,13 +249,11 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int ret;
 
-	if (src_addr) {
-		ret = ft_getsrcaddr(src_addr, NULL, &hints);
-		if (ret) {
-			fprintf(stderr, "source address error %s\n",
-					gai_strerror(ret));
-			return ret;
-		}
+	ret = ft_getsrcaddr(src_addr, NULL, &hints);
+	if (ret) {
+		fprintf(stderr, "source address error %s\n",
+				gai_strerror(ret));
+		return ret;
 	}
 
 	if (dst_addr) {

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -315,12 +315,10 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int ret;
 
-	if (src_addr) {
-		ret = ft_getsrcaddr(src_addr, port, &hints);
-		if (ret) {
-			fprintf(stderr, "source address error %s\n", gai_strerror(ret));
-			return ret;
-		}
+	ret = ft_getsrcaddr(src_addr, port, &hints);
+	if (ret) {
+		fprintf(stderr, "source address error %s\n", gai_strerror(ret));
+		return ret;
 	}
 
 	if (dst_addr) {

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -513,19 +513,10 @@ static int run(void)
 int main(int argc, char **argv)
 {
 	int op, ret;
+	opts = INIT_OPTS;
 
-	/* default options for test */
-	opts.iterations = 1000;
-	opts.transfer_size = 1024;
-	opts.port = "9228";
-	opts.argc = argc;
-	opts.argv = argv;
-
-	while ((op = getopt(argc, argv, "vhg:" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'v':
-			ft_version(argv[0]);
-			return EXIT_SUCCESS;
 		default:
 			ft_parseinfo(op, optarg, &hints);
 			ft_parsecsopts(op, optarg, &opts);
@@ -540,13 +531,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	if (opts.src_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
 
-		if (ret) {
-			FI_DEBUG("source address error %s\n", gai_strerror(ret));
-			return EXIT_FAILURE;
-		}
+	if (ret) {
+		FI_DEBUG("source address error %s\n", gai_strerror(ret));
+		return EXIT_FAILURE;
 	}
 
 	hints.ep_type = FI_EP_DGRAM;


### PR DESCRIPTION
Move src==NULL check into ft_getsrcaddr.
Remove print version option from tests, add to fi_info.
Update fi_info with latest values from fabric.h
Init options with struct initializer.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>