### PR TITLE
Add --with-libfabric option to spec file.

### DIFF
--- a/fabtests.spec.in
+++ b/fabtests.spec.in
@@ -18,7 +18,7 @@ Fabtests provides a set of examples that uses libfabric - a high-performance fab
 %setup -q -n %{name}-%{version}
 
 %build
-%configure
+%configure %{?_with_libfabric}
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
This allows to build the fabtests RPM against a libfabric not installed on the system. Useful for automation.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>