### PR TITLE
simple/rdm_rma.c: fix compiler warning

### DIFF
--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -279,7 +279,8 @@ static int alloc_ep_res(struct fi_info *fi)
 		break;
 	default:
 		/* Impossible to reach here */
-		assert(0);
+		FT_PRINTERR("invalid op_type", ret);
+		exit(1);
 	}
 	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)), 
 			access_mode, 0, 0, 0, &mr, NULL);


### PR DESCRIPTION
If not compiled with asserts enabled, an invalid op_type would fall
through to fi_mr_reg() with an uninitialized access_mode.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>