### PR TITLE
Fix gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,28 +21,5 @@ fabtests.spec
 
 ported/libibverbs/fi_rc_pingpong
 
-simple/fi_dgram
-simple/fi_imm_data
-simple/fi_info
-simple/fi_msg
-simple/fi_msg_pingpong
-simple/fi_msg_rma
-simple/fi_pingpong
-simple/fi_poll
-simple/fi_rdm
-simple/fi_rdm_atomic
-simple/fi_rdm_cntr_pingpong
-simple/fi_rdm_inject_pingpong
-simple/fi_rdm_multi_recv
-simple/fi_rdm_pingpong
-simple/fi_rdm_rma
-simple/fi_rdm_tagged_pingpong
-simple/fi_rdm_tagged_search
-simple/fi_read_bw
-simple/fi_read_lat
-simple/fi_ud_pingpong
-simple/fi_write_bw
-simple/fi_write_lat
-
-unit/fi_av_test
-unit/fi_eq_test
+simple/fi*
+unit/fi*


### PR DESCRIPTION
Change gitignore to ignore all files under simple/ and unit/ that start with
the prefix "fi".

Master on fabtests currently has a couple of tests that were added, but 
the gitignore was not modified. If all of the binaries generated are going to
start with the prefix fi*, then use it as the ignore condition.

Signed-off-by: Ben Turrubiates <bturrubiates@lanl.gov>