### PR TITLE
Re-factored code to add -f and remove -d option

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -98,14 +98,15 @@ void init_test(int size, char *test_name, size_t test_name_len,
 		int *transfer_size, int *iterations);
 int wait_for_completion(struct fid_cq *cq, int num_completions);
 void cq_readerr(struct fid_cq *cq, char *cq_str);
-int64_t get_elapsed(const struct timespec *b, const struct timespec *a, enum precision p);
+int64_t get_elapsed(const struct timespec *b, const struct timespec *a, 
+		enum precision p);
 void show_perf(char *name, int tsize, int iters, struct timespec *start, 
 		struct timespec *end, int xfers_per_iter);
-void show_perf_mr(int tsize, int iters, struct timespec *start,
-		  struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
+void show_perf_mr(int tsize, int iters, struct timespec *start, 
+		struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
 
 #define FI_PRINTERR(call, retv) \
-	do { fprintf(stderr, call "(): %d (%s)\n", retv, fi_strerror(-retv)); } while (0)
+	do { fprintf(stderr, call "(): %d, %d (%s)\n", __LINE__, (int) retv, fi_strerror((int) -retv)); } while (0)
 
 #define FI_DEBUG(fmt, ...) \
 	do { fprintf(stderr, "%s:%d: " fmt, __FILE__, __LINE__, ##__VA_ARGS__); } while (0)

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -107,14 +107,14 @@ static int alloc_ep_res(void)
 	/* Open completion queue for send completions */
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -157,27 +157,27 @@ static int bind_ep_res(void)
 	/* Bind Send CQ with endpoint to collect send completions */
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	/* Bind Recv CQ with endpoint to collect recv completions */
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	
 	/* Bind AV with the endpoint to map addresses */
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	ret = fi_enable(ep);
 	if (ret) {
-			FI_PRINTERR("fi_enable", ret);
-			return ret;
+		FI_PRINTERR("fi_enable", ret);
+		return ret;
 	 }
 
 	return ret;
@@ -286,7 +286,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read: scq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);
@@ -307,7 +307,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read: rcq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -66,12 +66,24 @@ struct fi_context fi_ctx_send;
 struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_av;
 
-static void usage(char *name)
+
+void print_usage(char *name, char *desc)
 {
-	printf("usage: %s\n", name);
-	printf("\t[-d destination_address]\n");
-	printf("\t[-p port_number]\n");
-	exit(1);
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "  %s [OPTIONS]\t\tstart server\n", name);
+	fprintf(stderr, "  %s [OPTIONS] <host>\tconnect to server \t\n", name);
+	
+	if (desc)
+		fprintf(stderr, "\n%s\n", desc);
+
+	fprintf(stderr, "\nOptions:\n");
+	fprintf(stderr, "  -n <domain>\tdomain name\n");
+	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
+	fprintf(stderr, "  -s <address>\tsource address\n");
+	fprintf(stderr, "  -h\t\tdisplay this help output\n");
+	
+	return;
 }
 
 static void free_ep_res(void)
@@ -231,10 +243,6 @@ static int init_fabric(void)
 	char *node;
 	int ret;
 
-	ret = ft_getsrcaddr(src_addr, NULL, &hints);
-	if (ret)
-		return ret;
-
 	if (dst_addr) {
 		node = dst_addr;
 	} else {
@@ -242,7 +250,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -402,7 +410,7 @@ static int send_recv()
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FI_PRINTERR("fi_cq_read: scq", ret);
 			}
 			
 			return ret;
@@ -417,7 +425,7 @@ static int send_recv()
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FI_PRINTERR("fi_cq_read: rcq", ret);
 			}
 
 			return ret;
@@ -429,15 +437,10 @@ static int send_recv()
 
 int main(int argc, char **argv)
 {
-	struct fi_domain_attr domain_hints;
-	struct fi_ep_attr ep_hints;
 	int op, ret = 0;
 
-	while ((op = getopt(argc, argv, "d:p:s:")) != -1) {
+	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'd':
-			dst_addr = optarg;
-			break;
 		case 'p':
 			port = optarg;
 			break;
@@ -445,15 +448,22 @@ int main(int argc, char **argv)
 			src_addr = optarg;
 			break;
 		default:
-			usage(argv[0]);
+			ft_parseinfo(op, optarg, &hints);
+			break;
+		case '?':
+		case 'h':
+			print_usage(argv[0], "A DGRAM client-server example that uses waitset.\n");
+			return EXIT_FAILURE;
 		}
 	}
 
-	memset(&domain_hints, 0, sizeof(domain_hints));
-	memset(&ep_hints, 0, sizeof(ep_hints));
+	if (optind < argc)
+		dst_addr = argv[optind];
+	
+	ret = ft_getsrcaddr(src_addr, port, &hints);
+	if (ret)
+		return EXIT_FAILURE;
 
-	hints.domain_attr = &domain_hints;
-	hints.ep_attr = &ep_hints;
 	hints.ep_type = FI_EP_DGRAM;
 	hints.caps = FI_MSG;
 	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -128,14 +128,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	/* Open completion queue for send completions */
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	/* Open completion queue for recv completions */
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
 	
@@ -180,19 +180,19 @@ static int bind_ep_res(void)
 	/* Bind AV and CQs with endpoint */
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -410,7 +410,7 @@ static int send_recv()
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read: scq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 			
 			return ret;
@@ -425,7 +425,7 @@ static int send_recv()
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read: rcq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 
 			return ret;

--- a/simple/imm_data.c
+++ b/simple/imm_data.c
@@ -47,8 +47,6 @@ static int rx_depth = 500;
 static size_t cq_data_size;
 
 static struct fi_info hints;
-static struct fi_domain_attr domain_hints;
-static struct fi_ep_attr ep_hints;
 static char *dst_addr, *src_addr;
 static char *port = "9228";
 
@@ -59,6 +57,24 @@ static struct fid_ep *ep;
 static struct fid_eq *cmeq;
 static struct fid_cq *rcq, *scq;
 static struct fid_mr *mr;
+
+void print_usage(char *name, char *desc)
+{
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "  %s [OPTIONS]\t\tstart server\n", name);
+	fprintf(stderr, "  %s [OPTIONS] <host>\tconnect to server \t\n", name);
+	if (desc)
+		fprintf(stderr, "\n%s\n", desc);
+	
+	fprintf(stderr, "\nOptions:\n");
+	fprintf(stderr, "  -n <domain>\tdomain name\n");
+	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
+	fprintf(stderr, "  -s <address>\tsource address\n");
+	fprintf(stderr, "  -h\t\tdisplay this help output\n");
+
+	return;
+}
 
 static void free_lres(void)
 {
@@ -74,7 +90,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		printf("fi_eq_open() cm %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_eq_open: cm", ret);
 
 	return ret;
 }
@@ -105,20 +121,20 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		printf("fi_cq_open() send comp %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_cq_open: recv completion", ret);
 		goto err1;
 	}
 
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		printf("fi_cq_open() recv comp %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_cq_open: send completion", ret);
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		printf("fi_mr_reg() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -133,9 +149,9 @@ static int alloc_ep_res(struct fi_info *fi)
 err4:
 	fi_close(&mr->fid);
 err3:
-	fi_close(&rcq->fid);
-err2:
 	fi_close(&scq->fid);
+err2:
+	fi_close(&rcq->fid);
 err1:
 	free(buf);
 	return ret;
@@ -147,19 +163,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_ep_bind: cmeq", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_ep_bind: scq", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_ep_bind: rcq", ret);
 		return ret;
 	}
 
@@ -169,7 +185,7 @@ static int bind_ep_res(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -179,10 +195,10 @@ static int server_listen(void)
 	struct fi_info *fi;
 	int ret;
 
-	ret = fi_getinfo(FI_VERSION(1, 0), src_addr, port, FI_SOURCE, &hints,
+	ret = fi_getinfo(FT_FIVERSION, src_addr, port, FI_SOURCE, &hints,
 			&fi);
 	if (ret) {
-		printf("fi_getinfo() %s\n", strerror(-ret));
+		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -190,13 +206,13 @@ static int server_listen(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		printf("fi_fabric() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_passive_ep(fab, fi, &pep, NULL);
 	if (ret) {
-		printf("fi_passive_ep() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_passive_ep", ret);
 		goto err1;
 	}
 
@@ -206,13 +222,13 @@ static int server_listen(void)
 
 	ret = fi_pep_bind(pep, &cmeq->fid, 0);
 	if (ret) {
-		printf("fi_pep_bind() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_pep_bind", ret);
 		goto err3;
 	}
 
 	ret = fi_listen(pep);
 	if (ret) {
-		printf("fi_listen() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_listen", ret);
 		goto err3;
 	}
 
@@ -239,12 +255,12 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		printf("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
 	if (event != FI_CONNREQ) {
-		printf("Unexpected CM event %d\n", event);
+		FI_DEBUG("Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err1;
 	}
@@ -252,13 +268,13 @@ static int server_connect(void)
 	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
-		printf("fi_domain() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
-		printf("fi_endpoint() for req %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_endpoint", ret);
 		goto err1;
 	}
 
@@ -272,18 +288,18 @@ static int server_connect(void)
 
 	ret = fi_accept(ep, NULL, 0);
 	if (ret) {
-		printf("fi_accept() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_accept", ret);
 		goto err3;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		printf("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		goto err3;
 	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
-		printf("Unexpected CM event %d fid %p (ep %p)\n",
+		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
 			event, entry.fid, ep);
 		ret = -FI_EOTHER;
 		goto err3;
@@ -310,13 +326,13 @@ static int client_connect(void)
 	ssize_t rd;
 	int ret;
 
-	ret = ft_getsrcaddr(src_addr, NULL, &hints);
+	ret = ft_getsrcaddr(src_addr, port, &hints);
 	if (ret)
 		return ret;
 
-	ret = fi_getinfo(FI_VERSION(1, 0), dst_addr, port, 0, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, dst_addr, port, 0, &hints, &fi);
 	if (ret) {
-		printf("fi_getinfo() %s\n", strerror(-ret));
+		FI_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
 
@@ -324,20 +340,19 @@ static int client_connect(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		printf("fi_fabric() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		printf("fi_domain() %s %s\n", fi_strerror(-ret),
-			fi->domain_attr->name);
+		FI_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		printf("fi_endpoint() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_endpoint", ret);
 		goto err3;
 	}
 
@@ -351,18 +366,18 @@ static int client_connect(void)
 
 	ret = fi_connect(ep, fi->dest_addr, NULL, 0);
 	if (ret) {
-		printf("fi_connect() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_connect", ret);
 		goto err5;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		printf("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
-		printf("Unexpected CM event %d fid %p (ep %p)\n",
+		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
 			event, entry.fid, ep);
 		ret = -FI_EOTHER;
 		goto err5;
@@ -476,15 +491,8 @@ static int run(void)
 int main(int argc, char **argv)
 {
 	int op;
-
-	while ((op = getopt(argc, argv, "d:n:p:s:")) != -1) {
+	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'd':
-			dst_addr = optarg;
-			break;
-		case 'n':
-			domain_hints.name = optarg;
-			break;
 		case 'p':
 			port = optarg;
 			break;
@@ -492,17 +500,18 @@ int main(int argc, char **argv)
 			src_addr = optarg;
 			break;
 		default:
-			printf("usage: %s\n", argv[0]);
-			printf("\t[-d destination_address]\n");
-			printf("\t[-n domain_name]\n");
-			printf("\t[-p port_number]\n");
-			printf("\t[-s source_address]\n");
-			exit(1);
+			ft_parseinfo(op, optarg, &hints);
+			break;
+		case '?':
+		case 'h':
+			print_usage(argv[0], "A client-server example that tranfers immediate data.\n");
+			return EXIT_FAILURE;
 		}
 	}
+	
+	if (optind < argc)
+		dst_addr = argv[optind];
 
-	hints.domain_attr = &domain_hints;
-	hints.ep_attr = &ep_hints;
 	hints.ep_type = FI_EP_MSG;
 	hints.caps = FI_MSG | FI_REMOTE_CQ_DATA;
 	hints.mode = FI_LOCAL_MR | FI_PROV_MR_ATTR;

--- a/simple/imm_data.c
+++ b/simple/imm_data.c
@@ -90,7 +90,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		FI_PRINTERR("fi_eq_open: cm", ret);
+		FI_PRINTERR("fi_eq_open", ret);
 
 	return ret;
 }
@@ -121,14 +121,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: recv completion", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: send completion", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -163,19 +163,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: cmeq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -440,7 +440,7 @@ static int run_test()
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read: rcq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}

--- a/simple/info.c
+++ b/simple/info.c
@@ -32,6 +32,7 @@
 #include <getopt.h>
 
 #include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
 
 #include "shared.h"
 
@@ -166,7 +167,7 @@ static int run(struct fi_info *hints, char *node, char *port)
 
 	ret = fi_getinfo(FT_FIVERSION, node, port, 0, hints, &info);
 	if (ret) {
-		printf("fi_getinfo() %s\n", strerror(-ret));
+		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -212,7 +213,7 @@ int main(int argc, char **argv)
 			return EXIT_SUCCESS;
 		case 'h':
 		default:
-			printf("usage: %s\n", argv[0]);
+			printf("Usage: %s\n", argv[0]);
 			usage();
 			return EXIT_FAILURE;
 		}

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -84,7 +84,7 @@ static int alloc_cm_res(void)
 	/* Open EQ to receive CM events */
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		FI_PRINTERR("fi_eq_open: cmeq", ret);
+		FI_PRINTERR("fi_eq_open", ret);
 
 	return ret;
 }
@@ -116,14 +116,14 @@ static int alloc_ep_res(void)
 	/* Open completion queue for send completions */
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -152,21 +152,21 @@ static int bind_ep_res(void)
 	/* Bind EQ with endpoint */
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: cmeq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	/* Bind Send CQ with endpoint to collect send completions */
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	/* Bind Recv CQ with endpoint to collect recv completions */
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -207,7 +207,7 @@ static int server_listen(void)
 	/* Bind EQ to passive endpoint */
 	ret = fi_pep_bind(pep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_pep_bind: cmeq", ret);
+		FI_PRINTERR("fi_pep_bind", ret);
 		goto err3;
 	}
 
@@ -420,7 +420,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read: scq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);
@@ -440,7 +440,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read: rcq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -408,7 +408,7 @@ static int client_connect(void)
 	ssize_t rd;
 	int ret;
 
-	ret = fi_getinfo(FI_VERSION(1,0), opts.dst_addr, opts.port, 0, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, opts.port, 0, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		goto err0;

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -73,7 +73,7 @@ static int send_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read: scq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -99,7 +99,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read: rcq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -204,7 +204,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		FI_PRINTERR("fi_eq_open: cm", ret);
+		FI_PRINTERR("fi_eq_open", ret);
 
 	return ret;
 }
@@ -236,13 +236,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
@@ -278,13 +278,13 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: cmeq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -73,7 +73,7 @@ static int send_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				printf("Completion queue read %d (%s)\n", ret, fi_strerror(-ret));
+				FI_PRINTERR("fi_cq_read: scq", ret);
 			}
 			return ret;
 		}
@@ -83,7 +83,7 @@ static int send_xfer(int size)
 post:
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), 0, NULL);
 	if (ret)
-		printf("fi_send() %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_send", ret);
 
 	return ret;
 }
@@ -99,7 +99,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				printf("Completion queue read %d (%s)\n", ret, fi_strerror(-ret));
+				FI_PRINTERR("fi_cq_read: rcq", ret);
 			}
 			return ret;
 		}
@@ -107,7 +107,7 @@ static int recv_xfer(int size)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -119,7 +119,7 @@ static int read_data(size_t size)
 	ret = fi_read(ep, buf, size, fi_mr_desc(mr), 
 		      0, remote.addr, remote.key, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_read() %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_read", ret);
 		return ret;
 	}
 
@@ -133,7 +133,7 @@ static int write_data(size_t size)
 	ret = fi_write(ep, buf, size, fi_mr_desc(mr),  
 		       0, remote.addr, remote.key, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_write() %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_write", ret);
 		return ret;
 	}
 	return 0;
@@ -181,9 +181,11 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	if (opts.machr)
-		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 1, opts.argc, opts.argv);
+		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 
+				1, opts.argc, opts.argv);
 	else
-		show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 1);
+		show_perf(test_name, opts.transfer_size, opts.iterations, 
+				&start, &end, 1);
 
 	return 0;
 }
@@ -202,7 +204,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		fprintf(stderr, "fi_eq_open() cm %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_eq_open: cm", ret);
 
 	return ret;
 }
@@ -220,7 +222,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_cq_attr cq_attr;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
+	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : 
+		opts.transfer_size;
 	buf = malloc(MAX(buffer_size, sizeof(uint64_t)));
 	if (!buf) {
 		perror("malloc");
@@ -233,20 +236,20 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_cq_open() send comp %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_cq_open: scq", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_cq_open() recv comp %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_cq_open: rcq", ret);
 		goto err2;
 	}
 	
 	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)), 
 			op_type, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_mr_reg() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -275,19 +278,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_ep_bind: cmeq", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_ep_bind: scq", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		printf("fi_ep_bind() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -297,7 +300,7 @@ static int bind_ep_res(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -307,21 +310,22 @@ static int server_listen(void)
 	struct fi_info *fi;
 	int ret;
 
-	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.port, FI_SOURCE, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.port, FI_SOURCE, 
+			&hints, &fi);
 	if (ret) {
-		fprintf(stderr, "fi_getinfo() %s\n", strerror(-ret));
+		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_fabric() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_passive_ep(fab, fi, &pep, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_passive_ep() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_passive_ep", ret);
 		goto err1;
 	}
 
@@ -331,13 +335,13 @@ static int server_listen(void)
 
 	ret = fi_pep_bind(pep, &cmeq->fid, 0);
 	if (ret) {
-		printf("fi_pep_bind() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_pep_bind", ret);
 		goto err3;
 	}
 
 	ret = fi_listen(pep);
 	if (ret) {
-		fprintf(stderr, "fi_listen() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_listen", ret);
 		goto err3;
 	}
 
@@ -364,12 +368,12 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		fprintf(stderr, "fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
 	if (event != FI_CONNREQ) {
-		fprintf(stderr, "Unexpected CM event %d\n", event);
+		FI_DEBUG("Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err1;
 	}
@@ -377,14 +381,14 @@ static int server_connect(void)
 	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_domain() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_endpoint() for req %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_endpoint", -ret);
 		goto err1;
 	}
 
@@ -398,18 +402,18 @@ static int server_connect(void)
 
 	ret = fi_accept(ep, NULL, 0);
 	if (ret) {
-		fprintf(stderr, "fi_accept() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_accept", ret);
 		goto err3;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
  	if (rd != sizeof entry) {
-		fprintf(stderr, "fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		goto err3;
  	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
- 		fprintf(stderr, "Unexpected CM event %d fid %p (ep %p)\n",
+ 		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
 			event, entry.fid, ep);
  		ret = -FI_EOTHER;
  		goto err3;
@@ -439,26 +443,25 @@ static int client_connect(void)
 
 	ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, opts.port, 0, &hints, &fi);
 	if (ret) {
-		fprintf(stderr, "fi_getinfo() %s\n", strerror(-ret));
+		FI_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_fabric() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
  	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_domain() %s %s\n", fi_strerror(-ret),
-			fi->domain_attr->name);
+		FI_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		fprintf(stderr, "fi_endpoint() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_endpoint", ret);
 		goto err3;
 	}
 
@@ -472,18 +475,18 @@ static int client_connect(void)
 
 	ret = fi_connect(ep, fi->dest_addr, NULL, 0);
 	if (ret) {
-		fprintf(stderr, "fi_connect() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_connect", ret);
 		goto err5;
 	}
 
  	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		fprintf(stderr, "fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
  	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
- 		fprintf(stderr, "Unexpected CM event %d fid %p (ep %p)\n",
+ 		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
  			event, entry.fid, ep);
  		ret = -FI_EOTHER;
  		goto err1;
@@ -581,7 +584,6 @@ int main(int argc, char **argv)
 	int op, ret;
 	opts = INIT_OPTS;
 
-
 	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		case 'o':
@@ -591,6 +593,7 @@ int main(int argc, char **argv)
 				op_type = FI_REMOTE_WRITE;
 			else {
 				ft_csusage(argv[0], NULL);
+				fprintf(stderr, "  -o <op>\tselect operation type (read or write)\n");
 				return EXIT_FAILURE;
 			}
 			break;

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -71,13 +71,23 @@ struct fi_context fi_ctx_send;
 struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_av;
 
-static void usage(char *name)
+void print_usage(char *name, char *desc)
 {
-	printf("usage: %s\n", name);
-	printf("\t[-d destination_address]\n");
-	printf("\t[-n domain_name]\n");
-	printf("\t[-p port_number]\n");
-	exit(1);
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "  %s [OPTIONS]\t\tstart server\n", name);
+	fprintf(stderr, "  %s [OPTIONS] <host>\tconnect to server \t\n", name);
+	
+	if (desc)
+		fprintf(stderr, "\n%s\n", desc);
+
+	fprintf(stderr, "\nOptions:\n");
+	fprintf(stderr, "  -n <domain>\tdomain name\n");
+	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
+	fprintf(stderr, "  -s <address>\tsource address\n");
+	fprintf(stderr, "  -h\t\tdisplay this help output\n");
+	
+	return;
 }
 
 static void free_ep_res(void)
@@ -248,10 +258,6 @@ static int init_fabric(void)
 	char *node;
 	int ret;
 
-	ret = ft_getsrcaddr(src_addr, NULL, &hints);
-	if (ret)
-		return ret;
-
 	if (dst_addr) {
 		node = dst_addr;
 	} else {
@@ -259,7 +265,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -454,18 +460,10 @@ static int send_recv()
 
 int main(int argc, char **argv)
 {
-	struct fi_domain_attr domain_hints;
-	struct fi_ep_attr ep_hints;
 	int op, ret = 0;
-
-	while ((op = getopt(argc, argv, "d:n:p:s:")) != -1) {
+	
+	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'd':
-			dst_addr = optarg;
-			break;
-		case 'n':
-			domain_hints.name = optarg;
-			break;
 		case 'p':
 			port = optarg;
 			break;
@@ -473,15 +471,22 @@ int main(int argc, char **argv)
 			src_addr = optarg;
 			break;
 		default:
-			usage(argv[0]);
+			ft_parseinfo(op, optarg, &hints);
+			break;
+		case '?':
+		case 'h':
+			print_usage(argv[0], "A MSG client-server example that uses poll.\n");
+			return EXIT_FAILURE;
 		}
 	}
 
-	memset(&domain_hints, 0, sizeof(domain_hints));
-	memset(&ep_hints, 0, sizeof(ep_hints));
-
-	hints.domain_attr = &domain_hints;
-	hints.ep_attr = &ep_hints;
+	if (optind < argc)
+		dst_addr = argv[optind];
+	
+	ret = ft_getsrcaddr(src_addr, port, &hints);
+	if (ret)
+		return EXIT_FAILURE;
+	
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG;
 	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -121,14 +121,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	/* Open completion queue for send completions */
 	ret = fi_cq_open(dom, &cq_attr, &scq, (void *)CQ_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
 	ret = fi_cq_open(dom, &cq_attr, &rcq, (void *)CQ_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -143,14 +143,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	/* Add send CQ to the polling set */
 	ret = fi_poll_add(pollset, &scq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_poll_add: scq", ret);
+		FI_PRINTERR("fi_poll_add", ret);
 		goto err3;
 	}
 
 	/* Add recv CQ to the polling set */
 	ret = fi_poll_add(pollset, &rcq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_poll_add: scq", ret);
+		FI_PRINTERR("fi_poll_add", ret);
 		goto err3;
 	}
 
@@ -195,19 +195,19 @@ static int bind_ep_res(void)
 	/* Bind AV and CQs with endpoint */
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -448,7 +448,7 @@ static int send_recv()
 				if (ret == -FI_EAVAIL) {
 					cq_readerr(cq, "cq");
 				} else {
-					FI_PRINTERR("fi_cq_read", ret);
+					FI_PRINTERR("fi_cq_sread", ret);
 				}
 				return ret;
 			}

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -62,11 +62,20 @@ struct fi_context fi_ctx_send;
 struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_av;
 
-static void usage(char *name)
+void print_usage(char *name, char *desc)
 {
-	printf("usage: %s\n", name);
-	printf("\t-d destination address\n");
-	exit(1);
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "  %s [OPTIONS]\t\tstart server\n", name);
+	fprintf(stderr, "  %s [OPTIONS] <host>\tconnect to server\n", name);
+
+	if (desc)
+		fprintf(stderr, "\n%s\n", desc);
+
+	fprintf(stderr, "\nOptions:\n");
+	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
+	fprintf(stderr, "  -h\t\tdisplay this help output\n");
+							
+	return;
 }
 
 static void free_ep_res(void)
@@ -186,7 +195,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	
 	/* Get fabric info */
-	ret = fi_getinfo(FI_VERSION(1, 0), dst_addr, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, dst_addr, port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		goto err0;
@@ -312,24 +321,29 @@ static int send_recv()
 int main(int argc, char **argv)
 {
 	int op, ret;
-	struct fi_domain_attr domain_hints;
-	struct fi_ep_attr ep_hints;
-	
-	memset(&domain_hints, 0, sizeof(struct fi_domain_attr));
-	memset(&ep_hints, 0, sizeof(struct fi_ep_attr));
-
-	while ((op = getopt(argc, argv, "d:")) != -1) {
-		switch (op) {
-		case 'd':
-			dst_addr = optarg;
+	struct fi_fabric_attr *fabric_hints;
+		
+	while ((op = getopt(argc, argv, "f:h")) != -1) {
+		switch (op) {			
+		case 'f':
+			fabric_hints = malloc(sizeof *fabric_hints);
+			if (!fabric_hints) {
+				perror("malloc");
+				exit(EXIT_FAILURE);
+			}
+			fabric_hints->prov_name = optarg;
+			hints.fabric_attr = fabric_hints;
 			break;
-		default:
-			usage(argv[0]);
+		case '?':
+		case 'h':
+			print_usage(argv[0], "A simple RDM client-sever example.");
+			return EXIT_FAILURE;
 		}
 	}
 	
-	hints.domain_attr	= &domain_hints;
-	hints.ep_attr		= &ep_hints;
+	if (optind < argc)
+		dst_addr = argv[optind];
+	
 	hints.ep_type		= FI_EP_RDM;
 	hints.caps		= FI_MSG | FI_BUFFERED_RECV;
 	hints.mode		= FI_CONTEXT;

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -107,14 +107,14 @@ static int alloc_ep_res(void)
 	/* Open completion queue for send completions */
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -157,27 +157,27 @@ static int bind_ep_res(void)
 	/* Bind Send CQ with endpoint to collect send completions */
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	/* Bind Recv CQ with endpoint to collect recv completions */
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	
 	/* Bind AV with the endpoint to map addresses */
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	ret = fi_enable(ep);
 	if (ret) {
-			FI_PRINTERR("fi_enable", ret);
-			return ret;
+		FI_PRINTERR("fi_enable", ret);
+		return ret;
 	 }
 
 	return ret;
@@ -286,7 +286,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read: scq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);
@@ -307,7 +307,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read: rcq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -392,13 +392,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = 128;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
@@ -465,19 +465,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND | FI_READ | FI_WRITE);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", -ret);
+		FI_PRINTERR("fi_ep_bind", -ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", -ret);
+		FI_PRINTERR("fi_ep_bind", -ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -297,8 +297,12 @@ static int run_op(void)
 	
 	if (ret)
 		goto out;
-		
-	show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 2);
+
+	if(op_type == FI_CSWAP)		
+		show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 1);
+	else
+		show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 2);
+
 	ret = 0;
 
 out:

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -74,7 +74,7 @@ static int get_send_completions()
 
 	ret = fi_cntr_wait(scntr, send_count, CNTR_TIMEOUT);
 	if (ret < 0) {
-		FI_PRINTERR("fi_cntr_wait: scntr", ret);
+		FI_PRINTERR("fi_cntr_wait", ret);
 		return ret;
 	}
 
@@ -90,7 +90,7 @@ static int send_xfer(int size)
 	if (!credits) {
 		ret = fi_cntr_wait(scntr, send_count, CNTR_TIMEOUT);
 		if (ret < 0) {
-			FI_PRINTERR("fi_cntr_wait: scntr", ret);
+			FI_PRINTERR("fi_cntr_wait", ret);
 			return ret;
 		}
 	}
@@ -113,7 +113,7 @@ static int recv_xfer(int size)
 
 	ret = fi_cntr_wait(rcntr, recv_outs, CNTR_TIMEOUT);
 	if (ret < 0) {
-		FI_PRINTERR("fi_cntr_wait: rcntr", ret);
+		FI_PRINTERR("fi_cntr_wait", ret);
 		return ret;
 	}
 
@@ -140,7 +140,7 @@ static int send_msg(int size)
 
 	ret = fi_cntr_wait(scntr, send_count, CNTR_TIMEOUT);
 	if (ret < 0) {
-		FI_PRINTERR("fi_cntr_wait: scntr", ret);
+		FI_PRINTERR("fi_cntr_wait", ret);
 	}
 
 	return ret;
@@ -159,7 +159,7 @@ static int recv_msg(void)
 
 	ret = fi_cntr_wait(rcntr, recv_outs, CNTR_TIMEOUT);
 	if (ret < 0) {
-		FI_PRINTERR("fi_cntr_wait: rcntr", ret);
+		FI_PRINTERR("fi_cntr_wait", ret);
 		return ret;
 	}
 
@@ -241,13 +241,13 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_cntr_open(dom, &cntr_attr, &scntr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cntr_open: scntr", ret);
+		FI_PRINTERR("fi_cntr_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cntr_open(dom, &cntr_attr, &rcntr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cntr_open: rcntr", ret);
+		FI_PRINTERR("fi_cntr_open", ret);
 		goto err2;
 	}
 
@@ -287,19 +287,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scntr->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scntr", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcntr->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcntr", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -88,7 +88,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read: rcq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -208,13 +208,13 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -222,7 +222,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	 * fi_inject copies the buffer of data that needs to be sent. */
 	ret = fi_mr_reg(dom, recv_buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
 
@@ -257,19 +257,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -246,7 +246,7 @@ static int run_test(void)
 	
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
-	show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 2);
+	show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 1);
 	ret = 0;
 
 out:

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -292,7 +292,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	
 	ret = fi_mr_reg(dom, send_buf, max_send_buf_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg for send_buf", ret);
+		FI_PRINTERR("fi_mr_reg", ret);
 		goto err1;
 	}
 	
@@ -301,7 +301,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		MULTI_BUF_SIZE_FACTOR;
 	multi_recv_buf = malloc(multi_buf_size);
 	if(!multi_recv_buf) {
-		fprintf(stderr, "Cannot allocate multi_recv_buf\n");
+		FI_DEBUG("Cannot allocate multi_recv_buf\n");
 		ret = -1;
 		goto err1;
 	}
@@ -309,7 +309,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	ret = fi_mr_reg(dom, multi_recv_buf, multi_buf_size, 0, 0, 1, 0, 
 			&mr_multi_recv, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg for multi_recv_buf", ret);
+		FI_PRINTERR("fi_mr_reg", ret);
 		goto err2;
 	}
 
@@ -319,13 +319,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
 	
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err4;
 	}
 
@@ -374,19 +374,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -78,7 +78,7 @@ static int send_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read: scq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -105,7 +105,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read: rcq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -228,13 +228,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -274,19 +274,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -105,7 +105,7 @@ static int read_data(size_t size)
 	ret = fi_read(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 
 		      remote.addr, remote.key, &fi_ctx_read);
 	if (ret){
-		FI_PRINTERR("fi_readfrom", ret);
+		FI_PRINTERR("fi_read", ret);
 		return ret;
 	}
 
@@ -119,7 +119,7 @@ static int write_data(size_t size)
 	ret = fi_write(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 
 		       remote.addr, remote.key, &fi_ctx_write);
 	if (ret){
-		FI_PRINTERR("fi_writeto", ret);
+		FI_PRINTERR("fi_write", ret);
 		return ret;
 	}
 	return 0;
@@ -197,13 +197,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
@@ -244,19 +244,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -161,10 +161,10 @@ static int run_test(void)
 
 	if (opts.machr)
 		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 
-				2, opts.argc, opts.argv);
+				1, opts.argc, opts.argv);
 	else
 		show_perf(test_name, opts.transfer_size, opts.iterations, 
-				&start, &end, 2);
+				&start, &end, 1);
 
 	return 0;
 }

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -41,25 +41,16 @@
 #include <rdma/fi_errno.h>
 #include <shared.h>
 
+static struct cs_opts opts;
 static uint64_t op_type = FI_REMOTE_WRITE;
-static int custom;
-static int size_option;
-static int iterations = 1000;
-static int transfer_size = 1024;
 static int max_credits = 128;
 static char test_name[10] = "custom";
 static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
 struct fi_rma_iov local, remote;
-static int machr, g_argc;
-static char **g_argv;
 
 static struct fi_info hints;
-static struct fi_domain_attr domain_hints;
-static struct fi_ep_attr ep_hints;
-static char *dst_addr, *src_addr;
-static char *port = "9228";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -75,20 +66,6 @@ struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_write;
 struct fi_context fi_ctx_read;
 struct fi_context fi_ctx_av;
-
-void usage(char *name)
-{
-	fprintf(stderr, "usage: %s\n", name);
-	fprintf(stderr, "\t[-d destination_address]\n");
-	fprintf(stderr, "\t[-n domain_name]\n");
-	fprintf(stderr, "\t[-p port_number]\n");
-	fprintf(stderr, "\t[-s source_address]\n");
-	fprintf(stderr, "\t[-I iterations]\n");
-	fprintf(stderr, "\t[-o read|write] (default: write)\n");
-	fprintf(stderr, "\t[-S transfer_size or 'all']\n");
-	fprintf(stderr, "\t[-m machine readable output]\n");
-	exit(1);
-}
 
 static int send_msg(int size)
 {
@@ -152,11 +129,11 @@ static int sync_test(void)
 {
 	int ret;
 
-	ret = dst_addr ? send_msg(16) : recv_msg();
+	ret = opts.dst_addr ? send_msg(16) : recv_msg();
 	if (ret)
 		return ret;
 
-	return dst_addr ? recv_msg() : send_msg(16);
+	return opts.dst_addr ? recv_msg() : send_msg(16);
 }
 
 static int run_test(void)
@@ -168,11 +145,11 @@ static int run_test(void)
 		return ret;
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
-	for (i = 0; i < iterations; i++) {
+	for (i = 0; i < opts.iterations; i++) {
 		if (op_type == FI_REMOTE_WRITE) {
-			ret = write_data(transfer_size);
+			ret = write_data(opts.transfer_size);
 		} else {
-			ret = read_data(transfer_size); 
+			ret = read_data(opts.transfer_size); 
 		}
 		if (ret)
 			return ret;
@@ -182,11 +159,12 @@ static int run_test(void)
 	}
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
-	if (machr)
-		show_perf_mr(transfer_size, iterations, &start, &end, 1, g_argc,
-			       	g_argv);
+	if (opts.machr)
+		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 
+				2, opts.argc, opts.argv);
 	else
-		show_perf(test_name, transfer_size, iterations, &start, &end, 1);
+		show_perf(test_name, opts.transfer_size, opts.iterations, 
+				&start, &end, 2);
 
 	return 0;
 }
@@ -206,7 +184,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !custom ? test_size[TEST_CNT - 1].size : transfer_size;
+	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
 	buf = malloc(MAX(buffer_size, sizeof(uint64_t)));
 	if (!buf) {
 		perror("malloc");
@@ -298,18 +276,14 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int ret;
 
-	ret = ft_getsrcaddr(src_addr, NULL, &hints);
-	if (ret)
-		return ret;
-
-	if (dst_addr) {
-		node = dst_addr;
+	if (opts.dst_addr) {
+		node = opts.dst_addr;
 	} else {
-		node = src_addr;
+		node = opts.src_addr;
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -319,7 +293,7 @@ static int init_fabric(void)
 		fi->mode |= FI_PROV_MR_ATTR;
 
 	/* Get remote address */
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		addrlen = fi->dest_addrlen;
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, fi->dest_addr, addrlen);
@@ -371,7 +345,7 @@ static int init_av(void)
 {
 	int ret;
 
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		/* Get local address blob. Find the addrlen first. We set addrlen 
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
@@ -439,7 +413,7 @@ static int exchange_addr_key(void)
 	local.addr = (uint64_t)buf;
 	local.key = fi_mr_key(mr);
 
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		*(struct fi_rma_iov *)buf = local;
 		send_msg(sizeof local);
 		recv_msg();
@@ -470,13 +444,13 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!custom) {
+	if (!opts.custom) {
 		for (i = 0; i < TEST_CNT; i++) {
-			if (test_size[i].option > size_option)
+			if (test_size[i].option > opts.size_option)
 				continue;
-			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &transfer_size,
-					&iterations);
+			init_test(test_size[i].size, test_name, 
+					sizeof(test_name), &opts.transfer_size, 
+					&opts.iterations);
 			ret = run_test();
 			if(ret)
 				goto out;
@@ -497,58 +471,50 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op;
+	int op, ret;
+	opts = INIT_OPTS;
 
-	while ((op = getopt(argc, argv, "d:n:p:s:I:o:S:m")) != -1) {
+	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'd':
-			dst_addr = optarg;
-			break;
-		case 'n':
-			domain_hints.name = optarg;
-			break;
-		case 'p':
-			port = optarg;
-			break;
-		case 's':
-			src_addr = optarg;
-			break;
-		case 'I':
-			custom = 1;
-			iterations = atoi(optarg);
-			break;
 		case 'o':
 			if (!strcmp(optarg, "read"))
 				op_type = FI_REMOTE_READ;
 			else if (!strcmp(optarg, "write"))
 				op_type = FI_REMOTE_WRITE;
-			else
-				usage(argv[0]);
-			break;
-		case 'S':
-			if (!strncasecmp("all", optarg, 3)) {
-				size_option = 1;
-			} else {
-				custom = 1;
-				transfer_size = atoi(optarg);
-			}
-			break;
-		case 'm':
-			machr = 1;
-			g_argc = argc;
-			g_argv = argv;
+			else {
+				ft_csusage(argv[0], "Ping pong client and server using rma.");
+				fprintf(stderr, "  -o <op>\trma op type: read|write (default: write)]\n");
+				return EXIT_FAILURE;
+			}	
 			break;
 		default:
-			usage(argv[0]);
+			ft_parseinfo(op, optarg, &hints);
+			ft_parsecsopts(op, optarg, &opts);
+			break;
+		case '?':
+		case 'h':
+			ft_csusage(argv[0], "Ping pong client and server using rma.");
+			fprintf(stderr, "  -o <op>\trma op type: read|write (default: write)]\n");
+			return EXIT_FAILURE;
 		}
 	}
 
-	hints.domain_attr = &domain_hints;
-	hints.ep_attr = &ep_hints;
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+	
+	ret = ft_getsrcaddr(opts.src_addr, opts.port, &hints);
+	if (ret)
+		return EXIT_FAILURE;
+
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_RMA;
 	hints.mode = FI_CONTEXT | FI_PROV_MR_ATTR;
 	hints.addr_format = FI_FORMAT_UNSPEC;
+	
+	if (opts.prhints) {
+		printf("%s", fi_tostr(&hints, FI_TYPE_INFO));
+		return EXIT_SUCCESS;
+	}
 
 	return run();
 }

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -92,7 +92,7 @@ static int write_data(size_t size)
 	ret = fi_write(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 0, 
 			user_defined_key, &fi_ctx_write);
 	if (ret){
-		FI_PRINTERR("fi_writeto", ret);
+		FI_PRINTERR("fi_write", ret);
 		return ret;
 	}
 	return 0;
@@ -128,13 +128,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = 512;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
@@ -178,7 +178,7 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -186,13 +186,13 @@ static int bind_ep_res(void)
 	 *  for RMA write operation */
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV | FI_REMOTE_WRITE);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -150,7 +150,7 @@ static int alloc_ep_res(void)
 
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
@@ -162,7 +162,7 @@ static int alloc_ep_res(void)
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err4;
 	}
 
@@ -207,37 +207,37 @@ static int bind_ep_res(void)
 	for (i = 0; i < ep_cnt; i++) {
 		ret = fi_ep_bind(ep[i], &stx_ctx->fid, 0);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind: stx", ret);
+			FI_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_ep_bind(ep[i], &srx_ctx->fid, 0);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind: srx", ret);
+			FI_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_ep_bind(ep[i], &scq->fid, FI_SEND);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind: scq", ret);
+			FI_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_ep_bind(ep[i], &rcq->fid, FI_RECV);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind: rcq", ret);
+			FI_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_ep_bind(ep[i], &av->fid, 0);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind: av", ret);
+			FI_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_enable(ep[i]);
 		if (ret) {
-			FI_PRINTERR("fi_enable: ep", ret);
+			FI_PRINTERR("fi_enable", ret);
 			return ret;
 		}
 	}

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -55,8 +55,6 @@ static int rx_depth = 512;
 static char *dst_addr = NULL;
 static char *port = "9228";
 static struct fi_info hints;
-static struct fi_domain_attr domain_hints;
-static struct fi_ep_attr ep_hints;
 static char *dst_addr, *src_addr;
 
 static int ep_cnt = 2;
@@ -205,7 +203,6 @@ err1:
 static int bind_ep_res(void)
 {
 	int i, ret;
-
 	
 	for (i = 0; i < ep_cnt; i++) {
 		ret = fi_ep_bind(ep[i], &stx_ctx->fid, 0);
@@ -308,10 +305,6 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int i, ret;
 
-	ret = ft_getsrcaddr(src_addr, NULL, &hints);
-	if (ret)
-		return ret;
-
 	if (dst_addr) {
 		node = dst_addr;
 	} else {
@@ -319,7 +312,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -509,47 +502,54 @@ out:
 	return ret;
 }
 
-void print_usage(char *name)
+void print_usage(char *name, char *desc)
 {
 	fprintf(stderr, "Usage:\n");
 	fprintf(stderr, "  %s [OPTIONS]\t\tstart server\n", name);
-	fprintf(stderr, "  %s [OPTIONS] <host>\tconnect to given host \t\n", name);
+	fprintf(stderr, "  %s [OPTIONS] <host>\tconnect to server \t\n", name);
+
+	if(desc)
+		fprintf(stderr, "\n%s\n", desc);
 
 	fprintf(stderr, "\nOptions:\n");
-	fprintf(stderr, "  -n\tdomain_name\n");
-	fprintf(stderr, "  -p\tport number\n");
-	fprintf(stderr, "  -s\tsource address\n");
+	fprintf(stderr, "  -n <domain>\tdomain name\n");
+	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
+	fprintf(stderr, "  -s <address>\tsource address\n");
+	fprintf(stderr, "  -h\t\tdisplay this help output\n");
 
 	return;
 }
 
 int main(int argc, char **argv)
 {
-	int op;
+	int op, ret;
 
-	while ((op = getopt(argc, argv, "n:p:s:h")) != -1) {
+	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'n':
-			domain_hints.name = optarg;
-			break;
 		case 'p':
 			port = optarg;
 			break;
 		case 's':
 			src_addr = optarg;
 			break;
-		case 'h':
 		default:
-			print_usage(argv[0]);
-			exit(1);
+			ft_parseinfo(op, optarg, &hints);
+			break;
+		case '?':
+		case 'h':
+			print_usage(argv[0], "An RDM client-server example that uses shared context.\n");
+			return EXIT_FAILURE;
 		}
 	}
 
 	if (optind < argc)
 		dst_addr = argv[optind];
+	
+	ret = ft_getsrcaddr(src_addr, port, &hints);
+	if (ret)
+		return EXIT_FAILURE;
 
-	hints.domain_attr = &domain_hints;
-	hints.ep_attr = &ep_hints;
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_NAMED_RX_CTX;
 	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -99,7 +99,7 @@ static int send_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read: scq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -126,7 +126,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read: rcq", ret);
+				FI_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -257,13 +257,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -303,19 +303,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -188,13 +188,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -234,19 +234,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -48,8 +48,6 @@ static size_t buffer_size = 1024;
 static int rx_depth = 512;
 
 static struct fi_info hints;
-static struct fi_domain_attr domain_hints;
-static struct fi_ep_attr ep_hints;
 static char *dst_addr, *src_addr;
 static char *port = "9228";
 
@@ -70,6 +68,25 @@ struct fi_context fi_ctx_search;
 static uint64_t tag_data = 1;
 static uint64_t tag_control = 0x12345678;
 static uint64_t tag_param = 0x87654321;
+
+void print_usage(char *name, char *desc)
+{
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "  %s [OPTIONS]\t\tstart server\n", name);
+	fprintf(stderr, "  %s [OPTIONS] <host>\tconnect to server \t\n", name);
+	
+	if (desc)
+		fprintf(stderr, "\n%s\n", desc);
+
+	fprintf(stderr, "\nOptions:\n");
+	fprintf(stderr, "  -n <domain>\tdomain name\n");
+	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
+	fprintf(stderr, "  -s <address>\tsource address\n");
+	fprintf(stderr, "  -h\t\tdisplay this help output\n");
+	
+	return;
+}
 
 int wait_for_tagged_completion(struct fid_cq *cq, int num_completions)
 {
@@ -249,10 +266,6 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int ret;
 
-	ret = ft_getsrcaddr(src_addr, NULL, &hints);
-	if (ret)
-		return ret;
-
 	if (dst_addr) {
 		node = dst_addr;
 	} else {
@@ -260,7 +273,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -426,13 +439,11 @@ static int run(void)
 	if(dst_addr) {
 		// search for initial tag, it should fail since the sender 
 		// hasn't sent anyting
-		fprintf(stdout,
-			"[fi_tsearch] Searching msg with tag [%" PRIu64 "]\n",
-			tag_data);
+		fprintf(stdout, "Searching msg with tag [%" PRIu64 "]\n", tag_data);
 		tagged_search(tag_data);
 		
-		fprintf(stdout, "[fi_trecv] Posting buffer for msg with tag "
-				"[%" PRIu64 "]\n", tag_data + 1);
+		fprintf(stdout, "Posting buffer for msg with tag [%" PRIu64 "]\n", 
+				tag_data + 1);
 		ret = post_recv(tag_data + 1);
 		if(ret)
 			goto out;
@@ -447,9 +458,8 @@ static int run(void)
 		ret = wait_for_tagged_completion(rcq, 1);
 		if(ret)
 			goto out;
-		fprintf(stdout,
-			"[fi_cq_read] Received completion event for msg"
-			" with tag [%" PRIu64 "]\n", tag_data + 1);
+		fprintf(stdout, "Received completion event for msg with tag "
+				"[%" PRIu64 "]\n", tag_data + 1);
 		
 		// search again for the initial tag, it should be successful now
 		fprintf(stdout,
@@ -461,10 +471,8 @@ static int run(void)
 		ret = recv_msg(tag_data);	
 		if(ret)
 			goto out;
-		fprintf(stdout, "[fi_trecv][fi_cq_read] Posted buffer and "
-				"received completion event for msg with tag "
-				"[%" PRIu64 "]\n", tag_data);
-
+		fprintf(stdout, "Posted buffer and received completion event for"
+			       " msg with tag [%" PRIu64 "]\n", tag_data);
 	} else {
 		// Sender	
 		// synchronize with receiver
@@ -473,15 +481,13 @@ static int run(void)
 		if (ret)
 			goto out;
 
-		fprintf(stdout,
-			"[fi_tsend] Sending msg with tag [%" PRIu64 "]\n",
+		fprintf(stdout, "Sending msg with tag [%" PRIu64 "]\n",
 			tag_data);
 		ret = send_msg(16, tag_data);
 		if(ret)
 			goto out;
 
-		fprintf(stdout,
-			"[fi_tsend] Sending msg with tag [%" PRIu64 "]\n",
+		fprintf(stdout, "Sending msg with tag [%" PRIu64 "]\n",
 			tag_data + 1);
 		ret = send_msg(16, tag_data + 1);
 		if(ret)
@@ -504,28 +510,31 @@ int main(int argc, char **argv)
 {
 	int op, ret;
 
-	while ((op = getopt(argc, argv, "d:n:p:")) != -1) {
+	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'd':
-			dst_addr = optarg;
-			break;
-		case 'n':
-			domain_hints.name = optarg;
-			break;
 		case 'p':
 			port = optarg;
 			break;
+		case 's':
+			src_addr = optarg;
+			break;
 		default:
-			printf("usage: %s\n", argv[0]);
-			printf("\t[-d destination_address]\n");
-			printf("\t[-n domain_name]\n");
-			printf("\t[-p port_number]\n");
-			exit(1);
-		}
+			ft_parseinfo(op, optarg, &hints);
+			break;
+		case '?':
+		case 'h':
+			print_usage(argv[0], "An RDM client-server example that uses tagged search.\n");
+			return EXIT_FAILURE;
+		}		
 	}
 
-	hints.domain_attr = &domain_hints;
-	hints.ep_attr = &ep_hints;
+	if (optind < argc)
+		dst_addr = argv[optind];
+	
+	ret = ft_getsrcaddr(src_addr, port, &hints);
+	if (ret)
+		return EXIT_FAILURE;
+
 	hints.ep_type = FI_EP_RDM;
 	// FI_BUFFERED_RECV is required for tagged search
 	hints.caps = FI_MSG | FI_TAGGED | FI_BUFFERED_RECV;

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -180,7 +180,7 @@ static int alloc_ep_res(struct fid_ep *sep)
 
 		ret = fi_cq_open(dom, &cq_attr, &scq[i], NULL);
 		if (ret) {
-			FI_PRINTERR("fi_cq_open: scq", ret);
+			FI_PRINTERR("fi_cq_open", ret);
 			goto err2;
 		}
 	}
@@ -195,7 +195,7 @@ static int alloc_ep_res(struct fid_ep *sep)
 
 		ret = fi_cq_open(dom, &cq_attr, &rcq[i], NULL);
 		if (ret) {
-			FI_PRINTERR("fi_cq_open: rcq", ret);
+			FI_PRINTERR("fi_cq_open", ret);
 			goto err4;
 		}
 	}
@@ -250,13 +250,13 @@ static int bind_ep_res(void)
 	for (i = 0; i < ctx_cnt; i++) {
 		ret = fi_ep_bind(tx_ep[i], &scq[i]->fid, FI_SEND);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind: scq", ret);
+			FI_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_enable(tx_ep[i]);
 		if (ret) {
-			FI_PRINTERR("fi_enable: tx_ep", ret);
+			FI_PRINTERR("fi_enable", ret);
 			return ret;
 		}
 	}
@@ -264,13 +264,13 @@ static int bind_ep_res(void)
 	for (i = 0; i < ctx_cnt; i++) {
 		ret = fi_ep_bind(rx_ep[i], &rcq[i]->fid, FI_RECV);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind: rcq", ret);
+			FI_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_enable(rx_ep[i]);
 		if (ret) {
-			FI_PRINTERR("fi_enable: rx_ep", ret);
+			FI_PRINTERR("fi_enable", ret);
 			return ret;
 		}
 	}
@@ -278,7 +278,7 @@ static int bind_ep_res(void)
 	/* Bind scalable EP with AV */
 	ret = fi_scalable_ep_bind(sep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -55,8 +55,6 @@ static size_t transfer_size = 1000;
 static int rx_depth = 512;
 
 static struct fi_info hints;
-static struct fi_domain_attr domain_hints;
-static struct fi_ep_attr ep_hints;
 static char *dst_addr, *src_addr;
 static char *port = "5100";
 
@@ -77,6 +75,25 @@ struct fi_context fi_ctx_send;
 struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_av;
 static fi_addr_t *remote_rx_addr;
+
+void print_usage(char *name, char *desc)
+{
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "  %s [OPTIONS]\t\tstart server\n", name);
+	fprintf(stderr, "  %s [OPTIONS] <host>\tconnect to server \t\n", name);
+
+	if (desc)
+		fprintf(stderr, "\n%s\n", desc);
+
+	fprintf(stderr, "\nOptions:\n");
+	fprintf(stderr, "  -n <domain>\tdomain name\n");
+	fprintf(stderr, "  -p <port>\tnon default port number\n");
+	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
+	fprintf(stderr, "  -s <address>\tsource address\n");
+	fprintf(stderr, "  -h\t\tdisplay this help output\n");
+
+	return;
+}
 
 static int send_msg(int size)
 {
@@ -315,10 +332,6 @@ static int init_fabric(void)
 	uint64_t flags = 0;
 	int ret;
 
-	ret = ft_getsrcaddr(src_addr, port, &hints);
-	if (ret)
-		return ret;
-
 	if (dst_addr) {
 		node = dst_addr;
 	} else {
@@ -326,7 +339,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FI_VERSION(1, 0), node, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, port, flags, &hints, &fi);
 	if (ret) {
 		FI_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -489,16 +502,10 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op;
+	int op, ret;
 
-	while ((op = getopt(argc, argv, "d:n:p:s:")) != -1) {
+	while ((op = getopt(argc, argv, "p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'd':
-			dst_addr = optarg;
-			break;
-		case 'n':
-			domain_hints.name = optarg;
-			break;
 		case 'p':
 			port = optarg;
 			break;
@@ -506,17 +513,22 @@ int main(int argc, char **argv)
 			src_addr = optarg;
 			break;
 		default:
-			printf("usage: %s\n", argv[0]);
-			printf("\t[-d destination_address]\n");
-			printf("\t[-n domain_name]\n");
-			printf("\t[-p port_number]\n");
-			printf("\t[-s source_address]\n");
-			exit(1);
+			ft_parseinfo(op, optarg, &hints);
+			break;
+		case '?':
+		case 'h':
+			print_usage(argv[0], "An RDM client-server example with scalable endpoints.\n");
+			return EXIT_FAILURE;
 		}
 	}
 
-	hints.domain_attr = &domain_hints;
-	hints.ep_attr = &ep_hints;
+	if (optind < argc)
+		dst_addr = argv[optind];
+
+	ret = ft_getsrcaddr(src_addr, port, &hints);
+	if (ret)
+		return EXIT_FAILURE;
+	
 	hints.ep_type = FI_EP_RDM;
 	hints.caps = FI_MSG | FI_NAMED_RX_CTX;
 	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -181,15 +181,15 @@ static void free_ep_res(void)
 	
 	ret = fi_close(&mr->fid);
 	if (ret != 0) {
-		printf("fi_close(mr) ret=%d, %s\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_close: mr", ret);
 	}
 	ret = fi_close(&rcq->fid);
 	if (ret != 0) {
-		printf("fi_close(rcq) ret=%d, %s\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_close: rcq", ret);
 	}
 	ret = fi_close(&scq->fid);
 	if (ret != 0) {
-		printf("fi_close(scq) ret=%d, %s\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_close: scq", ret);
 	}
 	free(buf);
 }
@@ -221,19 +221,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		printf("fi_cq_open() send comp %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_cq_open: scq", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		printf("fi_cq_open() recv comp %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_cq_open: rcq", ret);
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		printf("fi_mr_reg() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -243,7 +243,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.flags = 0;
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		printf("fi_av_open() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
@@ -266,31 +266,31 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		printf("fi_ep_bind() scq %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_ep_bind: scq", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		printf("fi_ep_bind() rcq %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_ep_bind: rcq", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		printf("fi_ep_bind() av %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_ep_bind: av", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		printf("fi_enable() %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret) {
-		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_recv", ret);
 	}
 
 	return ret;
@@ -312,7 +312,7 @@ static int common_setup(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, opts.port, flags, &hints, &fi);
 	if (ret) {
-		printf("fi_getinfo() %s\n", strerror(-ret));
+		FI_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
 	if (fi->ep_attr->max_msg_size) {
@@ -321,7 +321,7 @@ static int common_setup(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		printf("fi_fabric() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 	if (fi->mode & FI_MSG_PREFIX) {
@@ -330,26 +330,23 @@ static int common_setup(void)
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		printf("fi_domain() %s %s\n", fi_strerror(-ret),
-			fi->domain_attr->name);
+		FI_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		printf("fi_endpoint() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_endpoint", ret);
 		goto err3;
 	}
 
 	ret = alloc_ep_res(fi);
 	if (ret) {
-		printf("alloc_ep_res() %s\n", fi_strerror(-ret));
 		goto err4;
 	}
 
 	ret = bind_ep_res();
 	if (ret) {
-		printf("bind_ep_res() %s\n", fi_strerror(-ret));
 		goto err5;
 	}
 
@@ -387,7 +384,7 @@ static int client_connect(void)
 
 	ret = fi_av_insert(av, hints.dest_addr, 1, &rem_addr, 0, NULL);
 	if (ret != 1) {
-		printf("fi_av_insert() %s\n", fi_strerror(-ret));
+		FI_PRINTERR("fi_av_insert", ret);
 		goto err;
 	}
 
@@ -425,7 +422,7 @@ static int server_connect(void)
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
 		if (ret < 0) {
-			printf("fi_cq_read() rcq %d (%s)\n", ret, fi_strerror(-ret));
+			FI_PRINTERR("fi_cq_read: rcq", ret);
 			return ret;
 		}
 	} while (ret == 0);
@@ -433,18 +430,18 @@ static int server_connect(void)
 	ret = fi_av_insert(av, buf_ptr, 1, &rem_addr, 0, NULL);
 	if (ret != 1) {
 		if (ret == 0) {
-			printf("Unable to resolve remote address 0x%x 0x%x\n",
+			FI_DEBUG("Unable to resolve remote address 0x%x 0x%x\n",
 					((uint32_t *)buf)[0], ((uint32_t *)buf)[1]);
 			ret = -FI_EINVAL;
 		} else {
-			printf("fi_insert_av() %d (%s)\n", ret, fi_strerror(-ret));
+			FI_PRINTERR("fi_av_insert", ret);
 		}
 		goto err;
 	}
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret != 0) {
-		printf("fi_recv() %d (%s)\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_recv", ret);
 		goto err;
 	}
 
@@ -491,20 +488,20 @@ static int run(void)
 
 	ret = fi_close(&ep->fid);
 	if (ret != 0) {
-		printf("fi_close(ep) ret=%d, %s\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_close: ep", ret);
 	}
 	free_ep_res();
 	ret = fi_close(&av->fid);
 	if (ret != 0) {
-		printf("fi_close(av) ret=%d, %s\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_close: av", ret);
 	}
 	ret = fi_close(&dom->fid);
 	if (ret != 0) {
-		printf("fi_close(dom) ret=%d, %s\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_close: dom", ret);
 	}
 	ret = fi_close(&fab->fid);
 	if (ret != 0) {
-		printf("fi_close(fab) ret=%d, %s\n", ret, fi_strerror(-ret));
+		FI_PRINTERR("fi_close: fab", ret);
 	}
 	fi_freeinfo(fi);
 	return ret;

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -181,15 +181,15 @@ static void free_ep_res(void)
 	
 	ret = fi_close(&mr->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close: mr", ret);
+		FI_PRINTERR("fi_close", ret);
 	}
 	ret = fi_close(&rcq->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close: rcq", ret);
+		FI_PRINTERR("fi_close", ret);
 	}
 	ret = fi_close(&scq->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close: scq", ret);
+		FI_PRINTERR("fi_close", ret);
 	}
 	free(buf);
 }
@@ -221,13 +221,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: scq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open: rcq", ret);
+		FI_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -266,19 +266,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: scq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: rcq", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind: av", ret);
+		FI_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -422,7 +422,7 @@ static int server_connect(void)
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
 		if (ret < 0) {
-			FI_PRINTERR("fi_cq_read: rcq", ret);
+			FI_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
 	} while (ret == 0);
@@ -488,20 +488,20 @@ static int run(void)
 
 	ret = fi_close(&ep->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close: ep", ret);
+		FI_PRINTERR("fi_close", ret);
 	}
 	free_ep_res();
 	ret = fi_close(&av->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close: av", ret);
+		FI_PRINTERR("fi_close", ret);
 	}
 	ret = fi_close(&dom->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close: dom", ret);
+		FI_PRINTERR("fi_close", ret);
 	}
 	ret = fi_close(&fab->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close: fab", ret);
+		FI_PRINTERR("fi_close", ret);
 	}
 	fi_freeinfo(fi);
 	return ret;


### PR DESCRIPTION
Followed @pmmccorm's re-factoring in the pingpong examples -
- Added -f option to include provider name
- Removed -d option as destination address
- Replaced printf/fpintf with FI_PRINTERR
- Added line number and casting in FR_PRINTERR
- Added missing FT_FIVERSION macro
- Mixed minor formatting issue

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>