### PR TITLE
simple: Add source and destination port options + cleanup

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -283,7 +283,8 @@ void ft_csusage(char *name, char *desc)
 
 	fprintf(stderr, "\nOptions:\n");
 	fprintf(stderr, "  -n <domain>\tdomain name\n");
-	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -b <src_port>\tnon default source port number\n");
+	fprintf(stderr, "  -p <dst_port>\tnon default destination port number\n");
 	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP,verbs\n");
 	fprintf(stderr, "  -s <address>\tsource address\n");
 	fprintf(stderr, "  -I <number>\tnumber of iterations\n");
@@ -334,8 +335,11 @@ void ft_parsecsopts(int op, char *optarg, struct cs_opts *opts)
 	case 's':
 		opts->src_addr = optarg;
 		break;
+	case 'b':
+		opts->src_port = optarg;
+		break;
 	case 'p':
-		opts->port = optarg;
+		opts->dst_port = optarg;
 		break;
 	case 'I':
 		opts->custom = 1;

--- a/include/shared.h
+++ b/include/shared.h
@@ -64,7 +64,8 @@ struct cs_opts {
 	int custom;
 	int iterations;
 	int transfer_size;
-	char *port;
+	char *src_port;
+	char *dst_port;
 	char *src_addr;
 	char *dst_addr;
 	int size_option;
@@ -77,11 +78,12 @@ void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
 void ft_parsecsopts(int op, char *optarg, struct cs_opts *opts);
 void ft_csusage(char *name, char *desc);
 #define INFO_OPTS "n:f:"
-#define CS_OPTS "p:I:S:s:mi"
+#define CS_OPTS "b:p:I:S:s:mi"
 
 #define INIT_OPTS (struct cs_opts) { .iterations = 1000, \
 				     .transfer_size = 1024, \
-				     .port = "9228", \
+				     .src_port = "9228", \
+				     .dst_port = "9228", \
 				     .argc = argc, .argv = argv }
 
 extern struct test_size_param test_size[];

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -50,7 +50,7 @@ static int rx_depth = 512;
 
 static struct fi_info hints;
 static char *dst_addr, *src_addr;
-static char *port = "5300";
+static char *dst_port = "5300", *src_port = "5300";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -78,7 +78,8 @@ void print_usage(char *name, char *desc)
 
 	fprintf(stderr, "\nOptions:\n");
 	fprintf(stderr, "  -n <domain>\tdomain name\n");
-	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -b <src_port>\tnon default source port number\n");
+	fprintf(stderr, "  -p <dst_port>\tnon default destination port number\n");
 	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
 	fprintf(stderr, "  -s <address>\tsource address\n");
 	fprintf(stderr, "  -h\t\tdisplay this help output\n");
@@ -240,17 +241,22 @@ static int init_fabric(void)
 {
 	struct fi_info *fi;
 	uint64_t flags = 0;
-	char *node;
+	char *node, *service;
 	int ret;
 
 	if (dst_addr) {
+		ret = ft_getsrcaddr(src_addr, src_port, &hints);
+		if (ret)
+			return ret;
 		node = dst_addr;
+		service = dst_port;
 	} else {
 		node = src_addr;
+		service = src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -439,10 +445,13 @@ int main(int argc, char **argv)
 {
 	int op, ret = 0;
 
-	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "b:p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
+		case 'b':
+			src_port = optarg;
+			break;
 		case 'p':
-			port = optarg;
+			dst_port = optarg;
 			break;
 		case 's':
 			src_addr = optarg;
@@ -460,10 +469,6 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		dst_addr = argv[optind];
 	
-	ret = ft_getsrcaddr(src_addr, port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
-
 	hints.ep_type = FI_EP_DGRAM;
 	hints.caps = FI_MSG;
 	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;

--- a/simple/imm_data.c
+++ b/simple/imm_data.c
@@ -48,7 +48,7 @@ static size_t cq_data_size;
 
 static struct fi_info hints;
 static char *dst_addr, *src_addr;
-static char *port = "9228";
+static char *dst_port = "9228", *src_port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_pep *pep;
@@ -68,7 +68,8 @@ void print_usage(char *name, char *desc)
 	
 	fprintf(stderr, "\nOptions:\n");
 	fprintf(stderr, "  -n <domain>\tdomain name\n");
-	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -b <src_port>\tnon default source port number\n");
+	fprintf(stderr, "  -p <dst_port>\tnon default destination port number\n");
 	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
 	fprintf(stderr, "  -s <address>\tsource address\n");
 	fprintf(stderr, "  -h\t\tdisplay this help output\n");
@@ -195,7 +196,7 @@ static int server_listen(void)
 	struct fi_info *fi;
 	int ret;
 
-	ret = fi_getinfo(FT_FIVERSION, src_addr, port, FI_SOURCE, &hints,
+	ret = fi_getinfo(FT_FIVERSION, src_addr, src_port, FI_SOURCE, &hints,
 			&fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
@@ -326,11 +327,11 @@ static int client_connect(void)
 	ssize_t rd;
 	int ret;
 
-	ret = ft_getsrcaddr(src_addr, port, &hints);
+	ret = ft_getsrcaddr(src_addr, src_port, &hints);
 	if (ret)
 		return ret;
 
-	ret = fi_getinfo(FT_FIVERSION, dst_addr, port, 0, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, dst_addr, dst_port, 0, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		goto err0;
@@ -491,10 +492,13 @@ static int run(void)
 int main(int argc, char **argv)
 {
 	int op;
-	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "b:p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
+		case 'b':
+			src_port = optarg;
+			break;
 		case 'p':
-			port = optarg;
+			dst_port = optarg;
 			break;
 		case 's':
 			src_addr = optarg;

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -277,7 +277,8 @@ static int server_listen(void)
 	struct fi_info *fi;
 	int ret;
 
-	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.port, FI_SOURCE, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.src_port, FI_SOURCE,
+			&hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -408,7 +409,11 @@ static int client_connect(void)
 	ssize_t rd;
 	int ret;
 
-	ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, opts.port, 0, &hints, &fi);
+	ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+	if (ret)
+		return ret;
+
+	ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, opts.dst_port, 0, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		goto err0;
@@ -536,7 +541,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
@@ -554,10 +559,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
 
 	hints.ep_type = FI_EP_MSG;
 	hints.caps = FI_MSG;

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -310,7 +310,7 @@ static int server_listen(void)
 	struct fi_info *fi;
 	int ret;
 
-	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.port, FI_SOURCE, 
+	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.src_port, FI_SOURCE,
 			&hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
@@ -441,7 +441,11 @@ static int client_connect(void)
 	ssize_t rd;
 	int ret;
 
-	ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, opts.port, 0, &hints, &fi);
+	ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+	if (ret)
+		return ret;
+
+	ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, opts.dst_port, 0, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		goto err0;
@@ -611,10 +615,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
 
 	hints.ep_type = FI_EP_MSG;
 	hints.caps = FI_MSG | FI_RMA;

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -489,18 +489,23 @@ static int bind_ep_res(void)
 static int init_fabric(void)
 {
 	struct fi_info *fi;
-	char *node;
 	uint64_t flags = 0;
+	char *node, *service;
 	int ret;
 
 	if (opts.dst_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		if (ret)
+			return ret;
 		node = opts.dst_addr;
+		service = opts.dst_port;
 	} else {
 		node = opts.src_addr;
+		service = opts.src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -712,7 +717,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS)) != -1) {
@@ -744,10 +749,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
 
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_ATOMICS | FI_BUFFERED_RECV;

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -315,18 +315,23 @@ static int bind_ep_res(void)
 static int init_fabric(void)
 {
 	struct fi_info *fi;
-	char *node;
 	uint64_t flags = 0;
+	char *node, *service;
 	int ret;
 
 	if (opts.dst_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		if (ret)
+			return ret;
 		node = opts.dst_addr;
+		service = opts.dst_port;
 	} else {
 		node = opts.src_addr;
+		service = opts.src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -496,29 +501,9 @@ out:
 	return ret;
 }
 
-void print_usage(char *name)
-{
-	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "  %s [OPTIONS]\t\tstart ping server\n", name);
-	fprintf(stderr, "  %s [OPTIONS] <host>\tpong given host\n", name);
-
-	fprintf(stderr, "\nOptions:\n");
-	fprintf(stderr, "  -n\tdomain name\n");
-	fprintf(stderr, "  -p\tport number\n");
-	fprintf(stderr, "  -s\tsource address\n");
-	fprintf(stderr, "  -I\tnumber of iterations\n");
-	fprintf(stderr, "  -S\tspecific transfer size or 'all'\n");
-	fprintf(stderr, "  -m\tmachine readable output\n");
-	fprintf(stderr, "  -i\tprint hints structure and exit\n");
-	fprintf(stderr, "  -v\tdisplay versions and exit\n");
-	fprintf(stderr, "  -h\tdisplay this help output\n");
-
-	return;
-}
-
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
@@ -536,10 +521,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
 
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG;

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -285,18 +285,23 @@ static int bind_ep_res(void)
 static int init_fabric(void)
 {
 	struct fi_info *fi;
-	char *node;
 	uint64_t flags = 0;
+	char *node, *service;
 	int ret;
 
 	if (opts.dst_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		if (ret)
+			return ret;
 		node = opts.dst_addr;
+		service = opts.dst_port;
 	} else {
 		node = opts.src_addr;
+		service = opts.src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -471,7 +476,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
@@ -489,10 +494,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
 
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_INJECT;

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -402,12 +402,23 @@ static int bind_ep_res(void)
 static int init_fabric(void)
 {
 	struct fi_info *fi;
-	char *node;
+	uint64_t flags = 0;
+	char *node, *service;
 	int ret;
 
-	node = opts.dst_addr ? opts.dst_addr : opts.src_addr;
+	if (opts.dst_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		if (ret)
+			return ret;
+		node = opts.dst_addr;
+		service = opts.dst_port;
+	} else {
+		node = opts.src_addr;
+		service = opts.src_port;
+		flags = FI_SOURCE;
+	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, opts.port, 0, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -573,7 +584,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
@@ -591,10 +602,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
 
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_MULTI_RECV | FI_BUFFERED_RECV;

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -302,18 +302,23 @@ static int bind_ep_res(void)
 static int init_fabric(void)
 {
 	struct fi_info *fi;
-	char *node;
 	uint64_t flags = 0;
+	char *node, *service;
 	int ret;
 
 	if (opts.dst_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		if (ret)
+			return ret;
 		node = opts.dst_addr;
+		service = opts.dst_port;
 	} else {
 		node = opts.src_addr;
+		service = opts.src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -490,7 +495,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
@@ -508,10 +513,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
 
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG;

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -272,18 +272,23 @@ static int bind_ep_res(void)
 static int init_fabric(void)
 {
 	struct fi_info *fi;
-	char *node;
 	uint64_t flags = 0;
+	char *node, *service;
 	int ret;
 
 	if (opts.dst_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		if (ret)
+			return ret;
 		node = opts.dst_addr;
+		service = opts.dst_port;
 	} else {
 		node = opts.src_addr;
+		service = opts.src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -471,7 +476,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS)) != -1) {
@@ -502,10 +507,6 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 	
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
-
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_RMA;
 	hints.mode = FI_CONTEXT | FI_PROV_MR_ATTR;

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -53,7 +53,7 @@ static size_t transfer_size = 1000;
 static int rx_depth = 512;
 
 static char *dst_addr = NULL;
-static char *port = "9228";
+static char *src_port = "9228", *dst_port = "9228";
 static struct fi_info hints;
 static char *dst_addr, *src_addr;
 
@@ -301,18 +301,23 @@ static int run_test()
 static int init_fabric(void)
 {
 	struct fi_info *fi;
-	char *node;
 	uint64_t flags = 0;
+	char *node, *service;
 	int i, ret;
 
 	if (dst_addr) {
+		ret = ft_getsrcaddr(src_addr, src_port, &hints);
+		if (ret)
+			return ret;
 		node = dst_addr;
+		service = dst_port;
 	} else {
 		node = src_addr;
+		service = src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -513,7 +518,8 @@ void print_usage(char *name, char *desc)
 
 	fprintf(stderr, "\nOptions:\n");
 	fprintf(stderr, "  -n <domain>\tdomain name\n");
-	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -b <src_port>\tnon default source port number\n");
+	fprintf(stderr, "  -p <dst_port>\tnon default destination port number\n");
 	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
 	fprintf(stderr, "  -s <address>\tsource address\n");
 	fprintf(stderr, "  -h\t\tdisplay this help output\n");
@@ -523,12 +529,15 @@ void print_usage(char *name, char *desc)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 
-	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "b:p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
+		case 'b':
+			src_port = optarg;
+			break;
 		case 'p':
-			port = optarg;
+			dst_port = optarg;
 			break;
 		case 's':
 			src_addr = optarg;
@@ -546,10 +555,6 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		dst_addr = argv[optind];
 	
-	ret = ft_getsrcaddr(src_addr, port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
-
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_NAMED_RX_CTX;
 	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -331,18 +331,23 @@ static int bind_ep_res(void)
 static int init_fabric(void)
 {
 	struct fi_info *fi;
-	char *node;
 	uint64_t flags = 0;
+	char *node, *service;
 	int ret;
 
 	if (opts.dst_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		if (ret)
+			return ret;
 		node = opts.dst_addr;
+		service = opts.dst_port;
 	} else {
 		node = opts.src_addr;
+		service = opts.src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -515,7 +520,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
@@ -533,10 +538,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
 
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_TAGGED;

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -49,7 +49,7 @@ static int rx_depth = 512;
 
 static struct fi_info hints;
 static char *dst_addr, *src_addr;
-static char *port = "9228";
+static char *src_port = "9228", *dst_port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -80,7 +80,8 @@ void print_usage(char *name, char *desc)
 
 	fprintf(stderr, "\nOptions:\n");
 	fprintf(stderr, "  -n <domain>\tdomain name\n");
-	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -b <src_port>\tnon default source port number\n");
+	fprintf(stderr, "  -p <dst_port>\tnon default destination port number\n");
 	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
 	fprintf(stderr, "  -s <address>\tsource address\n");
 	fprintf(stderr, "  -h\t\tdisplay this help output\n");
@@ -262,18 +263,23 @@ static int bind_ep_res(void)
 static int init_fabric(void)
 {
 	struct fi_info *fi;
-	char *node;
 	uint64_t flags = 0;
+	char *node, *service;
 	int ret;
 
 	if (dst_addr) {
+		ret = ft_getsrcaddr(src_addr, src_port, &hints);
+		if (ret)
+			return ret;
 		node = dst_addr;
+		service = dst_port;
 	} else {
 		node = src_addr;
+		service = src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -508,12 +514,15 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 
-	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "b:p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
+		case 'b':
+			src_port = optarg;
+			break;
 		case 'p':
-			port = optarg;
+			dst_port = optarg;
 			break;
 		case 's':
 			src_addr = optarg;
@@ -531,16 +540,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		dst_addr = argv[optind];
 	
-	ret = ft_getsrcaddr(src_addr, port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
-
 	hints.ep_type = FI_EP_RDM;
 	// FI_BUFFERED_RECV is required for tagged search
 	hints.caps = FI_MSG | FI_TAGGED | FI_BUFFERED_RECV;
 	hints.mode = FI_CONTEXT;
 	hints.addr_format = FI_FORMAT_UNSPEC;
 
-	ret = run();
-	return ret;
+	return run();
 }

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -300,17 +300,22 @@ static int bind_ep_res(void)
 static int common_setup(void)
 {
 	int ret;
-	char *node;
 	uint64_t flags = 0;
+	char *node, *service;
 
 	if (opts.dst_addr) {
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		if (ret)
+			return ret;
 		node = opts.dst_addr;
+		service = opts.dst_port;
 	} else {
 		node = opts.src_addr;
+		service = opts.src_port;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		goto err0;
@@ -378,7 +383,7 @@ static int client_connect(void)
 	if (ret != 0)
 		goto err;
 
-	ret = ft_getdestaddr(opts.dst_addr, opts.port, &hints);
+	ret = ft_getdestaddr(opts.dst_addr, opts.dst_port, &hints);
 	if (ret != 0)
 		goto err;
 
@@ -509,7 +514,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
@@ -527,10 +532,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
-	if (ret)
-		return EXIT_FAILURE;
 
 	hints.ep_type = FI_EP_DGRAM;
 	hints.caps = FI_MSG;


### PR DESCRIPTION
Add an option for specifying both source and destination ports.
Pass source address info only via hints. Remove redundant code 
that did the same using fi_getinfo parameters.

If these changes are fine I'll update the other examples. I've kept the port in cs_opts so that it doesn't break other examples for now.

This should fix #130 .

@shantonu @jithinjosepkl Let me know if these look good.