### PR TITLE
Use ep_type from ep_attr, rather than fi_info

### DIFF
--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -51,7 +51,7 @@ static void *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
 
-static struct fi_info hints;
+static struct fi_info *hints;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep;
@@ -195,7 +195,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	
 	/* Get fabric info */
-	ret = fi_getinfo(FT_FIVERSION, dst_addr, port, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, dst_addr, port, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		goto err0;
@@ -321,18 +321,15 @@ static int send_recv()
 int main(int argc, char **argv)
 {
 	int op, ret;
-	struct fi_fabric_attr *fabric_hints;
 	
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
 	while ((op = getopt(argc, argv, "f:h")) != -1) {
 		switch (op) {
 		case 'f':
-			fabric_hints = malloc(sizeof *fabric_hints);
-			if (!fabric_hints) {
-				perror("malloc");
-				exit(EXIT_FAILURE);
-			}
-			fabric_hints->prov_name = optarg;
-			hints.fabric_attr = fabric_hints;
+			hints->fabric_attr->prov_name = optarg;
 			break;
 		case '?':
 		case 'h':
@@ -344,10 +341,9 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		dst_addr = argv[optind];
 	
-	hints.ep_type		= FI_EP_DGRAM;
-	hints.caps		= FI_MSG;
-	hints.mode		= FI_CONTEXT;
-	hints.addr_format	= FI_FORMAT_UNSPEC;
+	hints->ep_attr->type	= FI_EP_DGRAM;
+	hints->caps		= FI_MSG;
+	hints->mode		= FI_CONTEXT;
 
 	/* Fabric initialization */
 	ret = init_fabric();
@@ -364,6 +360,7 @@ int main(int argc, char **argv)
 	free_ep_res();
 	fi_close(&dom->fid);
 	fi_close(&fab->fid);
+	fi_freeinfo(hints);
 
 	return ret;
 }

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -53,7 +53,7 @@ static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
 
-static struct fi_info hints;
+static struct fi_info *hints;
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -320,7 +320,7 @@ static int init_fabric(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
 		if (ret)
 			return ret;
 		node = opts.dst_addr;
@@ -331,7 +331,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -503,13 +503,17 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op;
+	int op, ret;
 	opts = INIT_OPTS;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
-			ft_parseinfo(op, optarg, &hints);
+			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
 			break;
 		case '?':
@@ -522,15 +526,16 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	hints.ep_type = FI_EP_RDM;
-	hints.caps = FI_MSG;
-	hints.mode = FI_CONTEXT;
-	hints.addr_format = FI_FORMAT_UNSPEC;
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG;
+	hints->mode = FI_CONTEXT;
 
 	if (opts.prhints) {
 		printf("%s", fi_tostr(&hints, FI_TYPE_INFO));
-		return EXIT_SUCCESS;
+		ret = EXIT_SUCCESS;
+	} else {
+		ret = run();
 	}
-
-	return run();
+	fi_freeinfo(hints);
+	return ret;
 }

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -502,7 +502,7 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	hints->ep_type = FI_EP_RDM;
+	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
 	hints->mode = FI_CONTEXT;
 

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -57,7 +57,7 @@ static struct timespec start, end;
 static void *send_buf, *multi_recv_buf;
 static size_t max_send_buf_size, multi_buf_size;
 
-static struct fi_info hints;
+static struct fi_info *hints;
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -407,7 +407,7 @@ static int init_fabric(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
 		if (ret)
 			return ret;
 		node = opts.dst_addr;
@@ -418,7 +418,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -584,13 +584,17 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op;
+	int op, ret;
 	opts = INIT_OPTS;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
-			ft_parseinfo(op, optarg, &hints);
+			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
 			break;
 		case '?':
@@ -603,10 +607,11 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	hints.ep_type = FI_EP_RDM;
-	hints.caps = FI_MSG | FI_MULTI_RECV;
-	hints.mode = FI_CONTEXT;
-	hints.addr_format = FI_FORMAT_UNSPEC;
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG | FI_MULTI_RECV;
+	hints->mode = FI_CONTEXT;
 
-	return run();
+	ret = run();
+	fi_freeinfo(hints);
+	return ret;
 }

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -50,7 +50,7 @@ static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
 
-static struct fi_info hints;
+static struct fi_info *hints;
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -307,7 +307,7 @@ static int init_fabric(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
 		if (ret)
 			return ret;
 		node = opts.dst_addr;
@@ -318,7 +318,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -495,13 +495,17 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op;
+	int op, ret;
 	opts = INIT_OPTS;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
-			ft_parseinfo(op, optarg, &hints);
+			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
 			break;
 		case '?':
@@ -514,15 +518,16 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	hints.ep_type = FI_EP_RDM;
-	hints.caps = FI_MSG;
-	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;
-	hints.addr_format = FI_FORMAT_UNSPEC;
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG;
+	hints->mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;
 
 	if (opts.prhints) {
 		printf("%s", fi_tostr(&hints, FI_TYPE_INFO));
-		return EXIT_SUCCESS;
+		ret = EXIT_SUCCESS;
+	} else {
+		ret = run();
 	}
-
-	return run();
+	fi_freeinfo(hints);
+	return ret;
 }

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -54,7 +54,7 @@ static int rx_depth = 512;
 
 static char *dst_addr = NULL;
 static char *src_port = "9228", *dst_port = "9228";
-static struct fi_info hints;
+static struct fi_info *hints;
 static char *dst_addr, *src_addr;
 
 static int ep_cnt = 2;
@@ -306,7 +306,7 @@ static int init_fabric(void)
 	int i, ret;
 
 	if (dst_addr) {
-		ret = ft_getsrcaddr(src_addr, src_port, &hints);
+		ret = ft_getsrcaddr(src_addr, src_port, hints);
 		if (ret)
 			return ret;
 		node = dst_addr;
@@ -317,7 +317,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -529,7 +529,11 @@ void print_usage(char *name, char *desc)
 
 int main(int argc, char **argv)
 {
-	int op;
+	int op, ret;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "b:p:s:h" INFO_OPTS)) != -1) {
 		switch (op) {
@@ -543,7 +547,7 @@ int main(int argc, char **argv)
 			src_addr = optarg;
 			break;
 		default:
-			ft_parseinfo(op, optarg, &hints);
+			ft_parseinfo(op, optarg, hints);
 			break;
 		case '?':
 		case 'h':
@@ -555,10 +559,12 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		dst_addr = argv[optind];
 	
-	hints.ep_type = FI_EP_RDM;
-	hints.caps = FI_MSG | FI_NAMED_RX_CTX;
-	hints.mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;
-	hints.addr_format = FI_SOCKADDR;
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG | FI_NAMED_RX_CTX;
+	hints->mode = FI_CONTEXT | FI_LOCAL_MR | FI_PROV_MR_ATTR;
+	hints->addr_format = FI_SOCKADDR;
 
-	return run();
+	ret = run();
+	fi_freeinfo(hints);
+	return ret;
 }

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -51,7 +51,7 @@ static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
 
-static struct fi_info hints;
+static struct fi_info *hints;
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -336,7 +336,7 @@ static int init_fabric(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, &hints);
+		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
 		if (ret)
 			return ret;
 		node = opts.dst_addr;
@@ -347,7 +347,7 @@ static int init_fabric(void)
 		flags = FI_SOURCE;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, service, flags, &hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -520,13 +520,17 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op;
+	int op, ret;
 	opts = INIT_OPTS;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
-			ft_parseinfo(op, optarg, &hints);
+			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
 			break;
 		case '?':
@@ -539,15 +543,16 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	hints.ep_type = FI_EP_RDM;
-	hints.caps = FI_MSG | FI_TAGGED;
-	hints.mode = FI_CONTEXT;
-	hints.addr_format = FI_FORMAT_UNSPEC;
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG | FI_TAGGED;
+	hints->mode = FI_CONTEXT;
 
 	if (opts.prhints) {
-		printf("%s", fi_tostr(&hints, FI_TYPE_INFO));
-		return EXIT_SUCCESS;
+		printf("%s", fi_tostr(hints, FI_TYPE_INFO));
+		ret = EXIT_SUCCESS;
+	} else {
+		ret = run();
 	}
-
-	return run();
+	fi_freeinfo(hints);
+	return ret;
 }

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -547,7 +547,7 @@ int main(int argc, char **argv)
 		dst_addr = argv[optind];
 	
 	hints->rx_attr->total_buffered_recv = buffer_size;
-	hints->ep_type = FI_EP_RDM;
+	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_TAGGED;
 	hints->mode = FI_CONTEXT;
 

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -56,10 +56,7 @@
 
 int fabtests_debug = 0;
 
-struct fi_info hints;
-struct fi_tx_attr tx_attr;
-struct fi_rx_attr rx_attr;
-static struct fi_fabric_attr fabric_hints;
+struct fi_info *hints;
 static struct fi_eq_attr eq_attr;
 
 static struct fi_info *fi;
@@ -355,18 +352,17 @@ int main(int argc, char **argv)
 		fabtests_debug = atoi(getenv("FABTESTS_DEBUG"));
 	}
 
-	memset(&hints, 0x00, sizeof(hints));
-	memset(&fabric_hints, 0x00, sizeof(fabric_hints));
+	hints = fi_allocinfo();
+	if (!hints)
+		exit(1);
 
 	while ((op = getopt(argc, argv, "f:p:")) != -1) {
 		switch (op) {
 		case 'f':
-			fabric_hints.name = optarg;
-			hints.fabric_attr = &fabric_hints;
+			hints->fabric_attr->name = optarg;
 			break;
 		case 'p':
-			fabric_hints.prov_name = optarg;
-			hints.fabric_attr = &fabric_hints;
+			hints->fabric_attr->prov_name = optarg;
 			break;
 		default:
 			printf("usage: %s\n", argv[0]);
@@ -376,9 +372,9 @@ int main(int argc, char **argv)
 		}
 	}
 
-	hints.mode = ~0;
+	hints->mode = ~0;
 
-	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, &hints, &fi);
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	if (ret != 0) {
 		printf("fi_getinfo %s\n", fi_strerror(-ret));
 		exit(1);
@@ -437,6 +433,7 @@ int main(int argc, char **argv)
 		printf("Error %d freeing info: %s\n", ret, fi_strerror(-ret));
 		exit(1);
 	}
+	fi_freeinfo(hints);
 
 	return (failed > 0);
 }


### PR DESCRIPTION
Allocate hints using fi_allocinfo, and reference the new
location of the ep_type field.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>