### PR TITLE
Fix segfault in fi_freeinfo.

### DIFF
--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -329,7 +329,7 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:h")) != -1) {
 		switch (op) {
 		case 'f':
-			hints->fabric_attr->prov_name = optarg;
+			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		case '?':
 		case 'h':

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:h")) != -1) {
 		switch (op) {			
 		case 'f':
-			hints->fabric_attr->prov_name = optarg;
+			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		case '?':
 		case 'h':

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -332,7 +332,7 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:h")) != -1) {
 		switch (op) {
 		case 'f':
-			hints->fabric_attr->prov_name = optarg;
+			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		case '?':
 		case 'h':

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1021,13 +1021,13 @@ int main(int argc, char **argv)
 			bad_address = optarg;
 			break;
 		case 'f':
-			hints->fabric_attr->name = optarg;
+			hints->fabric_attr->name = strdup(optarg);
 			break;
 		case 'n':
 			num_good_addr = atoi(optarg);
 			break;
 		case 'p':
-			hints->fabric_attr->prov_name = optarg;
+			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		default:
 			printf("usage: %s\n", argv[0]);

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -424,10 +424,10 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:p:")) != -1) {
 		switch (op) {
 		case 'f':
-			hints->fabric_attr->name = optarg;
+			hints->fabric_attr->name = strdup(optarg);
 			break;
 		case 'p':
-			hints->fabric_attr->prov_name = optarg;
+			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		default:
 			printf("usage: %s\n", argv[0]);

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -359,10 +359,10 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:p:")) != -1) {
 		switch (op) {
 		case 'f':
-			hints->fabric_attr->name = optarg;
+			hints->fabric_attr->name = strdup(optarg);
 			break;
 		case 'p':
-			hints->fabric_attr->prov_name = optarg;
+			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		default:
 			printf("usage: %s\n", argv[0]);


### PR DESCRIPTION
Strings from optarg can't be freed. This causes a seg fault in fi_freeinfo.
Wrap all string assignments using optarg with strdup.

Signed-off-by: Ben Turrubiates <bturrubiates@lanl.gov>