### PR TITLE
fi_ud_pingpong: fix bad fi_av_insert call

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -89,8 +89,8 @@ const unsigned int test_cnt;
 #define TEST_CNT test_cnt
 #define FI_STR_LEN 32
 
-int getaddr(char *node, char *service, struct sockaddr **addr, socklen_t *len);
 int ft_getsrcaddr(char *node, char *service, struct fi_info *hints);
+int ft_getdestaddr(char *node, char *service, struct fi_info *hints);
 char *size_str(char str[FI_STR_LEN], long long size);
 char *cnt_str(char str[FI_STR_LEN], long long cnt);
 int size_to_count(int size);

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -381,11 +381,11 @@ static int client_connect(void)
 	if (ret != 0)
 		goto err;
 
-	ret = ft_getsrcaddr(opts.dst_addr, opts.port, &hints);
+	ret = ft_getdestaddr(opts.dst_addr, opts.port, &hints);
 	if (ret != 0)
 		goto err;
 
-	ret = fi_av_insert(av, &hints.src_addr, 1, &rem_addr, 0, NULL);
+	ret = fi_av_insert(av, hints.dest_addr, 1, &rem_addr, 0, NULL);
 	if (ret != 1) {
 		printf("fi_av_insert() %s\n", fi_strerror(-ret));
 		goto err;


### PR DESCRIPTION
"&hints.src_addr" was being passed when "hints.src_addr" should have
been passed instead (no "&").

Also clean up the usage of ft_getsrcaddr for destination addresses by
adding an equivalent ft_getdestaddr routine and switching to use the
dest_addr field.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

This has been broken since the overhaul to use more of the fabtests common code.

@pmmccorm please review