### PR TITLE
1.0.0-alpha release

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -141,7 +141,11 @@ complex_fabtest_SOURCES = \
 
 man_MANS = man/fabtests.7
 
-EXTRA_DIST = include/shared.h include/unit_common.h fabtests.spec.in $(man_MANS)
+EXTRA_DIST = \
+	include/shared.h \
+	include/unit_common.h \
+	complex/fabtest.h \
+	fabtests.spec.in $(man_MANS)
 
 dist-hook: fabtests.spec
 	cp fabtests.spec $(distdir)

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT([fabtests], [0.0.2], [linux-rdma@vger.kernel.org])
+AC_INIT([fabtests], [1.0.0alpha], [linux-rdma@vger.kernel.org])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)


### PR DESCRIPTION
Fabtests are behind the libfabric release cycle, but tag a 1.0.0 alpha release, so that people downloading the libfabric release candidates have something that they can run against the library and providers.