### PR TITLE
fabtests/simple:fix prob with use of fi_reject

### DIFF
--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -260,13 +260,13 @@ static int server_connect(void)
 		return (int) rd;
 	}
 
+	info = entry.info;
 	if (event != FI_CONNREQ) {
 		fprintf(stderr, "Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err1;
 	}
 
-	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -246,13 +246,13 @@ static int server_connect(void)
 		return (int) rd;
 	}
 
+	info = entry.info;
 	if (event != FI_CONNREQ) {
 		fprintf(stderr, "Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err1;
 	}
 
-	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -339,13 +339,13 @@ static int server_connect(void)
 		return (int) rd;
 	}
 
+	info = entry.info;
 	if (event != FI_CONNREQ) {
 		fprintf(stderr, "Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err1;
 	}
 
-	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -444,13 +444,13 @@ static int server_connect(void)
 		return (int) rd;
 	}
 
+	info = entry.info;
 	if (event != FI_CONNREQ) {
 		fprintf(stderr, "Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err1;
 	}
 
-	info = entry.info;
 	ret = fi_domain(fab, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);


### PR DESCRIPTION
For tests where the fi_reject method was invoked
during processing of connection requests, the
info object was not being handled properly.  This results in
random segfaults within the sockets provider.
Initializing the info pointer correctly in the tests
eliminates segfaults.

@shefty 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>