### PR TITLE
Fixed fi_eq_read/write test issues when eq is empty/full

### DIFF
--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -175,7 +175,7 @@ eq_write_read_self()
 
 	/* queue is now empty */
 	ret = fi_eq_read(eq, &event, &entry, sizeof(entry), 0);
-	if (ret != -FI_EAGAIN) {
+	if (ret != 0) {
 		sprintf(err_buf, "fi_eq_read of empty EQ returned %d", ret);
 		goto fail;
 	}
@@ -221,7 +221,7 @@ eq_write_overflow()
 	}
 
 	ret = fi_eq_write(eq, FI_NOTIFY, &entry, sizeof(entry), 0);
-	if (ret != -FI_EAGAIN) {
+	if (ret != -FI_EAGAIN && ret != sizeof(entry)) {
 		sprintf(err_buf, "fi_eq_write of full EQ returned %d", ret);
 		goto fail;
 	}


### PR DESCRIPTION
Addressed EQ test failures based on libfabric man pages
- The return value of fi_eq_read should be 0 when eq is empty
- Both -EAGIAN and write-success should be allowed return value when EQ write overflow is tested. A provider can choose to buffer writes since the man page says the size attribute specifies the "minimum" size of the eq.

This fixes test failures.

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>