### PR TITLE
fix missing assert.h includes

### DIFF
--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -26,6 +26,7 @@
  * SOFTWARE.
  */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -26,6 +26,7 @@
  * SOFTWARE.
  */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This caused my (informal) continuous integration test builds to fail
because they run 'make CFLAGS="-g -O2 -Werror"'.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>