### PR TITLE
Add writedata support to RMA examples

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -172,6 +172,27 @@ void init_test(int size, char *test_name, size_t test_name_len,
 	*iterations = size_to_count(*transfer_size);
 }
 
+int wait_for_data_completion(struct fid_cq *cq, int num_completions)
+{
+	int ret;
+	struct fi_cq_data_entry comp;
+
+	while (num_completions > 0) {
+		ret = fi_cq_read(cq, &comp, 1);
+		if (ret > 0) {
+			num_completions--;
+		} else if (ret < 0) {
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(cq, "cq");
+			} else {
+				FT_PRINTERR("fi_cq_read", ret);
+			}
+			return ret;
+		}
+	}
+	return 0;
+}
+
 int wait_for_completion(struct fid_cq *cq, int num_completions)
 {
 	int ret;

--- a/include/shared.h
+++ b/include/shared.h
@@ -98,6 +98,7 @@ char *cnt_str(char str[FT_STR_LEN], long long cnt);
 int size_to_count(int size);
 void init_test(int size, char *test_name, size_t test_name_len,
 		int *transfer_size, int *iterations);
+int wait_for_data_completion(struct fid_cq *cq, int num_completions);
 int wait_for_completion(struct fid_cq *cq, int num_completions);
 void cq_readerr(struct fid_cq *cq, char *cq_str);
 int64_t get_elapsed(const struct timespec *b, const struct timespec *a, 
@@ -116,6 +117,14 @@ void show_perf_mr(int tsize, int iters, struct timespec *start,
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
 #define ARRAY_SIZE(A) (sizeof(A)/sizeof(*A))
+
+/* for RMA tests --- we want to be able to select fi_writedata, but there is no
+ * constant in libfabric for this */
+enum ft_rma_opcodes {
+	FT_RMA_READ = 1,
+	FT_RMA_WRITE,
+	FT_RMA_WRITEDATA,
+};
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add a command-line option to support using the writedata operation to
send remote CQ data to the simple/fi_msg_rma and simple/fi_rdm_rma
tools.

We test that provider gives a sensible context value on the remote CQ
data completion.  The two sensible values are NULL (meaning that the
remote CQ data did not consume a recv WQE) or the context value of the
next queued fi_recv* (meaning that the remote CQ data consumed a recv
WQE).  We also test that the completion data is correctly transferred.

We add an enum to specify the RMA operation type, which allows us to
cleanly add writedata to the set of operations supported by the RMA
tests (since libfabric itself doesn't supply a constant that can be
cleanly used for this purpose).

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>