### PR TITLE
Fix OS X build.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 AM_CFLAGS = -g -Wall -D_GNU_SOURCE -I$(srcdir)/include
+ACLOCAL_AMFLAGS = -I config
 
 bin_PROGRAMS = \
 	simple/fi_info \
@@ -30,112 +31,125 @@ bin_PROGRAMS = \
 	ported/librdmacm/fi_cmatose \
 	complex/fabtest
 
+noinst_LTLIBRARIES = libfabtests.la
+libfabtests_la_SOURCES = common/shared.c
+
+if MACOS
+libfabtests_la_SOURCES += common/osx/osd.h
+libfabtests_la_SOURCES += common/osx/osd.c
+endif
+
 simple_fi_info_SOURCES = \
-	simple/info.c \
-	common/shared.c
+	simple/info.c
+simple_fi_info_LDADD = libfabtests.la
 
 simple_fi_msg_SOURCES = \
-	simple/msg.c \
-	common/shared.c
+	simple/msg.c
+simple_fi_msg_LDADD = libfabtests.la
 
 simple_fi_msg_pingpong_SOURCES = \
-	simple/msg_pingpong.c \
-	common/shared.c
+	simple/msg_pingpong.c
+simple_fi_msg_pingpong_LDADD = libfabtests.la
 
 simple_fi_msg_rma_SOURCES = \
-	simple/msg_rma.c \
-	common/shared.c
+	simple/msg_rma.c
+simple_fi_msg_rma_LDADD = libfabtests.la
 
 simple_fi_rdm_SOURCES = \
-	simple/rdm.c \
-	common/shared.c
+	simple/rdm.c
+simple_fi_rdm_LDADD = libfabtests.la
 
 simple_fi_rdm_rma_simple_SOURCES = \
-	simple/rdm_rma_simple.c \
-	common/shared.c
+	simple/rdm_rma_simple.c
+simple_fi_rdm_rma_simple_LDADD = libfabtests.la
 
 simple_fi_dgram_SOURCES = \
-	simple/dgram.c \
-	common/shared.c
+	simple/dgram.c
+simple_fi_dgram_LDADD = libfabtests.la
 
 simple_fi_dgram_waitset_SOURCES = \
-	simple/dgram_waitset.c \
-	common/shared.c
+	simple/dgram_waitset.c
+simple_fi_dgram_waitset_LDADD = libfabtests.la
 
 simple_fi_rdm_pingpong_SOURCES = \
-	simple/rdm_pingpong.c \
-	common/shared.c
+	simple/rdm_pingpong.c
+simple_fi_rdm_pingpong_LDADD = libfabtests.la
 
 simple_fi_rdm_tagged_pingpong_SOURCES = \
-	simple/rdm_tagged_pingpong.c \
-	common/shared.c
+	simple/rdm_tagged_pingpong.c
+simple_fi_rdm_tagged_pingpong_LDADD = libfabtests.la
 
 simple_fi_rdm_tagged_search_SOURCES = \
-	simple/rdm_tagged_search.c \
-	common/shared.c
+	simple/rdm_tagged_search.c
+simple_fi_rdm_tagged_search_LDADD = libfabtests.la
 
 simple_fi_rdm_cntr_pingpong_SOURCES = \
-	simple/rdm_cntr_pingpong.c \
-	common/shared.c
+	simple/rdm_cntr_pingpong.c
+simple_fi_rdm_cntr_pingpong_LDADD = libfabtests.la
 
 simple_fi_rdm_rma_SOURCES = \
-	simple/rdm_rma.c \
-	common/shared.c
+	simple/rdm_rma.c
+simple_fi_rdm_rma_LDADD = libfabtests.la
 	
 simple_fi_rdm_atomic_SOURCES = \
-	simple/rdm_atomic.c \
-	common/shared.c
+	simple/rdm_atomic.c
+simple_fi_rdm_atomic_LDADD = libfabtests.la
 
 simple_fi_ud_pingpong_SOURCES = \
-	simple/ud_pingpong.c \
-	common/shared.c
+	simple/ud_pingpong.c
+simple_fi_ud_pingpong_LDADD = libfabtests.la
 
 simple_fi_cq_data_SOURCES = \
-	simple/cq_data.c \
-	common/shared.c
+	simple/cq_data.c
+simple_fi_cq_data_LDADD = libfabtests.la
 
 simple_fi_rdm_inject_pingpong_SOURCES = \
-	simple/rdm_inject_pingpong.c \
-	common/shared.c
+	simple/rdm_inject_pingpong.c
+simple_fi_rdm_inject_pingpong_LDADD = libfabtests.la
 
 simple_fi_scalable_ep_SOURCES = \
-	simple/scalable_ep.c \
-	common/shared.c
+	simple/scalable_ep.c
+simple_fi_scalable_ep_LDADD = libfabtests.la
 
 simple_fi_rdm_shared_ctx_SOURCES = \
-	simple/rdm_shared_ctx.c \
-	common/shared.c
+	simple/rdm_shared_ctx.c
+simple_fi_rdm_shared_ctx_LDADD = libfabtests.la
 
 simple_fi_poll_SOURCES = \
-	simple/poll.c \
-	common/shared.c
+	simple/poll.c
+simple_fi_poll_LDADD = libfabtests.la
 
 simple_fi_rdm_multi_recv_SOURCES = \
-	simple/rdm_multi_recv.c \
-	common/shared.c
+	simple/rdm_multi_recv.c
+simple_fi_rdm_multi_recv_LDADD = libfabtests.la
 
 unit_fi_eq_test_SOURCES = \
 	unit/eq_test.c \
-	unit/common.c \
-	common/shared.c
+	unit/common.c
+unit_fi_eq_test_LDADD = libfabtests.la
 
 unit_fi_av_test_SOURCES = \
 	unit/av_test.c \
 	unit/common.c
+unit_fi_av_test_LDADD = libfabtests.la
 
 unit_fi_size_left_test_SOURCES = \
 	unit/size_left_test.c \
 	unit/common.c
+unit_fi_size_left_test_LDADD = libfabtests.la
 
 unit_fi_dom_test_SOURCES = \
 	unit/dom_test.c \
 	unit/common.c
+unit_fi_dom_test_LDADD = libfabtests.la
 
 ported_libibverbs_fi_rc_pingpong_SOURCES = \
 	ported/libibverbs/rc_pingpong.c
+ported_libibverbs_fi_rc_pingpong_LDADD = libfabtests.la
 
 ported_librdmacm_fi_cmatose_SOURCES = \
 	ported/librdmacm/cmatose.c
+ported_librdmacm_fi_cmatose_LDADD = libfabtests.la
 
 complex_fabtest_SOURCES = \
 	complex/fabtest.c \
@@ -145,8 +159,8 @@ complex_fabtest_SOURCES = \
 	complex/ft_domain.c \
 	complex/ft_endpoint.c \
 	complex/ft_msg.c \
-	complex/ft_test.c \
-	common/shared.c
+	complex/ft_test.c
+complex_fabtest_LDADD = libfabtests.la
 
 man_MANS = man/fabtests.7
 

--- a/common/osx/osd.c
+++ b/common/osx/osd.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "osx/osd.h"
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp) {
+	int retval;
+
+	clock_serv_t cclock;
+	mach_timespec_t mts;
+
+	host_get_clock_service(mach_host_self(), clk_id, &cclock);
+	retval = clock_get_time(cclock, &mts);
+	mach_port_deallocate(mach_task_self(), cclock);
+
+	tp->tv_sec = mts.tv_sec;
+	tp->tv_nsec = mts.tv_nsec;
+
+	return retval;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,26 @@ AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+AC_CANONICAL_HOST
+
+macos=0
+linux=0
+
+case $host_os in
+*darwin*)
+	macos=1
+	;;
+*linux*)
+	linux=1
+	;;
+*)
+	AC_MSG_ERROR([libfabric only builds on Linux & OS X])
+	;;
+esac
+
+AM_CONDITIONAL([MACOS], [test $macos -eq 1])
+AM_CONDITIONAL([LINUX], [test $linux -eq 1])
+
 dnl Fix autoconf's habit of adding -g -O2 by default
 AS_IF([test -z "$CFLAGS"],
       [CFLAGS='-O2 -DNDEBUG -Wall'])
@@ -33,6 +53,8 @@ fi
 dnl Checks for programs
 AC_PROG_CC
 AM_PROG_CC_C_O
+
+LT_INIT
 
 AC_ARG_WITH([libfabric],
             AC_HELP_STRING([--with-libfabric], [Use non-default libfabric location - default NO]),

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _MACH_CLOCK_GETTIME_H_
+#define _MACH_CLOCK_GETTIME_H_
+
+#include <sys/time.h>
+#include <time.h>
+#include <mach/clock.h>
+#include <mach/mach.h>
+
+#define CLOCK_REALTIME CALENDAR_CLOCK
+#define CLOCK_MONOTONIC SYSTEM_CLOCK
+
+typedef int clockid_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/shared.h
+++ b/include/shared.h
@@ -39,12 +39,18 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_eq.h>
 
+#include <time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* all tests should work with 1.0 API */
 #define FT_FIVERSION FI_VERSION(1,0)
+
+#ifdef __APPLE__
+#include "osx/osd.h"
+#endif
 
 struct test_size_param {
 	int size;

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -38,7 +38,6 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <netdb.h>
-#include <byteswap.h>
 #include <getopt.h>
 
 #include <rdma/fabric.h>


### PR DESCRIPTION
I never submitted the OS X fix for fabtests. It's simpler and only requires adding a clock_gettime implementation for OS X. I copied the same solution.

@shefty cmatose.c includes byteswap.h and I couldn't see a reason for that. I removed it and it isn't generating any warnings/errors on OS X or Linux. Git blame says that you added that include statement. Is it still necessary? 

@jsquyres Could you check my configury? 

Signed-off-by: Ben Turrubiates <bturrubiates@lanl.gov>