### PR TITLE
eq_test: expect -FI_EAGAIN from empty EQ read

### DIFF
--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -175,7 +175,7 @@ eq_write_read_self()
 
 	/* queue is now empty */
 	ret = fi_eq_read(eq, &event, &entry, sizeof(entry), 0);
-	if (ret != 0) {
+	if (ret != -FI_EAGAIN) {
 		sprintf(err_buf, "fi_eq_read of empty EQ returned %d", ret);
 		goto fail;
 	}


### PR DESCRIPTION
This is a partial revert of daba27cfa2afbacad2b1f6c5b9f2f49a008e54d3.
See discussion at ofiwg/libfabric#738 for reasoning behind this change.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>