### PR TITLE
univ/av_test: fix minor bug in test

### DIFF
--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1009,7 +1009,7 @@ int main(int argc, char **argv)
 	int failed;
 
 	hints = fi_allocinfo();
-	if (hints)
+	if (!hints)
 		exit(1);
 
 	while ((op = getopt(argc, argv, "f:p:d:D:n:")) != -1) {


### PR DESCRIPTION
The return from fi_allocinfo struct wasn't
being checked correctly.

@shefty 

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>