### PR TITLE
Replaced FI_* macros with FT_* macros

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -77,7 +77,7 @@ static int getaddr(char *node, char *service, void **addr,
 
 	ret = getaddrinfo(node, service, NULL, &ai);
 	if (ret) {
-		FI_DEBUG("getaddrfino error %s\n", gai_strerror(ret));
+		FT_DEBUG("getaddrfino error %s\n", gai_strerror(ret));
 		return ret;
 	}
 
@@ -85,7 +85,7 @@ static int getaddr(char *node, char *service, void **addr,
 		memcpy(*addr, ai->ai_addr, ai->ai_addrlen);
 		*len = (size_t)ai->ai_addrlen;
 	} else {
-		FI_DEBUG("src_addr allocation failed\n");
+		FT_DEBUG("src_addr allocation failed\n");
 		ret = EAI_MEMORY;
 	}
 
@@ -103,12 +103,12 @@ int ft_getdestaddr(char *node, char *service, struct fi_info *hints)
 	return getaddr(node, service, &hints->dest_addr, &hints->dest_addrlen);
 }
 
-char *size_str(char str[FI_STR_LEN], long long size)
+char *size_str(char str[FT_STR_LEN], long long size)
 {
 	long long base, fraction = 0;
 	char mag;
 
-	memset(str, '\0', FI_STR_LEN);
+	memset(str, '\0', FT_STR_LEN);
 
 	if (size >= (1 << 30)) {
 		base = 1 << 30;
@@ -128,23 +128,23 @@ char *size_str(char str[FI_STR_LEN], long long size)
 		fraction = (size % base) * 10 / base;
 
 	if (fraction)
-		snprintf(str, FI_STR_LEN, "%lld.%lld%c", size / base, fraction, mag);
+		snprintf(str, FT_STR_LEN, "%lld.%lld%c", size / base, fraction, mag);
 	else
-		snprintf(str, FI_STR_LEN, "%lld%c", size / base, mag);
+		snprintf(str, FT_STR_LEN, "%lld%c", size / base, mag);
 
 	return str;
 }
 
-char *cnt_str(char str[FI_STR_LEN], long long cnt)
+char *cnt_str(char str[FT_STR_LEN], long long cnt)
 {
 	if (cnt >= 1000000000)
-		snprintf(str, FI_STR_LEN, "%lldb", cnt / 1000000000);
+		snprintf(str, FT_STR_LEN, "%lldb", cnt / 1000000000);
 	else if (cnt >= 1000000)
-		snprintf(str, FI_STR_LEN, "%lldm", cnt / 1000000);
+		snprintf(str, FT_STR_LEN, "%lldm", cnt / 1000000);
 	else if (cnt >= 1000)
-		snprintf(str, FI_STR_LEN, "%lldk", cnt / 1000);
+		snprintf(str, FT_STR_LEN, "%lldk", cnt / 1000);
 	else
-		snprintf(str, FI_STR_LEN, "%lld", cnt);
+		snprintf(str, FT_STR_LEN, "%lld", cnt);
 
 	return str;
 }
@@ -164,7 +164,7 @@ int size_to_count(int size)
 void init_test(int size, char *test_name, size_t test_name_len,
 	int *transfer_size, int *iterations)
 {
-	char sstr[FI_STR_LEN];
+	char sstr[FT_STR_LEN];
 
 	size_str(sstr, size);
 	snprintf(test_name, test_name_len, "%s_lat", sstr);
@@ -185,7 +185,7 @@ int wait_for_completion(struct fid_cq *cq, int num_completions)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(cq, "cq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -201,10 +201,10 @@ void cq_readerr(struct fid_cq *cq, char *cq_str)
 
 	ret = fi_cq_readerr(cq, &cq_err, 0);
 	if (ret < 0)
-		FI_PRINTERR("fi_cq_readerr", ret);
+		FT_PRINTERR("fi_cq_readerr", ret);
 
 	err_str = fi_cq_strerror(cq, cq_err.prov_errno, cq_err.err_data, NULL, 0);
-	FI_DEBUG("%s %s (%d)\n", cq_str, err_str, cq_err.prov_errno);
+	FT_DEBUG("%s %s (%d)\n", cq_str, err_str, cq_err.prov_errno);
 }
 
 int64_t get_elapsed(const struct timespec *b, const struct timespec *a,
@@ -221,7 +221,7 @@ void show_perf(char *name, int tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter)
 {
 	static int header = 1;
-	char str[FI_STR_LEN];
+	char str[FT_STR_LEN];
 	int64_t elapsed = get_elapsed(start, end, MICRO);
 	long long bytes = (long long) iters * tsize * xfers_per_iter;
 

--- a/complex/fabtest.c
+++ b/complex/fabtest.c
@@ -335,7 +335,7 @@ static int ft_fw_server(void)
 				 ft_strptr(test_info.service), FI_SOURCE,
 				 &hints, &info);
 		if (ret) {
-			FI_PRINTERR("fi_getinfo", ret);
+			FT_PRINTERR("fi_getinfo", ret);
 		} else {
 			if (info->next) {
 				printf("fi_getinfo returned multiple matches\n");
@@ -417,7 +417,7 @@ static int ft_fw_client(void)
 		ret = fi_getinfo(FT_VERSION, ft_strptr(test_info.node),
 				 ft_strptr(test_info.service), 0, &hints, &info);
 		if (ret) {
-			FI_PRINTERR("fi_getinfo", ret);
+			FT_PRINTERR("fi_getinfo", ret);
 		} else {
 			ret = ft_fw_process_list(&hints, info);
 			fi_freeinfo(info);

--- a/complex/ft_comm.c
+++ b/complex/ft_comm.c
@@ -51,7 +51,7 @@ static int ft_accept(void)
 
 	ret = fi_accept(ep, NULL, 0);
 	if (ret) {
-		FI_PRINTERR("fi_accept", ret);
+		FT_PRINTERR("fi_accept", ret);
 		return ret;
 	}
 
@@ -72,7 +72,7 @@ static int ft_connect(void)
 
 	ret = fi_connect(ep, fabric_info->dest_addr, NULL, 0);
 	if (ret) {
-		FI_PRINTERR("fi_connect", ret);
+		FT_PRINTERR("fi_connect", ret);
 		return ret;
 	}
 
@@ -93,7 +93,7 @@ static int ft_load_av(void)
 	len = sizeof(msg.data);
 	ret = fi_getname(&ep->fid, msg.data, &len);
 	if (ret) {
-		FI_PRINTERR("fi_getname", ret);
+		FT_PRINTERR("fi_getname", ret);
 		return ret;
 	}
 
@@ -108,7 +108,7 @@ static int ft_load_av(void)
 
 	ret = fi_av_insert(av, msg.data, 1, &ft_tx.addr, 0, NULL);
 	if (ret != 1) {
-		FI_PRINTERR("fi_av_insert", ret);
+		FT_PRINTERR("fi_av_insert", ret);
 		return ret;
 	}
 

--- a/complex/ft_comp.c
+++ b/complex/ft_comp.c
@@ -65,7 +65,7 @@ static int ft_open_cqs(void)
 
 		ret = fi_cq_open(domain, &attr, &txcq, NULL);
 		if (ret) {
-			FI_PRINTERR("fi_cq_open", ret);
+			FT_PRINTERR("fi_cq_open", ret);
 			return ret;
 		}
 	}
@@ -78,7 +78,7 @@ static int ft_open_cqs(void)
 
 		ret = fi_cq_open(domain, &attr, &rxcq, NULL);
 		if (ret) {
-			FI_PRINTERR("fi_cq_open", ret);
+			FT_PRINTERR("fi_cq_open", ret);
 			return ret;
 		}
 	}
@@ -103,7 +103,7 @@ int ft_bind_comp(struct fid_ep *ep, uint64_t flags)
 	if (flags & FI_SEND) {
 		ret = fi_ep_bind(ep, &txcq->fid, flags & ~FI_RECV);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 	}
@@ -111,7 +111,7 @@ int ft_bind_comp(struct fid_ep *ep, uint64_t flags)
 	if (flags & FI_RECV) {
 		ret = fi_ep_bind(ep, &rxcq->fid, flags & ~FI_SEND);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 	}
@@ -149,7 +149,7 @@ int ft_comp_rx(void)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rxcq, "rxcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		} else if (ret) {
@@ -175,7 +175,7 @@ int ft_comp_tx(void)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(txcq, "txcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		} else if (ret) {

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -53,7 +53,7 @@ static int ft_open_fabric(void)
 
 	ret = fi_fabric(fabric_info->fabric_attr, &fabric, NULL);
 	if (ret)
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 
 	return ret;
 }
@@ -70,7 +70,7 @@ static int ft_open_eq(void)
 	attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fabric, &attr, &eq, NULL);
 	if (ret)
-		FI_PRINTERR("fi_eq_open", ret);
+		FT_PRINTERR("fi_eq_open", ret);
 
 	return ret;
 }
@@ -82,7 +82,7 @@ int ft_eq_readerr(void)
 
 	ret = fi_eq_readerr(eq, &err, 0);
 	if (ret != sizeof(err)) {
-		FI_PRINTERR("fi_eq_readerr", ret);
+		FT_PRINTERR("fi_eq_readerr", ret);
 		return ret;
 	} else {
 		fprintf(stderr, "Error event %d %s\n",
@@ -100,7 +100,7 @@ ssize_t ft_get_event(uint32_t *event, void *buf, size_t len,
 	if (ret == -FI_EAVAIL) {
 		return ft_eq_readerr();
 	} else if (ret < 0) {
-		FI_PRINTERR("fi_eq_sread", ret);
+		FT_PRINTERR("fi_eq_sread", ret);
 		return ret;
 	}
 
@@ -134,7 +134,7 @@ static int ft_open_domain(void)
 
 	ret = fi_domain(fabric, fabric_info, &domain, NULL);
 	if (ret)
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 
 	return ret;
 }
@@ -152,7 +152,7 @@ static int ft_open_av(void)
 	attr.count = 2;
 	ret = fi_av_open(domain, &attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		return ret;
 	}
 
@@ -175,7 +175,7 @@ static int ft_setup_xcontrol_bufs(struct ft_xcontrol *ctrl)
 		ret = fi_mr_reg(domain, ctrl->buf, size,
 				0, 0, 0, 0, &ctrl->mr, NULL);
 		if (ret) {
-			FI_PRINTERR("fi_mr_reg", ret);
+			FT_PRINTERR("fi_mr_reg", ret);
 			return ret;
 		}
 		ctrl->memdesc = fi_mr_desc(ctrl->mr);

--- a/complex/ft_endpoint.c
+++ b/complex/ft_endpoint.c
@@ -51,19 +51,19 @@ int ft_open_passive(void)
 
 	ret = fi_passive_ep(fabric, fabric_info, &pep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_passive_ep", ret);
+		FT_PRINTERR("fi_passive_ep", ret);
 		return ret;
 	}
 
 	ret = fi_pep_bind(pep, &eq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_pep_bind", ret);
+		FT_PRINTERR("fi_pep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_listen(pep);
 	if (ret) {
-		FI_PRINTERR("fi_listen", ret);
+		FT_PRINTERR("fi_listen", ret);
 		return ret;
 	}
 
@@ -87,7 +87,7 @@ int ft_open_active(void)
 
 	ret = fi_endpoint(domain, fabric_info, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		return ret;
 	}
 
@@ -96,7 +96,7 @@ int ft_open_active(void)
 
 	ret = fi_ep_bind(ep, &eq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -107,14 +107,14 @@ int ft_open_active(void)
 	if (test_info.ep_type != FI_EP_MSG) {
 		ret = fi_ep_bind(ep, &av->fid, 0);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -181,7 +181,7 @@ int ft_post_recv_bufs(void)
 		if (ret) {
 			if (ret == -FI_EAGAIN)
 				break;
-			FI_PRINTERR("recv", ret);
+			FT_PRINTERR("recv", ret);
 			return ret;
 		}
 	}
@@ -222,7 +222,7 @@ int ft_send_msg(void)
 	ret = (test_info.caps & FI_MSG) ?
 		ft_post_send() : ft_post_tsend();
 	if (ret) {
-		FI_PRINTERR("send", ret);
+		FT_PRINTERR("send", ret);
 		return ret;
 	}
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -89,12 +89,12 @@ void ft_csusage(char *name, char *desc);
 extern struct test_size_param test_size[];
 const unsigned int test_cnt;
 #define TEST_CNT test_cnt
-#define FI_STR_LEN 32
+#define FT_STR_LEN 32
 
 int ft_getsrcaddr(char *node, char *service, struct fi_info *hints);
 int ft_getdestaddr(char *node, char *service, struct fi_info *hints);
-char *size_str(char str[FI_STR_LEN], long long size);
-char *cnt_str(char str[FI_STR_LEN], long long cnt);
+char *size_str(char str[FT_STR_LEN], long long size);
+char *cnt_str(char str[FT_STR_LEN], long long cnt);
 int size_to_count(int size);
 void init_test(int size, char *test_name, size_t test_name_len,
 		int *transfer_size, int *iterations);
@@ -107,10 +107,10 @@ void show_perf(char *name, int tsize, int iters, struct timespec *start,
 void show_perf_mr(int tsize, int iters, struct timespec *start, 
 		struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
 
-#define FI_PRINTERR(call, retv) \
+#define FT_PRINTERR(call, retv) \
 	do { fprintf(stderr, call "(): %d, %d (%s)\n", __LINE__, (int) retv, fi_strerror((int) -retv)); } while (0)
 
-#define FI_DEBUG(fmt, ...) \
+#define FT_DEBUG(fmt, ...) \
 	do { fprintf(stderr, "%s:%d: " fmt, __FILE__, __LINE__, ##__VA_ARGS__); } while (0)
 
 #define MIN(a,b) (((a)<(b))?(a):(b))

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -107,21 +107,21 @@ static int alloc_ep_res(void)
 	/* Open completion queue for send completions */
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	/* Register memory */
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -133,7 +133,7 @@ static int alloc_ep_res(void)
 	/* Open address vector (AV) for mapping address */
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		 goto err4;
 	 }
 
@@ -157,26 +157,26 @@ static int bind_ep_res(void)
 	/* Bind Send CQ with endpoint to collect send completions */
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	/* Bind Recv CQ with endpoint to collect recv completions */
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	
 	/* Bind AV with the endpoint to map addresses */
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	 }
 
@@ -197,7 +197,7 @@ static int init_fabric(void)
 	/* Get fabric info */
 	ret = fi_getinfo(FT_FIVERSION, dst_addr, port, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
 	
@@ -211,21 +211,21 @@ static int init_fabric(void)
 	/* Open fabric */
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	/* Open domain */
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
 	/* Open endpoint */
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err3;
 	}
 
@@ -244,7 +244,7 @@ static int init_fabric(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 	}
@@ -278,7 +278,7 @@ static int send_recv()
 		ret = fi_send(ep, buf, sizeof("Hello from Client!"), 
 				fi_mr_desc(mr), remote_fi_addr, &fi_ctx_send);
 		if (ret) {
-			FI_PRINTERR("fi_send", ret);
+			FT_PRINTERR("fi_send", ret);
 			return ret;
 		}
 
@@ -286,7 +286,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);
@@ -298,7 +298,7 @@ static int send_recv()
 		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, 
 				&fi_ctx_recv);
 		if (ret) {
-			FI_PRINTERR("fi_recv", ret);
+			FT_PRINTERR("fi_recv", ret);
 			return ret;
 		}
 
@@ -307,7 +307,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -115,7 +115,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	wait_attr.wait_obj = FI_WAIT_UNSPEC;
 	ret = fi_wait_open(fab, &wait_attr, &waitset);
 	if (ret) {
-		FI_PRINTERR("fi_wait_open", ret);
+		FT_PRINTERR("fi_wait_open", ret);
 		goto err1;
 	}
 
@@ -129,21 +129,21 @@ static int alloc_ep_res(struct fi_info *fi)
 	/* Open completion queue for send completions */
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	/* Open completion queue for recv completions */
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
 	
 	/* Register memory */
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err4;
 	}
 
@@ -155,7 +155,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	/* Open Address Vector */
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err5;
 	}
 
@@ -181,25 +181,25 @@ static int bind_ep_res(void)
 	/* Bind AV and CQs with endpoint */
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -213,7 +213,7 @@ static int send_msg(int size)
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 
@@ -228,7 +228,7 @@ static int recv_msg(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 
@@ -258,7 +258,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -271,19 +271,19 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
@@ -321,21 +321,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -363,7 +363,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -385,7 +385,7 @@ static int send_recv()
 	ret = fi_recv(ep, buf, transfer_size, fi_mr_desc(mr),
 			remote_fi_addr, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 	recv_pending++;
@@ -394,7 +394,7 @@ static int send_recv()
 	ret = fi_send(ep, buf, transfer_size, fi_mr_desc(mr),
 			remote_fi_addr, &fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 	send_pending++;
@@ -403,7 +403,7 @@ static int send_recv()
 		/* Wait for completion events on CQs */
 		ret = fi_wait(waitset, WAIT_TIMEOUT);
 		if (ret < 0) {
-			FI_PRINTERR("fi_wait", ret);
+			FT_PRINTERR("fi_wait", ret);
 			return ret;
 		}
 		
@@ -416,7 +416,7 @@ static int send_recv()
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			
 			return ret;
@@ -431,7 +431,7 @@ static int send_recv()
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 
 			return ret;

--- a/simple/imm_data.c
+++ b/simple/imm_data.c
@@ -91,7 +91,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		FI_PRINTERR("fi_eq_open", ret);
+		FT_PRINTERR("fi_eq_open", ret);
 
 	return ret;
 }
@@ -122,20 +122,20 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -164,19 +164,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -186,7 +186,7 @@ static int bind_ep_res(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -199,7 +199,7 @@ static int server_listen(void)
 	ret = fi_getinfo(FT_FIVERSION, src_addr, src_port, FI_SOURCE, &hints,
 			&fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -207,13 +207,13 @@ static int server_listen(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_passive_ep(fab, fi, &pep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_passive_ep", ret);
+		FT_PRINTERR("fi_passive_ep", ret);
 		goto err1;
 	}
 
@@ -223,13 +223,13 @@ static int server_listen(void)
 
 	ret = fi_pep_bind(pep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_pep_bind", ret);
+		FT_PRINTERR("fi_pep_bind", ret);
 		goto err3;
 	}
 
 	ret = fi_listen(pep);
 	if (ret) {
-		FI_PRINTERR("fi_listen", ret);
+		FT_PRINTERR("fi_listen", ret);
 		goto err3;
 	}
 
@@ -256,12 +256,12 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FT_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
 	if (event != FI_CONNREQ) {
-		FI_DEBUG("Unexpected CM event %d\n", event);
+		FT_DEBUG("Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err1;
 	}
@@ -269,13 +269,13 @@ static int server_connect(void)
 	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err1;
 	}
 
@@ -289,18 +289,18 @@ static int server_connect(void)
 
 	ret = fi_accept(ep, NULL, 0);
 	if (ret) {
-		FI_PRINTERR("fi_accept", ret);
+		FT_PRINTERR("fi_accept", ret);
 		goto err3;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FT_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		goto err3;
 	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
-		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
+		FT_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
 			event, entry.fid, ep);
 		ret = -FI_EOTHER;
 		goto err3;
@@ -333,7 +333,7 @@ static int client_connect(void)
 
 	ret = fi_getinfo(FT_FIVERSION, dst_addr, dst_port, 0, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
 
@@ -341,19 +341,19 @@ static int client_connect(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err3;
 	}
 
@@ -367,18 +367,18 @@ static int client_connect(void)
 
 	ret = fi_connect(ep, fi->dest_addr, NULL, 0);
 	if (ret) {
-		FI_PRINTERR("fi_connect", ret);
+		FT_PRINTERR("fi_connect", ret);
 		goto err5;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FT_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
-		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
+		FT_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
 			event, entry.fid, ep);
 		ret = -FI_EOTHER;
 		goto err5;
@@ -422,7 +422,7 @@ static int run_test()
 		ret = fi_senddata(ep, buf, size, fi_mr_desc(mr), remote_cq_data,
 				0, buf);
 		if (ret) {
-			FI_PRINTERR("fi_send", ret);
+			FT_PRINTERR("fi_send", ret);
 			return ret;
 		}
 
@@ -431,7 +431,7 @@ static int run_test()
 	} else {
 		ret = fi_recv(ep, buf, size, fi_mr_desc(mr), 0, buf);
 		if (ret) {
-			FI_PRINTERR("fi_recv", ret);
+			FT_PRINTERR("fi_recv", ret);
 			return ret;
 		}
 
@@ -441,7 +441,7 @@ static int run_test()
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}

--- a/simple/info.c
+++ b/simple/info.c
@@ -167,7 +167,7 @@ static int run(struct fi_info *hints, char *node, char *port)
 
 	ret = fi_getinfo(FT_FIVERSION, node, port, 0, hints, &info);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -72,7 +72,7 @@ static int send_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -82,7 +82,7 @@ static int send_xfer(int size)
 post:
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), 0, NULL);
 	if (ret)
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 
 	return ret;
 }
@@ -98,7 +98,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -106,7 +106,7 @@ static int recv_xfer(int size)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -173,7 +173,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		FI_PRINTERR("fi_eq_open", ret);
+		FT_PRINTERR("fi_eq_open", ret);
 
 	return ret;
 }
@@ -204,19 +204,19 @@ static int alloc_ep_res(void)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -245,19 +245,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -267,7 +267,7 @@ static int bind_ep_res(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -280,19 +280,19 @@ static int server_listen(void)
 	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.src_port, FI_SOURCE,
 			&hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_passive_ep(fab, fi, &pep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_passive_ep", ret);
+		FT_PRINTERR("fi_passive_ep", ret);
 		goto err1;
 	}
 
@@ -302,13 +302,13 @@ static int server_listen(void)
 
 	ret = fi_pep_bind(pep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_pep_bind", ret);
+		FT_PRINTERR("fi_pep_bind", ret);
 		goto err3;
 	}
 
 	ret = fi_listen(pep);
 	if (ret) {
-		FI_PRINTERR("fi_listen", ret);
+		FT_PRINTERR("fi_listen", ret);
 		goto err3;
 	}
 
@@ -335,12 +335,12 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FT_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
 	if (event != FI_CONNREQ) {
-		FI_DEBUG("Unexpected CM event %d\n", event);
+		FT_DEBUG("Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err1;
 	}
@@ -348,13 +348,13 @@ static int server_connect(void)
 	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err1;
 	}
 
@@ -368,18 +368,18 @@ static int server_connect(void)
 
 	ret = fi_accept(ep, NULL, 0);
 	if (ret) {
-		FI_PRINTERR("fi_accept", ret);
+		FT_PRINTERR("fi_accept", ret);
 		goto err3;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FT_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		goto err3;
 	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
-		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
+		FT_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
 			event, entry.fid, ep);
 		ret = -FI_EOTHER;
 		goto err3;
@@ -415,25 +415,25 @@ static int client_connect(void)
 
 	ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, opts.dst_port, 0, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err3;
 	}
 
@@ -447,7 +447,7 @@ static int client_connect(void)
 
 	ret = fi_connect(ep, fi->dest_addr, NULL, 0);
 	if (ret) {
-		FI_PRINTERR("fi_connect", ret);
+		FT_PRINTERR("fi_connect", ret);
 		goto err5;
 	}
 
@@ -456,19 +456,19 @@ static int client_connect(void)
 		if (rd == -FI_EAVAIL) {
 			rd = fi_eq_readerr(cmeq, &err, 0);
 			if (rd != sizeof(err)) {
-				FI_DEBUG("fi_eq_readerr() %zd %s\n", rd, fi_strerror((int) -rd));
+				FT_DEBUG("fi_eq_readerr() %zd %s\n", rd, fi_strerror((int) -rd));
 			} else {
-				FI_DEBUG("EQ report error %d %s\n", err.err,
+				FT_DEBUG("EQ report error %d %s\n", err.err,
 						fi_strerror(err.err));
 			}
 		} else {
-			FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+			FT_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		}
 		return (int) rd;
 	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
-		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
+		FT_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
 			event, entry.fid, ep);
 		ret = -FI_EOTHER;
 		goto err5;

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -73,7 +73,7 @@ static int send_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -83,7 +83,7 @@ static int send_xfer(int size)
 post:
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), 0, NULL);
 	if (ret)
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 
 	return ret;
 }
@@ -99,7 +99,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -107,7 +107,7 @@ static int recv_xfer(int size)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -119,7 +119,7 @@ static int read_data(size_t size)
 	ret = fi_read(ep, buf, size, fi_mr_desc(mr), 
 		      0, remote.addr, remote.key, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_read", ret);
+		FT_PRINTERR("fi_read", ret);
 		return ret;
 	}
 
@@ -133,7 +133,7 @@ static int write_data(size_t size)
 	ret = fi_write(ep, buf, size, fi_mr_desc(mr),  
 		       0, remote.addr, remote.key, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_write", ret);
+		FT_PRINTERR("fi_write", ret);
 		return ret;
 	}
 	return 0;
@@ -204,7 +204,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
 	if (ret)
-		FI_PRINTERR("fi_eq_open", ret);
+		FT_PRINTERR("fi_eq_open", ret);
 
 	return ret;
 }
@@ -236,20 +236,20 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
 	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)), 
 			op_type, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -278,19 +278,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -300,7 +300,7 @@ static int bind_ep_res(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -313,19 +313,19 @@ static int server_listen(void)
 	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.src_port, FI_SOURCE,
 			&hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_passive_ep(fab, fi, &pep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_passive_ep", ret);
+		FT_PRINTERR("fi_passive_ep", ret);
 		goto err1;
 	}
 
@@ -335,13 +335,13 @@ static int server_listen(void)
 
 	ret = fi_pep_bind(pep, &cmeq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_pep_bind", ret);
+		FT_PRINTERR("fi_pep_bind", ret);
 		goto err3;
 	}
 
 	ret = fi_listen(pep);
 	if (ret) {
-		FI_PRINTERR("fi_listen", ret);
+		FT_PRINTERR("fi_listen", ret);
 		goto err3;
 	}
 
@@ -368,12 +368,12 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FT_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
 	if (event != FI_CONNREQ) {
-		FI_DEBUG("Unexpected CM event %d\n", event);
+		FT_DEBUG("Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err1;
 	}
@@ -381,14 +381,14 @@ static int server_connect(void)
 	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", -ret);
+		FT_PRINTERR("fi_endpoint", -ret);
 		goto err1;
 	}
 
@@ -402,18 +402,18 @@ static int server_connect(void)
 
 	ret = fi_accept(ep, NULL, 0);
 	if (ret) {
-		FI_PRINTERR("fi_accept", ret);
+		FT_PRINTERR("fi_accept", ret);
 		goto err3;
 	}
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
  	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FT_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		goto err3;
  	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
- 		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
+ 		FT_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
 			event, entry.fid, ep);
  		ret = -FI_EOTHER;
  		goto err3;
@@ -447,25 +447,25 @@ static int client_connect(void)
 
 	ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, opts.dst_port, 0, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
  	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err3;
 	}
 
@@ -479,18 +479,18 @@ static int client_connect(void)
 
 	ret = fi_connect(ep, fi->dest_addr, NULL, 0);
 	if (ret) {
-		FI_PRINTERR("fi_connect", ret);
+		FT_PRINTERR("fi_connect", ret);
 		goto err5;
 	}
 
  	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FI_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
+		FT_DEBUG("fi_eq_sread() %zd %s\n", rd, fi_strerror((int) -rd));
 		return (int) rd;
 	}
 
  	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
- 		FI_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
+ 		FT_DEBUG("Unexpected CM event %d fid %p (ep %p)\n",
  			event, entry.fid, ep);
  		ret = -FI_EOTHER;
  		goto err1;
@@ -585,7 +585,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	opts = INIT_OPTS;
 
 	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS)) != -1) {

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -122,14 +122,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	/* Open completion queue for send completions */
 	ret = fi_cq_open(dom, &cq_attr, &scq, (void *)CQ_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
 	ret = fi_cq_open(dom, &cq_attr, &rcq, (void *)CQ_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -137,28 +137,28 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&poll_attr, 0, sizeof poll_attr);
 	ret = fi_poll_open(dom, &poll_attr, &pollset);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 	
 	/* Add send CQ to the polling set */
 	ret = fi_poll_add(pollset, &scq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_poll_add", ret);
+		FT_PRINTERR("fi_poll_add", ret);
 		goto err3;
 	}
 
 	/* Add recv CQ to the polling set */
 	ret = fi_poll_add(pollset, &rcq->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_poll_add", ret);
+		FT_PRINTERR("fi_poll_add", ret);
 		goto err3;
 	}
 
 	/* Register memory */
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err4;
 	}
 
@@ -170,7 +170,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	/* Open Address Vector */
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err5;
 	}
 
@@ -196,25 +196,25 @@ static int bind_ep_res(void)
 	/* Bind AV and CQs with endpoint */
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -228,7 +228,7 @@ static int send_msg(int size)
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 
@@ -243,7 +243,7 @@ static int recv_msg(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 
@@ -273,7 +273,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -286,19 +286,19 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
@@ -336,21 +336,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -379,7 +379,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -404,7 +404,7 @@ static int send_recv()
 	ret = fi_recv(ep, buf, transfer_size, fi_mr_desc(mr),
 			remote_fi_addr, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 	recv_pending++;
@@ -413,7 +413,7 @@ static int send_recv()
 	ret = fi_send(ep, buf, transfer_size, fi_mr_desc(mr),
 			remote_fi_addr, &fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 	send_pending++;
@@ -424,7 +424,7 @@ static int send_recv()
 		do {
 			ret_count = fi_poll(pollset, context, MAX_POLL_CNT);
 			if (ret_count < 0) {
-				FI_PRINTERR("fi_poll", ret_count);
+				FT_PRINTERR("fi_poll", ret_count);
 				return ret_count;
 			}
 		} while (!ret_count);
@@ -454,7 +454,7 @@ static int send_recv()
 				if (ret == -FI_EAVAIL) {
 					cq_readerr(cq, "cq");
 				} else {
-					FI_PRINTERR("fi_cq_sread", ret);
+					FT_PRINTERR("fi_cq_sread", ret);
 				}
 				return ret;
 			}

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -107,21 +107,21 @@ static int alloc_ep_res(void)
 	/* Open completion queue for send completions */
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	/* Register memory */
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -133,7 +133,7 @@ static int alloc_ep_res(void)
 	/* Open address vector (AV) for mapping address */
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		 goto err4;
 	 }
 
@@ -157,26 +157,26 @@ static int bind_ep_res(void)
 	/* Bind Send CQ with endpoint to collect send completions */
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	/* Bind Recv CQ with endpoint to collect recv completions */
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	
 	/* Bind AV with the endpoint to map addresses */
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	 }
 
@@ -197,7 +197,7 @@ static int init_fabric(void)
 	/* Get fabric info */
 	ret = fi_getinfo(FT_FIVERSION, dst_addr, port, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
 	
@@ -211,21 +211,21 @@ static int init_fabric(void)
 	/* Open fabric */
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	/* Open domain */
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
 	/* Open endpoint */
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err3;
 	}
 
@@ -244,7 +244,7 @@ static int init_fabric(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 	}
@@ -278,7 +278,7 @@ static int send_recv()
 		ret = fi_send(ep, buf, sizeof("Hello from Client!"), 
 				fi_mr_desc(mr), remote_fi_addr, &fi_ctx_send);
 		if (ret) {
-			FI_PRINTERR("fi_send", ret);
+			FT_PRINTERR("fi_send", ret);
 			return ret;
 		}
 
@@ -286,7 +286,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);
@@ -298,7 +298,7 @@ static int send_recv()
 		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, 
 				&fi_ctx_recv);
 		if (ret) {
-			FI_PRINTERR("fi_recv", ret);
+			FT_PRINTERR("fi_recv", ret);
 			return ret;
 		}
 
@@ -307,7 +307,7 @@ static int send_recv()
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
 			if (ret < 0) {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
 		} while (!ret);

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -128,7 +128,7 @@ static int post_recv(void)
 	
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret){
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 	
@@ -142,7 +142,7 @@ static int send_msg(int size)
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr, 
 			&fi_ctx_send);
 	if (ret)
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 
 	return wait_for_completion(scq, 1);
 }
@@ -208,7 +208,7 @@ static int execute_base_atomic_op(enum fi_op op)
 	ret = fi_atomic(ep, buf, 1, fi_mr_desc(mr), remote_fi_addr, remote.addr,
 		       	remote.key, datatype, op, &fi_ctx_atomic);
 	if (ret) {
-		FI_PRINTERR("fi_atomic", ret);
+		FT_PRINTERR("fi_atomic", ret);
 	} else {						
 		ret = wait_for_completion(scq, 1);
 	}
@@ -224,7 +224,7 @@ static int execute_fetch_atomic_op(enum fi_op op)
 			fi_mr_desc(mr_result), remote_fi_addr, remote.addr, 
 			remote.key, datatype, op, &fi_ctx_atomic);
 	if (ret) {
-		FI_PRINTERR("fi_fetch_atomic", ret);
+		FT_PRINTERR("fi_fetch_atomic", ret);
 	} else {						
 		ret = wait_for_completion(scq, 1);
 	}
@@ -241,7 +241,7 @@ static int execute_compare_atomic_op(enum fi_op op)
 			remote_fi_addr, remote.addr, remote.key, datatype, op, 
 			&fi_ctx_atomic);
 	if (ret) {
-		FI_PRINTERR("fi_compare_atomic", ret);
+		FT_PRINTERR("fi_compare_atomic", ret);
 	} else {			
 		ret = wait_for_completion(scq, 1);
 	}
@@ -396,13 +396,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = 128;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
@@ -411,7 +411,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)), 
 		FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -420,7 +420,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	ret = fi_mr_reg(dom, result, MAX(buffer_size, sizeof(uint64_t)), 
 		FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0, 0, &mr_result, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", -ret);
+		FT_PRINTERR("fi_mr_reg", -ret);
 		goto err4;
 	}
 	
@@ -428,7 +428,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	ret = fi_mr_reg(dom, compare, MAX(buffer_size, sizeof(uint64_t)), 
 		FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0, 0, &mr_compare, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err5;
 	}
 
@@ -439,7 +439,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err6;
 	}
 	
@@ -469,19 +469,19 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND | FI_READ | FI_WRITE);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", -ret);
+		FT_PRINTERR("fi_ep_bind", -ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", -ret);
+		FT_PRINTERR("fi_ep_bind", -ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -511,7 +511,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -529,24 +529,24 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
 	if (opts.dst_addr == NULL) {
-		FI_DEBUG("EP opened on fabric %s\n", fi->fabric_attr->name);
+		FT_DEBUG("EP opened on fabric %s\n", fi->fabric_attr->name);
 	}
 
 	ret = alloc_ep_res(fi);
@@ -583,21 +583,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -625,7 +625,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -74,7 +74,7 @@ static int get_send_completions()
 
 	ret = fi_cntr_wait(scntr, send_count, CNTR_TIMEOUT);
 	if (ret < 0) {
-		FI_PRINTERR("fi_cntr_wait", ret);
+		FT_PRINTERR("fi_cntr_wait", ret);
 		return ret;
 	}
 
@@ -90,7 +90,7 @@ static int send_xfer(int size)
 	if (!credits) {
 		ret = fi_cntr_wait(scntr, send_count, CNTR_TIMEOUT);
 		if (ret < 0) {
-			FI_PRINTERR("fi_cntr_wait", ret);
+			FT_PRINTERR("fi_cntr_wait", ret);
 			return ret;
 		}
 	}
@@ -99,7 +99,7 @@ static int send_xfer(int size)
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr, 
 			&fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 	send_count++;
@@ -113,14 +113,14 @@ static int recv_xfer(int size)
 
 	ret = fi_cntr_wait(rcntr, recv_outs, CNTR_TIMEOUT);
 	if (ret < 0) {
-		FI_PRINTERR("fi_cntr_wait", ret);
+		FT_PRINTERR("fi_cntr_wait", ret);
 		return ret;
 	}
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr, 
 			&fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 	recv_outs++;
 
 	return ret;
@@ -133,14 +133,14 @@ static int send_msg(int size)
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 	send_count++;
 
 	ret = fi_cntr_wait(scntr, send_count, CNTR_TIMEOUT);
 	if (ret < 0) {
-		FI_PRINTERR("fi_cntr_wait", ret);
+		FT_PRINTERR("fi_cntr_wait", ret);
 	}
 
 	return ret;
@@ -152,14 +152,14 @@ static int recv_msg(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 	recv_outs++;
 
 	ret = fi_cntr_wait(rcntr, recv_outs, CNTR_TIMEOUT);
 	if (ret < 0) {
-		FI_PRINTERR("fi_cntr_wait", ret);
+		FT_PRINTERR("fi_cntr_wait", ret);
 		return ret;
 	}
 
@@ -241,19 +241,19 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_cntr_open(dom, &cntr_attr, &scntr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cntr_open", ret);
+		FT_PRINTERR("fi_cntr_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cntr_open(dom, &cntr_attr, &rcntr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cntr_open", ret);
+		FT_PRINTERR("fi_cntr_open", ret);
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -264,7 +264,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
@@ -287,25 +287,25 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scntr->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcntr->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -333,7 +333,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -351,19 +351,19 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
@@ -401,21 +401,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -444,7 +444,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -458,7 +458,7 @@ static int init_av(void)
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 	recv_outs++;
 
 	return ret;

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -72,7 +72,7 @@ static int send_xfer(int size)
 
 	ret = fi_inject(ep, send_buf, (size_t) size, remote_fi_addr);
 	if (ret)
-		FI_PRINTERR("fi_inject", ret);
+		FT_PRINTERR("fi_inject", ret);
 
 	return ret;
 }
@@ -88,7 +88,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -97,7 +97,7 @@ static int recv_xfer(int size)
 	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -108,7 +108,7 @@ static int send_msg(int size)
 
 	ret = fi_inject(ep, send_buf, (size_t) size, remote_fi_addr);
 	if (ret) {
-		FI_PRINTERR("fi_inject", ret);
+		FT_PRINTERR("fi_inject", ret);
 		return ret;
 	}
 
@@ -121,7 +121,7 @@ static int recv_msg(void)
 
 	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 
@@ -208,13 +208,13 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
@@ -222,7 +222,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	 * fi_inject copies the buffer of data that needs to be sent. */
 	ret = fi_mr_reg(dom, recv_buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
 
@@ -233,7 +233,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
@@ -257,25 +257,25 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -303,14 +303,14 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 	
 	/* check max msg size */
 	max_inject_size = fi->ep_attr->inject_size;
 	if (opts.custom && opts.transfer_size > max_inject_size) {
-		FI_DEBUG("Msg size greater than max inject size\n");
+		FT_DEBUG("Msg size greater than max inject size\n");
 		ret = -FI_EINVAL;
 		goto err0;
 	}
@@ -329,19 +329,19 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
@@ -379,21 +379,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -422,7 +422,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -436,7 +436,7 @@ static int init_av(void)
 	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -93,7 +93,7 @@ int wait_for_send_completion(int num_completions)
 		if (ret > 0) {
 			num_completions--;
 		} else if (ret < 0) {
-			FI_PRINTERR("fi_cq_read", ret);
+			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
 	}
@@ -123,7 +123,7 @@ int wait_for_recv_completion(void **recv_data, enum data_type type,
 						remote_fi_addr, 
 						&ctx_multi_recv[buf_index].context);
 				if (ret) { 
-					FI_PRINTERR("fi_recv", ret);
+					FT_PRINTERR("fi_recv", ret);
 					return ret;
 				} 
 			} else {			
@@ -136,7 +136,7 @@ int wait_for_recv_completion(void **recv_data, enum data_type type,
 				}
 			}
 		} else if (ret < 0) {
-			FI_PRINTERR("fi_cq_read", ret);
+			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
 	}
@@ -151,7 +151,7 @@ static int send_msg(int size)
 	ret = fi_send(ep, send_buf, (size_t) size, fi_mr_desc(mr), 
 			remote_fi_addr, &ctx_send->context);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 
@@ -189,7 +189,7 @@ static int post_multi_recv_buffer()
 			   	multi_buf_size/2, fi_mr_desc(mr_multi_recv), 
 				remote_fi_addr, &ctx_multi_recv[i].context);
 		if (ret) { 
-			FI_PRINTERR("fi_recv", ret);
+			FT_PRINTERR("fi_recv", ret);
 			return ret;
 		}
 	}
@@ -209,7 +209,7 @@ static int send_multi_recv_msg()
 				fi_mr_desc(mr), remote_fi_addr, 
 				&ctx_send->context);
 		if (ret) {
-			FI_PRINTERR("fi_send", ret);
+			FT_PRINTERR("fi_send", ret);
 			return ret;
 		}
 		ret = wait_for_send_completion(1);
@@ -292,7 +292,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	
 	ret = fi_mr_reg(dom, send_buf, max_send_buf_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err1;
 	}
 	
@@ -301,7 +301,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		MULTI_BUF_SIZE_FACTOR;
 	multi_recv_buf = malloc(multi_buf_size);
 	if(!multi_recv_buf) {
-		FI_DEBUG("Cannot allocate multi_recv_buf\n");
+		FT_DEBUG("Cannot allocate multi_recv_buf\n");
 		ret = -1;
 		goto err1;
 	}
@@ -309,7 +309,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	ret = fi_mr_reg(dom, multi_recv_buf, multi_buf_size, 0, 0, 1, 0, 
 			&mr_multi_recv, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err2;
 	}
 
@@ -319,13 +319,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
 	
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err4;
 	}
 
@@ -336,7 +336,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err5;
 	}
 
@@ -374,25 +374,25 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 	
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -420,7 +420,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 	
@@ -436,19 +436,19 @@ static int init_fabric(void)
 	
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
@@ -497,21 +497,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -545,7 +545,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 		ret = 0;

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -78,7 +78,7 @@ static int send_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -89,7 +89,7 @@ post:
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_send);
 	if (ret)
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 
 	return ret;
 }
@@ -105,7 +105,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -114,7 +114,7 @@ static int recv_xfer(int size)
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -126,7 +126,7 @@ static int send_msg(int size)
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 
@@ -141,7 +141,7 @@ static int recv_msg(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 
@@ -228,19 +228,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -251,7 +251,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
@@ -274,25 +274,25 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -320,7 +320,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -338,24 +338,24 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
 	if (opts.dst_addr == NULL) {
-		FI_DEBUG("EP opened on fabric %s\n", fi->fabric_attr->name);
+		FT_DEBUG("EP opened on fabric %s\n", fi->fabric_attr->name);
 	}
 
 	ret = alloc_ep_res(fi);
@@ -392,21 +392,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -435,7 +435,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -449,7 +449,7 @@ static int init_av(void)
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -74,7 +74,7 @@ static int send_msg(int size)
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 
@@ -89,7 +89,7 @@ static int recv_msg(void)
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 
@@ -105,7 +105,7 @@ static int read_data(size_t size)
 	ret = fi_read(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 
 		      remote.addr, remote.key, &fi_ctx_read);
 	if (ret){
-		FI_PRINTERR("fi_read", ret);
+		FT_PRINTERR("fi_read", ret);
 		return ret;
 	}
 
@@ -119,7 +119,7 @@ static int write_data(size_t size)
 	ret = fi_write(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 
 		       remote.addr, remote.key, &fi_ctx_write);
 	if (ret){
-		FI_PRINTERR("fi_write", ret);
+		FT_PRINTERR("fi_write", ret);
 		return ret;
 	}
 	return 0;
@@ -197,20 +197,20 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
 	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)), 
 			op_type, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -221,7 +221,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
@@ -244,25 +244,25 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -290,7 +290,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -306,19 +306,19 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
@@ -356,21 +356,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -400,7 +400,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -92,7 +92,7 @@ static int write_data(size_t size)
 	ret = fi_write(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 0, 
 			user_defined_key, &fi_ctx_write);
 	if (ret){
-		FI_PRINTERR("fi_write", ret);
+		FT_PRINTERR("fi_write", ret);
 		return ret;
 	}
 	return 0;
@@ -128,13 +128,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = 512;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
@@ -144,7 +144,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	ret = fi_mr_reg(dom, buf, buffer_size, FI_REMOTE_WRITE, 0, 
 			user_defined_key, flags, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -155,7 +155,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
@@ -178,7 +178,7 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -186,19 +186,19 @@ static int bind_ep_res(void)
 	 *  for RMA write operation */
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV | FI_REMOTE_WRITE);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -221,7 +221,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, port, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -233,19 +233,19 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
@@ -261,7 +261,7 @@ static int init_fabric(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 	}

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -80,7 +80,7 @@ static int send_msg(int size)
 	ret = fi_send(ep[0], buf, (size_t) size, fi_mr_desc(mr),
 			remote_fi_addr[0], &fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 
@@ -95,7 +95,7 @@ static int recv_msg(void)
 
 	ret = fi_recv(srx_ctx, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 
@@ -144,31 +144,31 @@ static int alloc_ep_res(void)
 	
 	ret = fi_stx_context(dom, &tx_attr, &stx_ctx, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_stx_context", ret);
+		FT_PRINTERR("fi_stx_context", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 	
 	ret = fi_srx_context(dom, &rx_attr, &srx_ctx, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_srx_context", ret);
+		FT_PRINTERR("fi_srx_context", ret);
 		goto err3;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err4;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err5;
 	}
 
@@ -178,7 +178,7 @@ static int alloc_ep_res(void)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err6;
 	}
 
@@ -207,37 +207,37 @@ static int bind_ep_res(void)
 	for (i = 0; i < ep_cnt; i++) {
 		ret = fi_ep_bind(ep[i], &stx_ctx->fid, 0);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_ep_bind(ep[i], &srx_ctx->fid, 0);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_ep_bind(ep[i], &scq->fid, FI_SEND);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_ep_bind(ep[i], &rcq->fid, FI_RECV);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_ep_bind(ep[i], &av->fid, 0);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_enable(ep[i]);
 		if (ret) {
-			FI_PRINTERR("fi_enable", ret);
+			FT_PRINTERR("fi_enable", ret);
 			return ret;
 		}
 	}
@@ -255,7 +255,7 @@ static int run_test()
 		ret = fi_recv(srx_ctx, buf, buffer_size, fi_mr_desc(mr),
 				FI_ADDR_UNSPEC, NULL);
 		if (ret) {
-			FI_PRINTERR("fi_recv", ret);
+			FT_PRINTERR("fi_recv", ret);
 			return ret;
 		}
 	}
@@ -267,7 +267,7 @@ static int run_test()
 			ret = fi_send(ep[i], buf, transfer_size, fi_mr_desc(mr),
 					remote_fi_addr[i], NULL); 
 			if (ret) {
-				FI_PRINTERR("fi_send", ret);
+				FT_PRINTERR("fi_send", ret);
 				return ret;
 			}
 
@@ -287,7 +287,7 @@ static int run_test()
 			ret = fi_send(ep[i], buf, transfer_size, fi_mr_desc(mr),
 					remote_fi_addr[i], NULL); 
 			if (ret) {
-				FI_PRINTERR("fi_send", ret);
+				FT_PRINTERR("fi_send", ret);
 				return ret;
 			}
 
@@ -319,14 +319,14 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
 	/* Check the number of EPs supported by the provider */
 	if (ep_cnt > fi->domain_attr->ep_cnt) {
 		ep_cnt = fi->domain_attr->ep_cnt;
-		FI_DEBUG("Provider can support only %d of EPs\n", ep_cnt);
+		FT_DEBUG("Provider can support only %d of EPs\n", ep_cnt);
 	}
 
 	/* Get remote address */
@@ -338,13 +338,13 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
@@ -360,7 +360,7 @@ static int init_fabric(void)
 
 		ret = fi_endpoint(dom, fi, &ep[i], NULL);
 		if (ret) {
-			FI_PRINTERR("fi_endpoint", ret);
+			FT_PRINTERR("fi_endpoint", ret);
 			goto err2;
 		}
 	}
@@ -399,7 +399,7 @@ static int init_av(void)
 	addrlen = 0;
 	ret = fi_getname(&ep[0]->fid, local_addr, &addrlen);
 	if (ret != -FI_ETOOSMALL) {
-		FI_PRINTERR("fi_getname", ret);
+		FT_PRINTERR("fi_getname", ret);
 		return ret;
 	}
 
@@ -409,7 +409,7 @@ static int init_av(void)
 	for (i = 0; i < ep_cnt; i++) {
 		ret = fi_getname(&ep[i]->fid, local_addr + addrlen * i, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 	}
@@ -417,7 +417,7 @@ static int init_av(void)
 	if (dst_addr) {
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr[0], 0, &fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -441,7 +441,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr + addrlen, ep_cnt - 1, 
 				remote_fi_addr + 1, 0, &fi_ctx_av);
 		if (ret != ep_cnt - 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -463,7 +463,7 @@ static int init_av(void)
 		/* Insert remote addresses into AV */
 		ret = fi_av_insert(av, remote_addr, ep_cnt, remote_fi_addr, 0, &fi_ctx_av);
 		if (ret != ep_cnt) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 	

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -79,7 +79,7 @@ int wait_for_completion_tagged(struct fid_cq *cq, int num_completions)
 		if (ret > 0) {
 			num_completions--;
 		} else if (ret < 0) {
-			FI_PRINTERR("fi_cq_read", ret);
+			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
 	}
@@ -99,7 +99,7 @@ static int send_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -110,7 +110,7 @@ post:
 	ret = fi_tsend(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			tag_data, &fi_ctx_send);
 	if (ret)
-		FI_PRINTERR("fi_tsend", ret);
+		FT_PRINTERR("fi_tsend", ret);
 
 	return ret;
 }
@@ -126,7 +126,7 @@ static int recv_xfer(int size)
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FI_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_read", ret);
 			}
 			return ret;
 		}
@@ -136,7 +136,7 @@ static int recv_xfer(int size)
 	ret = fi_trecv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			tag_data + 1, 0, &fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_trecv", ret);
+		FT_PRINTERR("fi_trecv", ret);
 
 	return ret;
 }
@@ -148,7 +148,7 @@ static int send_msg(int size)
 	ret = fi_tsend(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			tag_control, &fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_tsend", ret);
+		FT_PRINTERR("fi_tsend", ret);
 		return ret;
 	}
 
@@ -164,7 +164,7 @@ static int recv_msg(void)
 	ret = fi_trecv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 		       tag_control, 0, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_trecv", ret);
+		FT_PRINTERR("fi_trecv", ret);
 		return ret;
 	}
 
@@ -257,19 +257,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -280,7 +280,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
@@ -303,25 +303,25 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -349,7 +349,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -367,19 +367,19 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
@@ -417,21 +417,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -460,7 +460,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -474,7 +474,7 @@ static int init_av(void)
 	ret = fi_trecv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			tag_data, 0, &fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_trecv", ret);
+		FT_PRINTERR("fi_trecv", ret);
 
 	return ret;
 }

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -99,7 +99,7 @@ int wait_for_tagged_completion(struct fid_cq *cq, int num_completions)
 		if (ret > 0) {
 			num_completions--;
 		} else if (ret < 0) {
-			FI_PRINTERR("fi_cq_read", ret);
+			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
 	}
@@ -113,7 +113,7 @@ static int send_msg(int size, uint64_t tag)
 	ret = fi_tsend(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			tag, &fi_ctx_send);
 	if (ret)
-		FI_PRINTERR("fi_tsend", ret);
+		FT_PRINTERR("fi_tsend", ret);
 
 	ret = wait_for_tagged_completion(scq, 1);
 
@@ -128,7 +128,7 @@ static int recv_msg(uint64_t tag)
 	ret = fi_trecv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			tag, 0, &fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_trecv", ret);
+		FT_PRINTERR("fi_trecv", ret);
 	
 	// wait for the completion event
 	ret = wait_for_tagged_completion(rcq, 1);
@@ -144,7 +144,7 @@ static int post_recv(uint64_t tag)
 	ret = fi_trecv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			tag, 0, &fi_ctx_recv);
 	if (ret)
-		FI_PRINTERR("fi_trecv", ret);
+		FT_PRINTERR("fi_trecv", ret);
 	
 	return ret;
 }
@@ -189,19 +189,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -212,7 +212,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
@@ -235,25 +235,25 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
@@ -281,7 +281,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -299,19 +299,19 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
 	}
 
@@ -349,21 +349,21 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -392,7 +392,7 @@ static int init_av(void)
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -416,7 +416,7 @@ static int tagged_search(uint64_t tag)
 				"No match found with tag [%" PRIu64 "]\n",
 				tag);
 		else
-			FI_PRINTERR("fi_tsearch", ret);
+			FT_PRINTERR("fi_tsearch", ret);
 	} else if(ret == 0) {
 		// search was initiated asynchronously, so wait for 
 		// the completion event

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -103,7 +103,7 @@ static int send_msg(int size)
 	ret = fi_send(tx_ep[0], buf, (size_t) size, fi_mr_desc(mr),
 			remote_rx_addr[0], &fi_ctx_send);
 	if (ret) {
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 		return ret;
 	}
 
@@ -119,7 +119,7 @@ static int recv_msg(void)
 	/* Messages sent to scalable EP fi_addr are received in context 0 */
 	ret = fi_recv(rx_ep[0], buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 
@@ -175,13 +175,13 @@ static int alloc_ep_res(struct fid_ep *sep)
 		/* Create TX contexts: tx_ep */
 		ret = fi_tx_context(sep, i, &tx_attr, &tx_ep[i], NULL);
 		if (ret) {
-			FI_PRINTERR("fi_tx_context", ret);
+			FT_PRINTERR("fi_tx_context", ret);
 			goto err1;
 		}
 
 		ret = fi_cq_open(dom, &cq_attr, &scq[i], NULL);
 		if (ret) {
-			FI_PRINTERR("fi_cq_open", ret);
+			FT_PRINTERR("fi_cq_open", ret);
 			goto err2;
 		}
 	}
@@ -190,20 +190,20 @@ static int alloc_ep_res(struct fid_ep *sep)
 		/* Create RX contexts: rx_ep */
 		ret = fi_rx_context(sep, i, &rx_attr, &rx_ep[i], NULL);
 		if (ret) {
-			FI_PRINTERR("fi_tx_context", ret);
+			FT_PRINTERR("fi_tx_context", ret);
 			goto err3;
 		}
 
 		ret = fi_cq_open(dom, &cq_attr, &rcq[i], NULL);
 		if (ret) {
-			FI_PRINTERR("fi_cq_open", ret);
+			FT_PRINTERR("fi_cq_open", ret);
 			goto err4;
 		}
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err5;
 	}
 
@@ -218,7 +218,7 @@ static int alloc_ep_res(struct fid_ep *sep)
 	/* Open Address Vector */
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err6;
 	}
 
@@ -251,13 +251,13 @@ static int bind_ep_res(void)
 	for (i = 0; i < ctx_cnt; i++) {
 		ret = fi_ep_bind(tx_ep[i], &scq[i]->fid, FI_SEND);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_enable(tx_ep[i]);
 		if (ret) {
-			FI_PRINTERR("fi_enable", ret);
+			FT_PRINTERR("fi_enable", ret);
 			return ret;
 		}
 	}
@@ -265,13 +265,13 @@ static int bind_ep_res(void)
 	for (i = 0; i < ctx_cnt; i++) {
 		ret = fi_ep_bind(rx_ep[i], &rcq[i]->fid, FI_RECV);
 		if (ret) {
-			FI_PRINTERR("fi_ep_bind", ret);
+			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
 		}
 
 		ret = fi_enable(rx_ep[i]);
 		if (ret) {
-			FI_PRINTERR("fi_enable", ret);
+			FT_PRINTERR("fi_enable", ret);
 			return ret;
 		}
 	}
@@ -279,7 +279,7 @@ static int bind_ep_res(void)
 	/* Bind scalable EP with AV */
 	ret = fi_scalable_ep_bind(sep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
@@ -298,7 +298,7 @@ static int run_test()
 		fprintf(stdout, "Posting recv for ctx: %d\n", i);
 		ret = fi_recv(rx_ep[i], buf, buffer_size, fi_mr_desc(mr), 0, NULL);
 		if (ret) {
-			FI_PRINTERR("fi_recv", ret);
+			FT_PRINTERR("fi_recv", ret);
 			return ret;
 		}
 	}
@@ -310,7 +310,7 @@ static int run_test()
 			ret = fi_send(tx_ep[i], buf, transfer_size, fi_mr_desc(mr),
 					remote_rx_addr[i], NULL); 
 			if (ret) {
-				FI_PRINTERR("fi_recv", ret);
+				FT_PRINTERR("fi_recv", ret);
 				return ret;
 			}
 
@@ -347,7 +347,7 @@ static int init_fabric(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
@@ -372,13 +372,13 @@ static int init_fabric(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
@@ -388,7 +388,7 @@ static int init_fabric(void)
 
 	ret = fi_scalable_ep(dom, fi, &sep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_scalable_ep", ret);
+		FT_PRINTERR("fi_scalable_ep", ret);
 		goto err2;
 	}
 
@@ -427,20 +427,20 @@ static int init_av(void)
 		addrlen = 0;
 		ret = fi_getname(&sep->fid, local_addr, &addrlen);
 		if (ret != -FI_ETOOSMALL) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		local_addr = malloc(addrlen);
 		ret = fi_getname(&sep->fid, local_addr, &addrlen);
 		if (ret) {
-			FI_PRINTERR("fi_getname", ret);
+			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
@@ -471,7 +471,7 @@ static int init_av(void)
 
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
 		if (ret != 1) {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -79,7 +79,7 @@ static int poll_all_sends(void)
 		if (ret > 0) {
 			credits++;
 		} else if (ret < 0) {
-			FI_PRINTERR("fi_cq_read", ret);
+			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
 	} while (ret);
@@ -96,7 +96,7 @@ static int send_xfer(int size)
 		if (ret > 0) {
 			goto post;
 		} else if (ret < 0) {
-			FI_PRINTERR("fi_cq_read", ret);
+			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
 	}
@@ -106,7 +106,7 @@ post:
 	ret = fi_send(ep, buf_ptr, (size_t) size, fi_mr_desc(mr),
 			rem_addr, NULL);
 	if (ret)
-		FI_PRINTERR("fi_send", ret);
+		FT_PRINTERR("fi_send", ret);
 
 	return ret;
 }
@@ -119,14 +119,14 @@ static int recv_xfer(int size)
 	do {
 		ret = fi_cq_read(rcq, &comp, sizeof comp);
 		if (ret < 0) {
-			FI_PRINTERR("fi_cq_read", ret);
+			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
 	} while (!ret);
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 
 	return ret;
 }
@@ -181,15 +181,15 @@ static void free_ep_res(void)
 	
 	ret = fi_close(&mr->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close", ret);
+		FT_PRINTERR("fi_close", ret);
 	}
 	ret = fi_close(&rcq->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close", ret);
+		FT_PRINTERR("fi_close", ret);
 	}
 	ret = fi_close(&scq->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close", ret);
+		FT_PRINTERR("fi_close", ret);
 	}
 	free(buf);
 }
@@ -221,19 +221,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = max_credits << 1;
 	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_cq_open", ret);
+		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_mr_reg", ret);
+		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
@@ -243,7 +243,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.flags = 0;
 	ret = fi_av_open(dom, &av_attr, &av, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_av_open", ret);
+		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
@@ -266,31 +266,31 @@ static int bind_ep_res(void)
 
 	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
-		FI_PRINTERR("fi_ep_bind", ret);
+		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	ret = fi_enable(ep);
 	if (ret) {
-		FI_PRINTERR("fi_enable", ret);
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 	}
 
 	return ret;
@@ -317,7 +317,7 @@ static int common_setup(void)
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
 	if (ret) {
-		FI_PRINTERR("fi_getinfo", ret);
+		FT_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
 	if (fi->ep_attr->max_msg_size) {
@@ -326,7 +326,7 @@ static int common_setup(void)
 
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_fabric", ret);
+		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 	if (fi->mode & FI_MSG_PREFIX) {
@@ -335,13 +335,13 @@ static int common_setup(void)
 
 	ret = fi_domain(fab, fi, &dom, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_domain", ret);
+		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
-		FI_PRINTERR("fi_endpoint", ret);
+		FT_PRINTERR("fi_endpoint", ret);
 		goto err3;
 	}
 
@@ -389,7 +389,7 @@ static int client_connect(void)
 
 	ret = fi_av_insert(av, hints.dest_addr, 1, &rem_addr, 0, NULL);
 	if (ret != 1) {
-		FI_PRINTERR("fi_av_insert", ret);
+		FT_PRINTERR("fi_av_insert", ret);
 		goto err;
 	}
 
@@ -427,7 +427,7 @@ static int server_connect(void)
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
 		if (ret < 0) {
-			FI_PRINTERR("fi_cq_read", ret);
+			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
 	} while (ret == 0);
@@ -435,18 +435,18 @@ static int server_connect(void)
 	ret = fi_av_insert(av, buf_ptr, 1, &rem_addr, 0, NULL);
 	if (ret != 1) {
 		if (ret == 0) {
-			FI_DEBUG("Unable to resolve remote address 0x%x 0x%x\n",
+			FT_DEBUG("Unable to resolve remote address 0x%x 0x%x\n",
 					((uint32_t *)buf)[0], ((uint32_t *)buf)[1]);
 			ret = -FI_EINVAL;
 		} else {
-			FI_PRINTERR("fi_av_insert", ret);
+			FT_PRINTERR("fi_av_insert", ret);
 		}
 		goto err;
 	}
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret != 0) {
-		FI_PRINTERR("fi_recv", ret);
+		FT_PRINTERR("fi_recv", ret);
 		goto err;
 	}
 
@@ -493,20 +493,20 @@ static int run(void)
 
 	ret = fi_close(&ep->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close", ret);
+		FT_PRINTERR("fi_close", ret);
 	}
 	free_ep_res();
 	ret = fi_close(&av->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close", ret);
+		FT_PRINTERR("fi_close", ret);
 	}
 	ret = fi_close(&dom->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close", ret);
+		FT_PRINTERR("fi_close", ret);
 	}
 	ret = fi_close(&fab->fid);
 	if (ret != 0) {
-		FI_PRINTERR("fi_close", ret);
+		FT_PRINTERR("fi_close", ret);
 	}
 	fi_freeinfo(fi);
 	return ret;


### PR DESCRIPTION
Replaced the FI_* macros defined in include/shared.h as suggested by @shefty so that FI_* is reserved for libfabric specific things. 
FI_STR_LEN  -> FT_STR_LEN
FI_DEBUG -> FT_DEBUG
FI_PRINTERR -> FT_PRINTERR

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>