### PR TITLE
fabtest: Add new comprehensive test app framework

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,8 @@ bin_PROGRAMS = \
 	unit/fi_eq_test \
 	unit/fi_av_test \
 	unit/fi_size_left_test \
-	ported/libibverbs/fi_rc_pingpong
+	ported/libibverbs/fi_rc_pingpong \
+	complex/fabtest
 
 simple_fi_info_SOURCES = \
 	simple/info.c \
@@ -126,6 +127,17 @@ unit_fi_size_left_test_SOURCES = \
 
 ported_libibverbs_fi_rc_pingpong_SOURCES = \
 	ported/libibverbs/rc_pingpong.c
+
+complex_fabtest_SOURCES = \
+	complex/fabtest.c \
+	complex/ft_comm.c \
+	complex/ft_comp.c \
+	complex/ft_config.c \
+	complex/ft_domain.c \
+	complex/ft_endpoint.c \
+	complex/ft_msg.c \
+	complex/ft_test.c \
+	common/shared.c
 
 man_MANS = man/fabtests.7
 

--- a/complex/fabtest.c
+++ b/complex/fabtest.c
@@ -1,0 +1,532 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <time.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
+#include <limits.h>
+#include <shared.h>
+
+#include "fabtest.h"
+
+
+int listen_sock = -1;
+int sock = -1;
+static int persistent = 1;
+
+//static struct timespec start, end;
+
+static struct ft_series *series;
+static int test_start_index, test_end_index = INT_MAX;
+struct ft_info test_info;
+struct fi_info *fabric_info;
+struct ft_xcontrol ft_rx, ft_tx;
+struct ft_control ft;
+
+size_t recv_size, send_size;
+
+enum {
+	FT_SUCCESS,
+	FT_ENODATA,
+	FT_ENOSYS,
+	FT_ERROR,
+	FT_MAX_RESULT
+};
+
+static int results[FT_MAX_RESULT];
+
+
+static int ft_nullstr(char *str)
+{
+	return (!str || str[0] == '\0');
+}
+
+static char *ft_strptr(char *str)
+{
+	return ft_nullstr(str) ? NULL : str;
+}
+
+static void ft_show_test_info(void)
+{
+	switch (test_info.test_type) {
+	case FT_TEST_LATENCY:
+		printf("latency");
+		break;
+	default:
+		break;
+	}
+
+	printf( " %s", fi_tostr(&test_info.ep_type, FI_TYPE_EP_TYPE));
+	printf( " [%s]", fi_tostr(&test_info.caps, FI_TYPE_CAPS));
+
+	switch (test_info.class_function) {
+	case FT_FUNC_SEND:
+		printf(" send");
+		break;
+	case FT_FUNC_SENDV:
+		printf(" sendv");
+		break;
+	case FT_FUNC_SENDMSG:
+		printf(" sendmsg");
+		break;
+	default:
+		break;
+	}
+	printf("\n");
+}
+
+static int ft_check_info(struct fi_info *hints, struct fi_info *info)
+{
+	if (hints->ep_type && hints->ep_type != info->ep_type) {
+		fprintf(stderr, "fi_getinfo ep type mismatch\n");
+		return -FI_EINVAL;
+	}
+	if (info->mode & ~hints->mode) {
+		fprintf(stderr, "fi_getinfo unsupported mode returned\n");
+		return -FI_EINVAL;
+	}
+	if (hints->caps != (hints->caps & info->caps)) {
+		fprintf(stderr, "fi_getinfo missing caps\n");
+		return -FI_EINVAL;
+	}
+
+	return 0;
+}
+
+static int ft_fw_listen(char *service)
+{
+	struct addrinfo *ai, hints;
+	int val, ret;
+
+	memset(&hints, 0, sizeof hints);
+	hints.ai_flags = AI_PASSIVE;
+
+	ret = getaddrinfo(NULL, service, &hints, &ai);
+	if (ret) {
+		fprintf(stderr, "getaddrinfo() %s\n", gai_strerror(ret));
+		return ret;
+	}
+
+	listen_sock = socket(ai->ai_family, SOCK_STREAM, 0);
+	if (listen_sock < 0) {
+		perror("socket");
+		ret = listen_sock;
+		goto free;
+	}
+
+	val = 1;
+	ret = setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof val);
+	if (ret) {
+		perror("setsockopt SO_REUSEADDR");
+		goto close;
+	}
+
+	ret = bind(listen_sock, ai->ai_addr, ai->ai_addrlen);
+	if (ret) {
+		perror("bind");
+		goto close;
+	}
+
+	ret = listen(listen_sock, 0);
+	if (ret)
+		perror("listen");
+
+	return 0;
+
+close:
+	close(listen_sock);
+free:
+	freeaddrinfo(ai);
+	return ret;
+}
+
+static int ft_fw_connect(char *node, char *service)
+{
+	struct addrinfo *ai;
+	int ret;
+
+	ret = getaddrinfo(node, service, NULL, &ai);
+	if (ret) {
+		perror("getaddrinfo");
+		return ret;
+	}
+
+	sock = socket(ai->ai_family, SOCK_STREAM, 0);
+	if (sock < 0) {
+		perror("socket");
+		ret = sock;
+		goto free;
+	}
+
+	ret = 1;
+	setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (void *) &ret, sizeof(ret));
+
+	ret = connect(sock, ai->ai_addr, ai->ai_addrlen);
+	if (ret) {
+		perror("connect");
+		close(sock);
+	}
+
+free:
+	freeaddrinfo(ai);
+	return ret;
+}
+
+static void ft_fw_shutdown(int fd)
+{
+	shutdown(fd, SHUT_RDWR);
+	close(fd);
+}
+
+int ft_fw_send(int fd, void *msg, size_t len)
+{
+	int ret;
+
+	ret = send(fd, msg, len, 0);
+	if (ret == len) {
+		return 0;
+	} else if (ret < 0) {
+		perror("send");
+		return -errno;
+	} else {
+		perror("send aborted");
+		return -FI_ECONNABORTED;
+	}
+}
+
+int ft_fw_recv(int fd, void *msg, size_t len)
+{
+	int ret;
+
+	ret = recv(fd, msg, len, MSG_WAITALL);
+	if (ret == len) {
+		return 0;
+	} else if (ret == 0) {
+		return -FI_ENOTCONN;
+	} else if (ret < 0) {
+		perror("recv");
+		return -errno;
+	} else {
+		perror("recv aborted");
+		return -FI_ECONNABORTED;
+	}
+}
+
+static void ft_fw_convert_info(struct fi_info *info,
+	struct fi_fabric_attr *fabric_attr,
+	struct fi_ep_attr *ep_attr, struct ft_info *test_info)
+{
+	memset(info, 0, sizeof *info);
+	info->caps = test_info->caps;
+	info->mode = test_info->mode;
+	info->ep_type = test_info->ep_type;
+
+	if (ep_attr) {
+		memset(ep_attr, 0, sizeof *ep_attr);
+		info->ep_attr = ep_attr;
+		ep_attr->protocol = test_info->protocol;
+		ep_attr->protocol_version = test_info->protocol_version;
+	}
+
+	if (fabric_attr) {
+		memset(fabric_attr, 0, sizeof *fabric_attr);
+		info->fabric_attr = fabric_attr;
+
+		if (!ft_nullstr(test_info->prov_name)) {
+			fabric_attr->prov_name = strndup(test_info->prov_name,
+						sizeof test_info->prov_name - 1);
+		}
+		if (!ft_nullstr(test_info->fabric_name)) {
+			fabric_attr->name = strndup(test_info->fabric_name,
+						sizeof test_info->fabric_name - 1);
+		}
+	}
+}
+
+static void
+ft_fw_update_info(struct ft_info *test_info, struct fi_info *info, int subindex)
+{
+	test_info->test_subindex = subindex;
+
+	if (info->ep_attr) {
+		test_info->protocol = info->ep_attr->protocol;
+		test_info->protocol_version = info->ep_attr->protocol_version;
+	}
+
+	if (info->fabric_attr) {
+		if (info->fabric_attr->prov_name) {
+			strncpy(test_info->prov_name, info->fabric_attr->prov_name,
+				sizeof test_info->prov_name);
+		}
+		if (info->fabric_attr->name) {
+			strncpy(test_info->fabric_name, info->fabric_attr->name,
+				sizeof test_info->fabric_name);
+		}
+	}
+}
+
+static int ft_fw_result_index(int fi_errno)
+{
+	switch (fi_errno) {
+	case 0:
+		return FT_SUCCESS;
+	case FI_ENODATA:
+		return FT_ENODATA;
+	case FI_ENOSYS:
+		return FT_ENOSYS;
+	default:
+		return FT_ERROR;
+	}
+}
+
+static int ft_fw_server(void)
+{
+	struct fi_info hints, *info;
+	struct fi_fabric_attr fabric_attr;
+	struct fi_ep_attr ep_attr;
+	int ret;
+
+	do {
+		ret = ft_fw_recv(sock, &test_info, sizeof test_info);
+		if (ret) {
+			if (ret == -FI_ENOTCONN)
+				ret = 0;
+			break;
+		}
+
+		ft_fw_convert_info(&hints, &fabric_attr, &ep_attr, &test_info);
+		printf("Starting test %d-%d: ", test_info.test_index,
+			test_info.test_subindex);
+		ft_show_test_info();
+		ret = fi_getinfo(FT_VERSION, ft_strptr(test_info.node),
+				 ft_strptr(test_info.service), FI_SOURCE,
+				 &hints, &info);
+		if (ret) {
+			FI_PRINTERR("fi_getinfo", ret);
+		} else {
+			if (info->next) {
+				printf("fi_getinfo returned multiple matches\n");
+				ret = -FI_E2BIG;
+			} else {
+				/* fabric_info is replaced when connecting */
+				fabric_info = info;
+
+				ret = ft_run_test();
+
+				if (fabric_info != info)
+					fi_freeinfo(fabric_info);
+			}
+			fi_freeinfo(info);
+		}
+
+		if (ret) {
+			printf("Node: %s\nService: %s\n",
+				test_info.node, test_info.service);
+			printf("%s\n", fi_tostr(&hints, FI_TYPE_INFO));
+		}
+
+		printf("Ending test %d-%d, result: %s\n", test_info.test_index,
+			test_info.test_subindex, fi_strerror(-ret));
+		results[ft_fw_result_index(-ret)]++;
+		ret = ft_fw_send(sock, &ret, sizeof ret);
+	} while (!ret);
+
+	return ret;
+}
+
+static int ft_fw_process_list(struct fi_info *hints, struct fi_info *info)
+{
+	int ret, subindex, result, sresult;
+
+	for (subindex = 1, fabric_info = info; fabric_info;
+	     fabric_info = fabric_info->next, subindex++) {
+
+		printf("Starting test %d-%d: ", series->test_index, subindex);
+		ft_show_test_info();
+		ret = ft_check_info(hints, fabric_info);
+		if (ret)
+			return ret;
+
+		ft_fw_update_info(&test_info, fabric_info, subindex);
+		ret = ft_fw_send(sock, &test_info, sizeof test_info);
+		if (ret)
+			return ret;
+
+		result = ft_run_test();
+
+		ret = ft_fw_recv(sock, &sresult, sizeof sresult);
+		if (result)
+			return result;
+		else if (ret)
+			return ret;
+		else if (sresult)
+			return sresult;
+	}
+
+	return 0;
+}
+
+static int ft_fw_client(void)
+{
+	struct fi_info hints, *info;
+	struct fi_fabric_attr fabric_attr;
+	struct fi_ep_attr ep_attr;
+	int ret;
+
+	for (fts_start(series, test_start_index);
+	     !fts_end(series, test_end_index);
+	     fts_next(series)) {
+
+		fts_cur_info(series, &test_info);
+		ft_fw_convert_info(&hints, &fabric_attr, &ep_attr, &test_info);
+
+		printf("Starting test %d / %d\n", test_info.test_index, series->test_count);
+		ret = fi_getinfo(FT_VERSION, ft_strptr(test_info.node),
+				 ft_strptr(test_info.service), 0, &hints, &info);
+		if (ret) {
+			FI_PRINTERR("fi_getinfo", ret);
+		} else {
+			ret = ft_fw_process_list(&hints, info);
+			fi_freeinfo(info);
+		}
+
+		if (ret) {
+			fprintf(stderr, "Node: %s\nService: %s\n",
+				test_info.node, test_info.service);
+			fprintf(stderr, "%s\n", fi_tostr(&hints, FI_TYPE_INFO));
+		}
+
+		printf("Ending test %d / %d, result: %s\n",
+			test_info.test_index, series->test_count, fi_strerror(-ret));
+		results[ft_fw_result_index(-ret)]++;
+	}
+
+	return 0;
+}
+
+static void ft_fw_show_results(void)
+{
+	printf("Success: %d\n", results[FT_SUCCESS]);
+	printf("ENODATA: %d\n", results[FT_ENODATA]);
+	printf("ENOSYS : %d\n", results[FT_ENOSYS]);
+	printf("ERROR  : %d\n", results[FT_ERROR]);
+}
+
+static void ft_fw_usage(char *program)
+{
+	printf("usage: %s [server_node]\n", program);
+	printf("\t[-f test_config_file]\n");
+	printf("\t[-p service_port]\n");
+	printf("\t[-x]   exit after test run\n");
+	printf("\t[-y start_test_index]\n");
+	printf("\t[-z end_test_index]\n");
+}
+
+int main(int argc, char **argv)
+{
+	char *node;
+	char *service = "2710";
+	char *filename = NULL;
+	int ret, op;
+
+	while ((op = getopt(argc, argv, "f:p:xy:z:")) != -1) {
+		switch (op) {
+		case 'f':
+			filename = optarg;
+			break;
+		case 'p':
+			service = optarg;
+			break;
+		case 'x':
+			persistent = 0;
+			break;
+		case 'y':
+			test_start_index = atoi(optarg);
+			break;
+		case 'z':
+			test_end_index = atoi(optarg);
+			break;
+		default:
+			ft_fw_usage(argv[0]);
+			exit(1);
+		}
+	}
+
+	if (optind < argc - 1) {
+		ft_fw_usage(argv[0]);
+		exit(1);
+	}
+
+	node = (optind == argc - 1) ? argv[optind] : NULL;
+
+	if (node) {
+		series = fts_load(filename);
+		if (!series)
+			exit(1);
+
+		ret = ft_fw_connect(node, service);
+		if (ret)
+			goto out;
+
+		ret = ft_fw_client();
+		ft_fw_shutdown(sock);
+	} else {
+		ret = ft_fw_listen(service);
+		if (ret)
+			goto out;
+
+		do {
+			sock = accept(listen_sock, NULL, 0);
+			if (sock < 0) {
+				ret = sock;
+				perror("accept");
+			}
+
+			op = 1;
+			setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
+				   (void *) &op, sizeof(op));
+
+			ret = ft_fw_server();
+			ft_fw_shutdown(sock);
+		} while (persistent);
+	}
+
+	ft_fw_show_results();
+out:
+	if (node)
+		fts_close(series);
+	return ret;
+}

--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2015 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FABTEST_H_
+#define _FABTEST_H_
+
+#include <stdlib.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_atomic.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_prov.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_tagged.h>
+#include <shared.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+extern int listen_sock, sock;
+
+extern struct fid_fabric *fabric;
+extern struct fid_domain *domain;
+extern struct fid_av	 *av;
+//extern struct fid_wait	 *waitset;
+//extern struct fid_poll	 *pollset;
+extern struct fid_eq	 *eq;
+extern struct fid_cq	 *txcq, *rxcq;
+//extern struct fid_cntr	 *txcntr, *rxcntr;
+extern struct fid_ep	 *ep;
+extern struct fid_pep	 *pep;
+//extern struct fid_stx	 *stx;
+//extern struct fid_sep	 *sep;
+
+extern struct ft_info test_info;
+extern struct fi_info *fabric_info;
+
+extern size_t sm_size_array[];
+extern size_t med_size_array[];
+extern size_t lg_size_array[];
+extern size_t size_array[];
+extern const unsigned int sm_size_cnt;
+extern const unsigned int med_size_cnt;
+extern const unsigned int lg_size_cnt;
+
+struct ft_xcontrol {
+	struct fid_ep		*ep;
+	void			*buf;
+	struct fid_mr		*mr;
+	void			*memdesc;
+	struct iovec		*iov;
+	void			**iov_desc;
+	int			iov_iter;
+	size_t			msg_size;
+	size_t			credits;
+	size_t			max_credits;
+	fi_addr_t		addr;
+	uint64_t		tag;
+	enum fi_cq_format	cq_format;
+	enum fi_wait_obj	comp_wait;  /* must be NONE */
+};
+
+struct ft_control {
+	size_t			*size_array;
+	int			size_cnt;
+	size_t			*iov_array;
+	int			iov_cnt;
+	int			inc_step;
+	int			xfer_iter;
+	int			error;
+};
+
+extern struct ft_xcontrol ft_rx, ft_tx;
+extern struct ft_control ft;
+
+/* Test must support all available versions */
+#define FT_VERSION	FI_VERSION(1, 0)
+
+enum {
+	FT_MAX_CAPS		= 64,
+	FT_MAX_EP_TYPES		= 8,
+	FT_MAX_PROV_MODES	= 4,
+	FT_DEFAULT_CREDITS	= 128,
+	FT_COMP_BUF_SIZE	= 256,
+	FT_TIMEOUT		= 15000
+};
+
+enum ft_comp_type {
+	FT_COMP_UNSPEC,
+	FT_COMP_QUEUE,
+//	FT_COMP_COUNTER,
+	FT_MAX_COMP
+};
+
+enum ft_test_type {
+	FT_TEST_UNSPEC,
+	FT_TEST_LATENCY,
+//	FT_TEST_BANDWIDTH,
+	FT_MAX_TEST
+};
+
+enum ft_class_function {
+	FT_FUNC_UNSPEC,
+	FT_FUNC_SEND,
+	FT_FUNC_SENDV,
+	FT_FUNC_SENDMSG,
+	FT_MAX_FUNCTIONS
+};
+
+#define FT_FLAG_QUICKTEST	(1ULL << 0)
+
+struct ft_set {
+	char			node[FI_NAME_MAX];
+	char			service[FI_NAME_MAX];
+	char			prov_name[FI_NAME_MAX];
+	enum ft_test_type	test_type[FT_MAX_TEST];
+	enum ft_class_function	class_function[FT_MAX_FUNCTIONS];
+	enum fi_ep_type		ep_type[FT_MAX_EP_TYPES];
+	enum ft_comp_type	comp_type[FT_MAX_COMP];
+	uint64_t		mode[FT_MAX_PROV_MODES];
+	uint64_t		caps[FT_MAX_CAPS];
+	uint64_t		test_flags;
+};
+
+struct ft_series {
+	struct ft_set		*sets;
+	int			nsets;
+	int			test_count;
+	int			test_index;
+	int			cur_set;
+	int			cur_type;
+	int			cur_func;
+	int			cur_ep;
+	int			cur_comp;
+	int			cur_mode;
+	int			cur_caps;
+};
+
+struct ft_info {
+	enum ft_test_type	test_type;
+	int			test_index;
+	int			test_subindex;
+	enum ft_class_function	class_function;
+	uint64_t		test_flags;
+	uint64_t		caps;
+	uint64_t		mode;
+	enum fi_av_type		av_type;
+	enum fi_ep_type		ep_type;
+	enum ft_comp_type	comp_type;
+	uint32_t		protocol;
+	uint32_t		protocol_version;
+	char			node[FI_NAME_MAX];
+	char			service[FI_NAME_MAX];
+	char			prov_name[FI_NAME_MAX];
+	char			fabric_name[FI_NAME_MAX];
+};
+
+
+struct ft_series * fts_load(char *filename);
+void fts_close(struct ft_series *series);
+void fts_start(struct ft_series *series, int index);
+void fts_next(struct ft_series *series);
+int  fts_end(struct ft_series *series, int index);
+void fts_cur_info(struct ft_series *series, struct ft_info *info);
+
+
+struct ft_msg {
+	uint32_t	len;
+	uint8_t		data[124];
+};
+
+int ft_fw_send(int fd, void *msg, size_t len);
+int ft_fw_recv(int fd, void *msg, size_t len);
+
+
+int ft_open_control();
+ssize_t ft_get_event(uint32_t *event, void *buf, size_t len,
+		     uint32_t event_check, size_t len_check);
+int ft_open_comp();
+int ft_bind_comp(struct fid_ep *ep, uint64_t flags);
+int ft_comp_rx();
+int ft_comp_tx();
+
+int ft_open_active();
+int ft_open_passive();
+int ft_enable_comm();
+int ft_post_recv_bufs();
+void ft_format_iov(struct iovec *iov, size_t cnt, char *buf, size_t len);
+void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt);
+
+int ft_recv_msg();
+int ft_send_msg();
+int ft_recv_dgram();
+int ft_sendrecv_dgram();
+
+int ft_run_test();
+int ft_reset_ep();
+void ft_record_error(int error);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FABTEST_H_ */

--- a/complex/ft_comm.c
+++ b/complex/ft_comm.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "fabtest.h"
+
+
+static int ft_accept(void)
+{
+	struct fi_eq_cm_entry entry;
+	uint32_t event;
+	ssize_t rd;
+	int ret;
+
+	rd = ft_get_event(&event, &entry, sizeof entry,
+			  FI_CONNREQ, sizeof entry);
+	if (rd < 0)
+		return (int) rd;
+
+	fabric_info = entry.info;
+	ret = ft_open_active();
+	if (ret)
+		return ret;
+
+	ret = fi_accept(ep, NULL, 0);
+	if (ret) {
+		FI_PRINTERR("fi_accept", ret);
+		return ret;
+	}
+
+	rd = ft_get_event(&event, &entry, sizeof entry,
+			  FI_CONNECTED, sizeof entry);
+	if (rd < 0)
+		return (int) rd;
+
+	return 0;
+}
+
+static int ft_connect(void)
+{
+	struct fi_eq_cm_entry entry;
+	uint32_t event;
+	ssize_t rd;
+	int ret;
+
+	ret = fi_connect(ep, fabric_info->dest_addr, NULL, 0);
+	if (ret) {
+		FI_PRINTERR("fi_connect", ret);
+		return ret;
+	}
+
+	rd = ft_get_event(&event, &entry, sizeof entry,
+			  FI_CONNECTED, sizeof entry);
+	if (rd < 0)
+		return (int) rd;
+
+	return 0;
+}
+
+static int ft_load_av(void)
+{
+	struct ft_msg msg;
+	size_t len;
+	int ret;
+
+	len = sizeof(msg.data);
+	ret = fi_getname(&ep->fid, msg.data, &len);
+	if (ret) {
+		FI_PRINTERR("fi_getname", ret);
+		return ret;
+	}
+
+	msg.len = (uint32_t) len;
+	ret = ft_fw_send(sock, &msg, sizeof msg);
+	if (ret)
+		return ret;
+
+	ret = ft_fw_recv(sock, &msg, sizeof msg);
+	if (ret)
+		return ret;
+
+	ret = fi_av_insert(av, msg.data, 1, &ft_tx.addr, 0, NULL);
+	if (ret != 1) {
+		FI_PRINTERR("fi_av_insert", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int ft_enable_comm(void)
+{
+	if (test_info.ep_type == FI_EP_MSG)
+		return pep ? ft_accept() : ft_connect();
+	else
+		return ft_load_av();
+}

--- a/complex/ft_comp.c
+++ b/complex/ft_comp.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "fabtest.h"
+
+
+struct fid_cq *txcq, *rxcq;
+//struct fid_cntr *txcntr, *rxcntr;
+
+static size_t comp_entry_cnt[] = {
+	[FI_CQ_FORMAT_UNSPEC] = 0,
+	[FI_CQ_FORMAT_CONTEXT] = FT_COMP_BUF_SIZE / sizeof(struct fi_cq_entry),
+	[FI_CQ_FORMAT_MSG] = FT_COMP_BUF_SIZE / sizeof(struct fi_cq_msg_entry),
+	[FI_CQ_FORMAT_DATA] = FT_COMP_BUF_SIZE / sizeof(struct fi_cq_data_entry),
+	[FI_CQ_FORMAT_TAGGED] = FT_COMP_BUF_SIZE / sizeof(struct fi_cq_tagged_entry)
+};
+
+static size_t comp_entry_size[] = {
+	[FI_CQ_FORMAT_UNSPEC] = 0,
+	[FI_CQ_FORMAT_CONTEXT] = sizeof(struct fi_cq_entry),
+	[FI_CQ_FORMAT_MSG] = sizeof(struct fi_cq_msg_entry),
+	[FI_CQ_FORMAT_DATA] = sizeof(struct fi_cq_data_entry),
+	[FI_CQ_FORMAT_TAGGED] = sizeof(struct fi_cq_tagged_entry)
+};
+
+
+static int ft_open_cqs(void)
+{
+	struct fi_cq_attr attr;
+	int ret;
+
+	if (!txcq) {
+		memset(&attr, 0, sizeof attr);
+		attr.format = ft_tx.cq_format;
+		attr.wait_obj = ft_tx.comp_wait;
+		attr.size = ft_tx.max_credits;
+
+		ret = fi_cq_open(domain, &attr, &txcq, NULL);
+		if (ret) {
+			FI_PRINTERR("fi_cq_open", ret);
+			return ret;
+		}
+	}
+
+	if (!rxcq) {
+		memset(&attr, 0, sizeof attr);
+		attr.format = ft_rx.cq_format;
+		attr.wait_obj = ft_rx.comp_wait;
+		attr.size = ft_rx.max_credits;
+
+		ret = fi_cq_open(domain, &attr, &rxcq, NULL);
+		if (ret) {
+			FI_PRINTERR("fi_cq_open", ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+int ft_open_comp(void)
+{
+	int ret;
+
+	ret = (test_info.comp_type == FT_COMP_QUEUE) ?
+		ft_open_cqs() : -FI_ENOSYS;
+
+	return 0;
+}
+
+int ft_bind_comp(struct fid_ep *ep, uint64_t flags)
+{
+	int ret;
+
+	if (flags & FI_SEND) {
+		ret = fi_ep_bind(ep, &txcq->fid, flags & ~FI_RECV);
+		if (ret) {
+			FI_PRINTERR("fi_ep_bind", ret);
+			return ret;
+		}
+	}
+
+	if (flags & FI_RECV) {
+		ret = fi_ep_bind(ep, &rxcq->fid, flags & ~FI_SEND);
+		if (ret) {
+			FI_PRINTERR("fi_ep_bind", ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static void ft_check_rx_comp(void *buf)
+{
+	struct fi_cq_err_entry *entry;
+
+	entry = buf;
+	switch (ft_rx.cq_format) {
+	case FI_CQ_FORMAT_TAGGED:
+	case FI_CQ_FORMAT_DATA:
+	case FI_CQ_FORMAT_MSG:
+		if (entry->len != ft_tx.msg_size)
+			ft_record_error(FI_EMSGSIZE);
+		/* fall through */
+	default:
+		if (entry->op_context != NULL)
+			ft_record_error(FI_EOTHER);
+		break;
+	}
+}
+
+int ft_comp_rx(void)
+{
+	uint8_t buf[FT_COMP_BUF_SIZE];
+	int i, ret;
+
+	do {
+		ret = fi_cq_read(rxcq, buf, comp_entry_cnt[ft_rx.cq_format]);
+		if (ret < 0) {
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(rxcq, "rxcq");
+			} else {
+				FI_PRINTERR("fi_cq_read", ret);
+			}
+			return ret;
+		} else if (ret) {
+			for (i = 0; i < ret; i++) {
+				ft_check_rx_comp(&buf[comp_entry_size[ft_rx.cq_format] * i]);
+			}
+			ft_rx.credits += ret;
+		}
+	} while (ret == comp_entry_cnt[ft_rx.cq_format]);
+
+	return 0;
+}
+
+
+int ft_comp_tx(void)
+{
+	uint8_t buf[FT_COMP_BUF_SIZE];
+	int ret;
+
+	do {
+		ret = fi_cq_read(txcq, buf, comp_entry_cnt[ft_tx.cq_format]);
+		if (ret < 0) {
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(txcq, "txcq");
+			} else {
+				FI_PRINTERR("fi_cq_read", ret);
+			}
+			return ret;
+		} else if (ret) {
+			ft_tx.credits += ret;
+		}
+	} while (ret == comp_entry_cnt[ft_tx.cq_format]);
+
+	return 0;
+}

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2015 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "fabtest.h"
+
+
+#define FT_CAP_MSG	FI_MSG | FI_SEND | FI_RECV
+#define FT_CAP_TAGGED	FI_TAGGED | FI_SEND | FI_RECV
+#define FT_CAP_RMA	FI_RMA | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE
+#define FT_CAP_ATOMIC	FI_ATOMICS | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE
+
+#define FT_MODE_ALL	/*FI_CONTEXT |*/ FI_LOCAL_MR | FI_PROV_MR_ATTR /*| FI_MSG_PREFIX*/
+#define FT_MODE_NONE	~0ULL
+
+
+static struct ft_set test_sets[] = {
+	{
+		.node = "127.0.0.1",
+		.service = "2224",
+		.prov_name = "sockets",
+		.test_type = {
+			FT_TEST_LATENCY
+		},
+		.class_function = {
+			FT_FUNC_SEND,
+			FT_FUNC_SENDV,
+			FT_FUNC_SENDMSG
+		},
+		.ep_type = {
+			FI_EP_MSG,
+			FI_EP_DGRAM,
+			FI_EP_RDM
+		},
+		.comp_type = {
+			FT_COMP_QUEUE
+		},
+		.mode = {
+			FT_MODE_ALL
+		},
+		.caps = {
+			FT_CAP_MSG,
+			FT_CAP_TAGGED,
+//			FT_CAP_RMA,
+//			FT_CAP_ATOMIC
+		},
+		.test_flags = FT_FLAG_QUICKTEST
+	},
+};
+
+static struct ft_series test_series;
+
+size_t sm_size_array[] = {
+		1 << 0,
+		1 << 1,
+		1 << 2, (1 << 2) + (1 << 1),
+		1 << 3, (1 << 3) + (1 << 2),
+		1 << 4, (1 << 4) + (1 << 3),
+		1 << 5, (1 << 5) + (1 << 4),
+		1 << 6, (1 << 6) + (1 << 5),
+		1 << 7, (1 << 7) + (1 << 6),
+		1 << 8
+};
+const unsigned int sm_size_cnt = (sizeof sm_size_array / sizeof sm_size_array[0]);
+
+size_t med_size_array[] = {
+		1 <<  4,
+		1 <<  5,
+		1 <<  6,
+		1 <<  7, (1 <<  7) + (1 <<  6),
+		1 <<  8, (1 <<  8) + (1 <<  7),
+		1 <<  9, (1 <<  9) + (1 <<  8),
+		1 << 10, (1 << 10) + (1 <<  9),
+		1 << 11, (1 << 11) + (1 << 10),
+		1 << 12, (1 << 12) + (1 << 11),
+		1 << 13, (1 << 13) + (1 << 12),
+		1 << 14
+};
+const unsigned int med_size_cnt = (sizeof med_size_array / sizeof med_size_array[0]);
+
+size_t lg_size_array[] = {
+		1 <<  4,
+		1 <<  5,
+		1 <<  6,
+		1 <<  7, (1 <<  7) + (1 <<  6),
+		1 <<  8, (1 <<  8) + (1 <<  7),
+		1 <<  9, (1 <<  9) + (1 <<  8),
+		1 << 10, (1 << 10) + (1 <<  9),
+		1 << 11, (1 << 11) + (1 << 10),
+		1 << 12, (1 << 12) + (1 << 11),
+		1 << 13, (1 << 13) + (1 << 12),
+		1 << 14, (1 << 14) + (1 << 13),
+		1 << 15, (1 << 15) + (1 << 14),
+		1 << 16, (1 << 16) + (1 << 15),
+		1 << 17, (1 << 17) + (1 << 16),
+		1 << 18, (1 << 18) + (1 << 17),
+		1 << 19, (1 << 19) + (1 << 18),
+		1 << 20, (1 << 20) + (1 << 19),
+		1 << 21, (1 << 21) + (1 << 20),
+		1 << 22, (1 << 22) + (1 << 21),
+};
+const unsigned int lg_size_cnt = (sizeof lg_size_array / sizeof lg_size_array[0]);
+
+
+/*
+ * TODO: Parse configuration file.
+ */
+struct ft_series *fts_load(char *filename)
+{
+	if (filename)
+		printf("Using static tests. Ignoring config file %s\n", filename);
+
+	test_series.sets = test_sets;
+	test_series.nsets = sizeof(test_sets) / sizeof(test_sets[0]);
+
+	for (fts_start(&test_series, 0); !fts_end(&test_series, 0);
+	     fts_next(&test_series))
+		test_series.test_count++;
+	fts_start(&test_series, 0);
+
+	printf("Test configurations loaded: %d\n", test_series.test_count);
+	return &test_series;
+}
+
+void fts_close(struct ft_series *series)
+{
+}
+
+void fts_start(struct ft_series *series, int index)
+{
+	series->cur_set = 0;
+	series->cur_type = 0;
+	series->cur_ep = 0;
+	series->cur_comp = 0;
+	series->cur_mode = 0;
+	series->cur_caps = 0;
+
+	series->test_index = 1;
+	if (index > 1) {
+		for (; !fts_end(series, index - 1); fts_next(series))
+			;
+	}
+}
+
+void fts_next(struct ft_series *series)
+{
+	struct ft_set *set;
+
+	if (fts_end(series, 0))
+		return;
+
+	series->test_index++;
+	set = &series->sets[series->cur_set];
+
+	if (set->caps[++series->cur_caps])
+		return;
+	series->cur_caps = 0;
+
+	if (set->mode[++series->cur_mode])
+		return;
+	series->cur_mode = 0;
+
+	if (set->class_function[++series->cur_func])
+		return;
+	series->cur_func = 0;
+
+	if (set->comp_type[++series->cur_comp])
+		return;
+	series->cur_comp = 0;
+
+	if (set->ep_type[++series->cur_ep])
+		return;
+	series->cur_ep = 0;
+
+	if (set->test_type[++series->cur_type])
+		return;
+
+	series->cur_set++;
+}
+
+int fts_end(struct ft_series *series, int index)
+{
+	return (series->cur_set >= series->nsets) ||
+		((index > 0) && (series->test_index > index));
+}
+
+void fts_cur_info(struct ft_series *series, struct ft_info *info)
+{
+	static struct ft_set *set;
+
+	memset(info, 0, sizeof *info);
+	if (series->cur_set >= series->nsets)
+		return;
+
+	set = &series->sets[series->cur_set];
+	info->test_type = set->test_type[series->cur_type];
+	info->test_index = series->test_index;
+	info->class_function = set->class_function[series->cur_func];
+	info->test_flags = set->test_flags;
+	info->caps = set->caps[series->cur_caps];
+	info->mode = (set->mode[series->cur_mode] == FT_MODE_NONE) ?
+			0 : set->mode[series->cur_mode];
+	info->ep_type = set->ep_type[series->cur_ep];
+	info->comp_type = set->comp_type[series->cur_comp];
+
+	memcpy(info->node, set->node, FI_NAME_MAX);
+	memcpy(info->service, set->service, FI_NAME_MAX);
+	memcpy(info->prov_name, set->prov_name, FI_NAME_MAX);
+}

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "fabtest.h"
+
+
+struct fid_fabric *fabric;
+struct fid_domain *domain;
+struct fid_eq *eq;
+struct fid_av *av;
+
+
+static int ft_open_fabric(void)
+{
+	int ret;
+
+	if (fabric) {
+		if (fabric_info->fabric_attr->fabric &&
+		    fabric_info->fabric_attr->fabric != fabric) {
+			printf("Opened fabric / fabric_attr mismatch\n");
+			return -FI_EOTHER;
+		}
+		return 0;
+	}
+
+	ret = fi_fabric(fabric_info->fabric_attr, &fabric, NULL);
+	if (ret)
+		FI_PRINTERR("fi_fabric", ret);
+
+	return ret;
+}
+
+static int ft_open_eq(void)
+{
+	struct fi_eq_attr attr;
+	int ret;
+
+	if (eq)
+		return 0;
+
+	memset(&attr, 0, sizeof attr);
+	attr.wait_obj = FI_WAIT_FD;
+	ret = fi_eq_open(fabric, &attr, &eq, NULL);
+	if (ret)
+		FI_PRINTERR("fi_eq_open", ret);
+
+	return ret;
+}
+
+int ft_eq_readerr(void)
+{
+	struct fi_eq_err_entry err;
+	ssize_t ret;
+
+	ret = fi_eq_readerr(eq, &err, 0);
+	if (ret != sizeof(err)) {
+		FI_PRINTERR("fi_eq_readerr", ret);
+		return ret;
+	} else {
+		fprintf(stderr, "Error event %d %s\n",
+			err.err, fi_strerror(err.err));
+		return err.err;
+	}
+}
+
+ssize_t ft_get_event(uint32_t *event, void *buf, size_t len,
+		     uint32_t event_check, size_t len_check)
+{
+	ssize_t ret;
+
+	ret = fi_eq_sread(eq, event, buf, len, FT_TIMEOUT, 0);
+	if (ret == -FI_EAVAIL) {
+		return ft_eq_readerr();
+	} else if (ret < 0) {
+		FI_PRINTERR("fi_eq_sread", ret);
+		return ret;
+	}
+
+	if (event_check && event_check != *event) {
+		fprintf(stderr, "Unexpected event %d, wanted %d\n",
+			*event, event_check);
+		return -FI_ENOMSG;
+
+	}
+
+	if (ret < len_check) {
+		fprintf(stderr, "Reported event too small\n");
+		return -FI_ETOOSMALL;
+	}
+
+	return ret;
+}
+
+static int ft_open_domain(void)
+{
+	int ret;
+
+	if (domain) {
+		if (fabric_info->domain_attr->domain &&
+		    fabric_info->domain_attr->domain != domain) {
+			fprintf(stderr, "Opened domain / domain_attr mismatch\n");
+			return -FI_EDOMAIN;
+		}
+		return 0;
+	}
+
+	ret = fi_domain(fabric, fabric_info, &domain, NULL);
+	if (ret)
+		FI_PRINTERR("fi_domain", ret);
+
+	return ret;
+}
+
+static int ft_open_av(void)
+{
+	struct fi_av_attr attr;
+	int ret;
+
+	if (av)
+		return 0;
+
+	memset(&attr, 0, sizeof attr);
+	attr.type = test_info.av_type;
+	attr.count = 2;
+	ret = fi_av_open(domain, &attr, &av, NULL);
+	if (ret) {
+		FI_PRINTERR("fi_av_open", ret);
+		return ret;
+	}
+
+	return ret;
+}
+
+static int ft_setup_xcontrol_bufs(struct ft_xcontrol *ctrl)
+{
+	size_t size;
+	int i, ret;
+
+	size = ft.size_array[ft.size_cnt - 1];
+	if (!ctrl->buf) {
+		ctrl->buf = calloc(1, size);
+		if (!ctrl->buf)
+			return -FI_ENOMEM;
+	}
+
+	if ((fabric_info->mode & FI_LOCAL_MR) && !ctrl->mr) {
+		ret = fi_mr_reg(domain, ctrl->buf, size,
+				0, 0, 0, 0, &ctrl->mr, NULL);
+		if (ret) {
+			FI_PRINTERR("fi_mr_reg", ret);
+			return ret;
+		}
+		ctrl->memdesc = fi_mr_desc(ctrl->mr);
+	}
+
+	for (i = 0; i < ft.iov_cnt; i++)
+		ctrl->iov_desc[i] = ctrl->memdesc;
+
+	return 0;
+}
+
+static int ft_setup_bufs(void)
+{
+	int ret;
+
+	ret = ft_setup_xcontrol_bufs(&ft_rx);
+	if (ret)
+		return ret;
+
+	ret = ft_setup_xcontrol_bufs(&ft_tx);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+int ft_open_control(void)
+{
+	int ret;
+
+	ret = ft_open_fabric();
+	if (ret)
+		return ret;
+
+	ret = ft_open_eq();
+	if (ret)
+		return ret;
+
+	ret = ft_open_domain();
+	if (ret)
+		return ret;
+
+	ret = ft_setup_bufs();
+	if (ret)
+		return ret;
+
+	if (test_info.ep_type != FI_EP_MSG) {
+		ret = ft_open_av();
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}

--- a/complex/ft_endpoint.c
+++ b/complex/ft_endpoint.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "fabtest.h"
+
+
+struct fid_ep	*ep;
+struct fid_pep	*pep;
+//struct fid_stx	 *stx;
+//struct fid_sep	 *sep;
+
+
+int ft_open_passive(void)
+{
+	int ret;
+
+	if (pep)
+		return 0;
+
+	ret = ft_open_control();
+	if (ret)
+		return ret;
+
+	ret = fi_passive_ep(fabric, fabric_info, &pep, NULL);
+	if (ret) {
+		FI_PRINTERR("fi_passive_ep", ret);
+		return ret;
+	}
+
+	ret = fi_pep_bind(pep, &eq->fid, 0);
+	if (ret) {
+		FI_PRINTERR("fi_pep_bind", ret);
+		return ret;
+	}
+
+	ret = fi_listen(pep);
+	if (ret) {
+		FI_PRINTERR("fi_listen", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int ft_open_active(void)
+{
+	int ret;
+
+	if (ep)
+		return 0;
+
+	ret = ft_open_control();
+	if (ret)
+		return ret;
+
+	ret = ft_open_comp();
+	if (ret)
+		return ret;
+
+	ret = fi_endpoint(domain, fabric_info, &ep, NULL);
+	if (ret) {
+		FI_PRINTERR("fi_endpoint", ret);
+		return ret;
+	}
+
+	ft_rx.ep = ep;
+	ft_tx.ep = ep;
+
+	ret = fi_ep_bind(ep, &eq->fid, 0);
+	if (ret) {
+		FI_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	ret = ft_bind_comp(ep, FI_TRANSMIT | FI_RECV);
+	if (ret)
+		return ret;
+
+	if (test_info.ep_type != FI_EP_MSG) {
+		ret = fi_ep_bind(ep, &av->fid, 0);
+		if (ret) {
+			FI_PRINTERR("fi_ep_bind", ret);
+			return ret;
+		}
+	}
+
+	ret = fi_enable(ep);
+	if (ret) {
+		FI_PRINTERR("fi_enable", ret);
+		return ret;
+	}
+
+	ret = ft_post_recv_bufs();
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+int ft_reset_ep(void)
+{
+	int ret;
+
+	ret = ft_comp_rx();
+	if (ret)
+		return ret;
+
+	while (ft_tx.credits < ft_tx.max_credits) {
+		ret = ft_comp_tx();
+		if (ret)
+			return ret;
+	}
+
+	ret = ft_post_recv_bufs();
+	if (ret)
+		return ret;
+
+	return 0;
+}

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "fabtest.h"
+
+
+static int ft_post_recv(void)
+{
+	struct fi_msg msg;
+	int ret;
+
+	switch (test_info.class_function) {
+	case FT_FUNC_SENDV:
+		ft_format_iov(ft_rx.iov, ft.iov_array[ft_rx.iov_iter],
+				ft_rx.buf, ft_rx.msg_size);
+		ret = fi_recvv(ft_rx.ep, ft_rx.iov, ft_rx.iov_desc,
+				ft.iov_array[ft_rx.iov_iter], ft_rx.addr, NULL);
+		ft_next_iov_cnt(&ft_rx, fabric_info->rx_attr->iov_limit);
+		break;
+	case FT_FUNC_SENDMSG:
+		ft_format_iov(ft_rx.iov, ft.iov_array[ft_rx.iov_iter],
+				ft_rx.buf, ft_rx.msg_size);
+		msg.msg_iov = ft_rx.iov;
+		msg.desc = ft_rx.iov_desc;
+		msg.iov_count = ft.iov_array[ft_rx.iov_iter];
+		msg.addr = ft_rx.addr;
+		msg.context = NULL;
+		msg.data = 0;
+		ret = fi_recvmsg(ft_rx.ep, &msg, 0);
+		ft_next_iov_cnt(&ft_rx, fabric_info->rx_attr->iov_limit);
+		break;
+	default:
+		ret = fi_recv(ft_rx.ep, ft_rx.buf, ft_rx.msg_size,
+				ft_rx.memdesc, ft_rx.addr, NULL);
+		break;
+	}
+
+	return ret;
+}
+
+static int ft_post_trecv(void)
+{
+	struct fi_msg_tagged msg;
+	int ret;
+
+	switch (test_info.class_function) {
+	case FT_FUNC_SENDV:
+		ft_format_iov(ft_rx.iov, ft.iov_array[ft_rx.iov_iter],
+				ft_rx.buf, ft_rx.msg_size);
+		ret = fi_trecvv(ft_rx.ep, ft_rx.iov, ft_rx.iov_desc,
+				ft.iov_array[ft_rx.iov_iter], ft_rx.addr,
+				ft_rx.tag++, 0, NULL);
+		ft_next_iov_cnt(&ft_rx, fabric_info->rx_attr->iov_limit);
+		break;
+	case FT_FUNC_SENDMSG:
+		ft_format_iov(ft_rx.iov, ft.iov_array[ft_rx.iov_iter],
+				ft_rx.buf, ft_rx.msg_size);
+		msg.msg_iov = ft_rx.iov;
+		msg.desc = ft_rx.iov_desc;
+		msg.iov_count = ft.iov_array[ft_rx.iov_iter];
+		msg.addr = ft_rx.addr;
+		msg.tag = ft_rx.tag++;
+		msg.ignore = 0;
+		msg.context = NULL;
+		ret = fi_trecvmsg(ft_rx.ep, &msg, 0);
+		ft_next_iov_cnt(&ft_rx, fabric_info->rx_attr->iov_limit);
+		break;
+	default:
+		ret = fi_trecv(ft_rx.ep, ft_rx.buf, ft_rx.msg_size,
+				ft_rx.memdesc, ft_rx.addr, ft_rx.tag++, 0, NULL);
+		break;
+	}
+	return ret;
+}
+
+static int ft_post_send(void)
+{
+	struct fi_msg msg;
+	int ret;
+
+	switch (test_info.class_function) {
+	case FT_FUNC_SENDV:
+		ft_format_iov(ft_tx.iov, ft.iov_array[ft_tx.iov_iter],
+				ft_tx.buf, ft_tx.msg_size);
+		ret = fi_sendv(ft_tx.ep, ft_tx.iov, ft_tx.iov_desc,
+				ft.iov_array[ft_tx.iov_iter], ft_tx.addr, NULL);
+		ft_next_iov_cnt(&ft_tx, fabric_info->tx_attr->iov_limit);
+		break;
+	case FT_FUNC_SENDMSG:
+		ft_format_iov(ft_tx.iov, ft.iov_array[ft_tx.iov_iter],
+				ft_tx.buf, ft_tx.msg_size);
+		msg.msg_iov = ft_tx.iov;
+		msg.desc = ft_tx.iov_desc;
+		msg.iov_count = ft.iov_array[ft_tx.iov_iter];
+		msg.addr = ft_tx.addr;
+		msg.context = NULL;
+		msg.data = 0;
+		ret = fi_sendmsg(ft_tx.ep, &msg, 0);
+		ft_next_iov_cnt(&ft_tx, fabric_info->tx_attr->iov_limit);
+		break;
+	default:
+		ret = fi_send(ft_tx.ep, ft_tx.buf, ft_tx.msg_size,
+				ft_tx.memdesc, ft_tx.addr, NULL);
+		break;
+	}
+
+	return ret;
+}
+
+static int ft_post_tsend(void)
+{
+	struct fi_msg_tagged msg;
+	int ret;
+
+	switch (test_info.class_function) {
+	case FT_FUNC_SENDV:
+		ft_format_iov(ft_tx.iov, ft.iov_array[ft_tx.iov_iter],
+				ft_tx.buf, ft_tx.msg_size);
+		ret = fi_tsendv(ft_tx.ep, ft_tx.iov, ft_tx.iov_desc,
+				ft.iov_array[ft_tx.iov_iter], ft_tx.addr,
+				ft_tx.tag++, NULL);
+		ft_next_iov_cnt(&ft_tx, fabric_info->tx_attr->iov_limit);
+		break;
+	case FT_FUNC_SENDMSG:
+		ft_format_iov(ft_tx.iov, ft.iov_array[ft_tx.iov_iter],
+				ft_tx.buf, ft_tx.msg_size);
+		msg.msg_iov = ft_tx.iov;
+		msg.desc = ft_tx.iov_desc;
+		msg.iov_count = ft.iov_array[ft_tx.iov_iter];
+		msg.addr = ft_tx.addr;
+		msg.tag = ft_tx.tag++;
+		msg.context = NULL;
+		msg.data = 0;
+		ret = fi_tsendmsg(ft_tx.ep, &msg, 0);
+		ft_next_iov_cnt(&ft_tx, fabric_info->tx_attr->iov_limit);
+		break;
+	default:
+		ret = fi_tsend(ft_tx.ep, ft_tx.buf, ft_tx.msg_size,
+				ft_tx.memdesc, ft_tx.addr, ft_tx.tag++, NULL);
+		break;
+	}
+	return ret;
+}
+
+int ft_post_recv_bufs(void)
+{
+	int ret;
+
+	for (; ft_rx.credits; ft_rx.credits--) {
+		ret = (test_info.caps & FI_TAGGED) ?
+			ft_post_trecv() : ft_post_recv();
+		if (ret) {
+			if (ret == -FI_EAGAIN)
+				break;
+			FI_PRINTERR("recv", ret);
+			return ret;
+		}
+	}
+	return 0;
+}
+
+int ft_recv_msg(void)
+{
+	int credits, ret;
+
+	if (ft_rx.credits > (ft_rx.max_credits >> 1)) {
+		ret = ft_post_recv_bufs();
+		if (ret)
+			return ret;
+	}
+
+	credits = ft_rx.credits;
+	do {
+		ret = ft_comp_rx();
+		if (ret)
+			return ret;
+	} while (credits == ft_rx.credits);
+
+	return 0;
+}
+
+int ft_send_msg(void)
+{
+	int ret;
+
+	while (!ft_tx.credits) {
+		ret = ft_comp_tx();
+		if (ret)
+			return ret;
+	}
+
+	ft_tx.credits--;
+	ret = (test_info.caps & FI_MSG) ?
+		ft_post_send() : ft_post_tsend();
+	if (ret) {
+		FI_PRINTERR("send", ret);
+		return ret;
+	}
+
+	if (!ft_tx.credits) {
+		ret = ft_comp_tx();
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+int ft_recv_dgram(void)
+{
+	struct timespec s, e;
+	int credits, ret;
+	int64_t poll_time = 0;
+
+	if (ft_rx.credits > (ft_rx.max_credits >> 1)) {
+		ret = ft_post_recv_bufs();
+		if (ret)
+			return ret;
+	}
+
+	credits = ft_rx.credits;
+	do {
+		ret = ft_comp_rx();
+		if ((credits != ft_rx.credits) || ret)
+			return ret;
+
+		if (!poll_time)
+			clock_gettime(CLOCK_MONOTONIC, &s);
+
+		clock_gettime(CLOCK_MONOTONIC,&e);
+		poll_time = get_elapsed(&s, &e, MILLI);
+
+	} while (poll_time < 1);
+
+	return -FI_ETIMEDOUT;
+}
+
+int ft_sendrecv_dgram(void)
+{
+	int ret, try;
+
+	for (try = 0; try < 1000; try++) {
+		ret = ft_send_msg();
+		if (ret)
+			return ret;
+
+		ret = ft_recv_dgram();
+		if (ret != -FI_ETIMEDOUT)
+			break;
+
+		/* resend last tag */
+		if (test_info.caps & FI_TAGGED)
+			ft_tx.tag--;
+	}
+
+	return ret;
+}

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "fabtest.h"
+
+static struct timespec start, end;
+
+
+#define FT_CLOSE_FID(fd) \
+	do { \
+		if (fd) { \
+			fi_close(&fd->fid); \
+			fd = NULL; \
+		} \
+	} while (0)
+
+
+void ft_record_error(int error)
+{
+	if (!ft.error) {
+		fprintf(stderr, "ERROR [%s], continuing with test",
+			fi_strerror(error));
+		ft.error = error;
+	}
+}
+
+static int ft_init_xcontrol(struct ft_xcontrol *ctrl)
+{
+	memset(ctrl, 0, sizeof *ctrl);
+	ctrl->credits = FT_DEFAULT_CREDITS;
+	ctrl->max_credits =  FT_DEFAULT_CREDITS;
+	ft_rx.comp_wait = FI_WAIT_NONE;
+
+	ctrl->iov = calloc(ft.iov_array[ft.iov_cnt - 1], sizeof *ctrl->iov);
+	ctrl->iov_desc = calloc(ft.iov_array[ft.iov_cnt - 1],
+				sizeof *ctrl->iov_desc);
+	if (!ctrl->iov || !ctrl->iov_desc)
+		return -FI_ENOMEM;
+
+	return 0;
+}
+
+static int ft_init_rx_control(void)
+{
+	int ret;
+
+	ret= ft_init_xcontrol(&ft_rx);
+	if (ret)
+		return ret;
+
+	ft_rx.cq_format = FI_CQ_FORMAT_MSG;
+	ft_rx.addr = FI_ADDR_UNSPEC;
+
+	ft_rx.msg_size = med_size_array[med_size_cnt - 1];
+	if (fabric_info && fabric_info->ep_attr &&
+	    fabric_info->ep_attr->max_msg_size &&
+	    fabric_info->ep_attr->max_msg_size < ft_rx.msg_size)
+		ft_rx.msg_size = fabric_info->ep_attr->max_msg_size;
+
+	return 0;
+}
+
+static int ft_init_tx_control(void)
+{
+	int ret;
+
+	ret = ft_init_xcontrol(&ft_tx);
+	if (ret)
+		return ret;
+
+	ft_tx.cq_format = FI_CQ_FORMAT_CONTEXT;
+	return 0;
+}
+
+static int ft_init_control(void)
+{
+	int ret;
+
+	memset(&ft, 0, sizeof ft);
+	ft.xfer_iter = FT_DEFAULT_CREDITS;
+	ft.inc_step = test_info.test_flags & FT_FLAG_QUICKTEST ? 4 : 1;
+
+	ft.iov_array = sm_size_array;
+	ft.iov_cnt = sm_size_cnt;
+
+	if (test_info.caps & FI_INJECT) {
+		ft.size_array = sm_size_array;
+		ft.size_cnt = sm_size_cnt;
+	} else if (test_info.caps & FI_RMA) {
+		ft.size_array = lg_size_array;
+		ft.size_cnt = lg_size_cnt;
+	} else {
+		ft.size_array = med_size_array;
+		ft.size_cnt = med_size_cnt;
+	}
+
+	ret = ft_init_rx_control();
+	if (!ret)
+		ret = ft_init_tx_control();
+	return ret;
+}
+
+static void ft_cleanup_xcontrol(struct ft_xcontrol *ctrl)
+{
+	FT_CLOSE_FID(ctrl->mr);
+	free(ctrl->buf);
+	free(ctrl->iov);
+	free(ctrl->iov_desc);
+	memset(ctrl, 0, sizeof *ctrl);
+}
+
+void ft_format_iov(struct iovec *iov, size_t cnt, char *buf, size_t len)
+{
+	size_t offset;
+	int i;
+
+	for (i = 0, offset = 0; i < cnt - 1; i++) {
+		iov[i].iov_base = buf + offset;
+		iov[i].iov_len = len / cnt;
+		offset += iov[i].iov_len;
+	}
+	iov[i].iov_base = buf + offset;
+	iov[i].iov_len = len - offset;
+}
+
+void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt)
+{
+	ctrl->iov_iter++;
+	if (ctrl->iov_iter > ft.iov_cnt ||
+	    ft.iov_array[ctrl->iov_iter] > max_iov_cnt)
+		ctrl->iov_iter = 0;
+}
+
+static int ft_sync_test(int value)
+{
+	int ret, result = -FI_EOTHER;
+
+	ret = ft_reset_ep();
+	if (ret)
+		return ret;
+
+	if (listen_sock < 0) {
+		ft_fw_send(sock, &value,  sizeof value);
+		ft_fw_recv(sock, &result, sizeof result);
+	} else {
+		ft_fw_recv(sock, &result, sizeof result);
+		ft_fw_send(sock, &value,  sizeof value);
+	}
+
+	return result;
+}
+
+static int ft_pingpong(void)
+{
+	int ret, i;
+
+	// TODO: current flow will not handle manual progress mode
+	// it can get stuck with both sides receiving
+	if (listen_sock < 0) {
+		for (i = 0; i < ft.xfer_iter; i++) {
+			ret = ft_send_msg();
+			if (ret)
+				return ret;
+
+			ret = ft_recv_msg();
+			if (ret)
+				return ret;
+		}
+	} else {
+		for (i = 0; i < ft.xfer_iter; i++) {
+			ret = ft_recv_msg();
+			if (ret)
+				return ret;
+
+			ret = ft_send_msg();
+			if (ret)
+				return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int ft_pingpong_dgram(void)
+{
+	int ret, i;
+
+	if (listen_sock < 0) {
+		for (i = 0; i < ft.xfer_iter; i++) {
+			ret = ft_sendrecv_dgram();
+			if (ret)
+				return ret;
+		}
+	} else {
+		ret = ft_recv_dgram();
+		if (ret)
+			return ret;
+
+		for (i = 0; i < ft.xfer_iter - 1; i++) {
+			ret = ft_sendrecv_dgram();
+			if (ret)
+				return ret;
+		}
+
+		ret = ft_send_msg();
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int ft_run_latency(void)
+{
+	int ret, i;
+
+	for (i = 0; i < ft.size_cnt; i += ft.inc_step) {
+		ft_tx.msg_size = ft.size_array[i];
+		if (ft_tx.msg_size > fabric_info->ep_attr->max_msg_size)
+			break;
+
+		ft.xfer_iter = size_to_count(ft_tx.msg_size);
+		if (test_info.test_flags & FT_FLAG_QUICKTEST)
+			ft.xfer_iter >>= 2;
+
+		ret = ft_sync_test(0);
+		if (ret)
+			return ret;
+
+		clock_gettime(CLOCK_MONOTONIC, &start);
+		ret = (test_info.ep_type == FI_EP_DGRAM) ?
+			ft_pingpong_dgram() : ft_pingpong();
+		clock_gettime(CLOCK_MONOTONIC, &end);
+		if (ret)
+			return ret;
+
+		show_perf("lat", ft_tx.msg_size, ft.xfer_iter, &start, &end, 2);
+	}
+
+	return 0;
+}
+
+static void ft_cleanup(void)
+{
+	FT_CLOSE_FID(ep);
+	FT_CLOSE_FID(pep);
+	FT_CLOSE_FID(rxcq);
+	FT_CLOSE_FID(txcq);
+	FT_CLOSE_FID(av);
+	FT_CLOSE_FID(eq);
+	FT_CLOSE_FID(domain);
+	FT_CLOSE_FID(fabric);
+	ft_cleanup_xcontrol(&ft_rx);
+	ft_cleanup_xcontrol(&ft_tx);
+	memset(&ft, 0, sizeof ft);
+}
+
+int ft_run_test()
+{
+	int ret;
+
+	ret = ft_init_control();
+	if (ret)
+		return ret;
+
+	ret = ft_open_control();
+	if (ret)
+		return ret;
+
+	if (test_info.ep_type == FI_EP_MSG && listen_sock >= 0)
+		ret = ft_open_passive();
+	else
+		ret = ft_open_active();
+	if (ret)
+		return ret;
+
+	ret = ft_enable_comm();
+	if (ret)
+		return ret;
+
+	switch (test_info.test_type) {
+	case FT_TEST_LATENCY:
+		ret = ft_run_latency();
+		break;
+	default:
+		ret = -FI_ENOSYS;
+		break;
+	}
+
+	ft_cleanup();
+
+	return ret ? ret : -ft.error;
+}


### PR DESCRIPTION
Introduce a new test that will be used as a framework
to provide full coverage of the libfabric API.

The test will run as either a persistent service or
single run client app.  The client will read in a test
configuration (currently hard-coded), connect to the
server, and communicate the test parameters to the server.

The client and server will then execute the test, with
the server reporting back the results to the client.
Communication of test data is communicated over standard
TCP sockets.

The framework will be expanded to run multiple tests,
iterating over multiple variables.  It may also be
expanded to run tests using multiple threads and/or
forked processes.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>
---
The test currently supports the msg and tagged interfaces over all 3 endpoint types.  It's far from done, but there's enough there to start running the tests and building on the framework.