### PR TITLE
Pr/fabtest: Fix for latest libfabric on 32 bit systems

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -32,6 +32,7 @@
 #include <string.h>
 
 #include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
 
 #include <shared.h>
 
@@ -225,6 +226,35 @@ void cq_readerr(struct fid_cq *cq, char *cq_str)
 
 	err_str = fi_cq_strerror(cq, cq_err.prov_errno, cq_err.err_data, NULL, 0);
 	fprintf(stderr, "%s %s (%d)\n", cq_str, err_str, cq_err.prov_errno);
+}
+
+int ft_finalize(struct fid_ep *tx_ep, struct fid_cq *scq, struct fid_cq *rcq,
+		fi_addr_t addr)
+{
+	struct fi_msg msg;
+	struct iovec iov;
+	struct fi_context tx_ctx;
+	char buf[4] = "fin";
+	int ret;
+
+	iov.iov_base = buf;
+	iov.iov_len = sizeof buf;
+	msg.msg_iov = &iov;
+	msg.desc = NULL;
+	msg.iov_count = 1;
+	msg.addr = addr;
+	msg.context = &tx_ctx;
+	msg.data = 0;
+
+	ret = fi_sendmsg(tx_ep, &msg, FI_INJECT | FI_REMOTE_COMPLETE);
+	if (ret) {
+		FT_PRINTERR("fi_sendmsg", ret);
+		return ret;
+	}
+
+	wait_for_data_completion(scq, 1);
+	wait_for_data_completion(rcq, 1);
+	return 0;
 }
 
 int64_t get_elapsed(const struct timespec *b, const struct timespec *a,

--- a/common/shared.c
+++ b/common/shared.c
@@ -161,15 +161,14 @@ int size_to_count(int size)
 		return 100000;
 }
 
-void init_test(int size, char *test_name, size_t test_name_len,
-	int *transfer_size, int *iterations)
+void init_test(struct cs_opts *opts, char *test_name, size_t test_name_len)
 {
 	char sstr[FT_STR_LEN];
 
-	size_str(sstr, size);
+	size_str(sstr, opts->transfer_size);
 	snprintf(test_name, test_name_len, "%s_lat", sstr);
-	*transfer_size = size;
-	*iterations = size_to_count(*transfer_size);
+	if (!(opts->user_options & FT_OPT_ITER))
+		opts->iterations = size_to_count(opts->transfer_size);
 }
 
 int wait_for_data_completion(struct fid_cq *cq, int num_completions)
@@ -361,14 +360,14 @@ void ft_parsecsopts(int op, char *optarg, struct cs_opts *opts)
 		opts->dst_port = optarg;
 		break;
 	case 'I':
-		opts->custom = 1;
+		opts->user_options |= FT_OPT_ITER;
 		opts->iterations = atoi(optarg);
 		break;
 	case 'S':
 		if (!strncasecmp("all", optarg, 3)) {
 			opts->size_option = 1;
 		} else {
-			opts->custom = 1;
+			opts->user_options |= FT_OPT_SIZE;
 			opts->transfer_size = atoi(optarg);
 		}
 		break;

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -245,12 +245,8 @@ static int ft_run_latency(void)
 		if (ft_tx.msg_size > fabric_info->ep_attr->max_msg_size)
 			break;
 
-		ft.xfer_iter = size_to_count(ft_tx.msg_size);
-		if (test_info.test_flags & FT_FLAG_QUICKTEST) {
-			ft.xfer_iter /= 100;
-			if (ft.xfer_iter == 0)
-				ft.xfer_iter = 1;
-		}
+		ft.xfer_iter = test_info.test_flags & FT_FLAG_QUICKTEST ?
+				5 : size_to_count(ft_tx.msg_size);
 
 		ret = ft_sync_test(0);
 		if (ret)
@@ -316,6 +312,7 @@ int ft_run_test()
 		break;
 	}
 
+	ft_sync_test(0);
 	ft_cleanup();
 
 	return ret ? ret : -ft.error;

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -246,8 +246,11 @@ static int ft_run_latency(void)
 			break;
 
 		ft.xfer_iter = size_to_count(ft_tx.msg_size);
-		if (test_info.test_flags & FT_FLAG_QUICKTEST)
-			ft.xfer_iter >>= 2;
+		if (test_info.test_flags & FT_FLAG_QUICKTEST) {
+			ft.xfer_iter /= 100;
+			if (ft.xfer_iter == 0)
+				ft.xfer_iter = 1;
+		}
 
 		ret = ft_sync_test(0);
 		if (ret)

--- a/include/shared.h
+++ b/include/shared.h
@@ -61,7 +61,6 @@ enum precision {
 
 struct cs_opts {
 	int prhints;
-	int custom;
 	int iterations;
 	int transfer_size;
 	char *src_port;
@@ -69,9 +68,15 @@ struct cs_opts {
 	char *src_addr;
 	char *dst_addr;
 	int size_option;
+	int user_options;
 	int machr;
 	int argc;
 	char **argv;
+};
+
+enum {
+	FT_OPT_ITER = 1 << 0,
+	FT_OPT_SIZE = 1 << 1
 };
 
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
@@ -96,8 +101,7 @@ int ft_getdestaddr(char *node, char *service, struct fi_info *hints);
 char *size_str(char str[FT_STR_LEN], long long size);
 char *cnt_str(char str[FT_STR_LEN], long long cnt);
 int size_to_count(int size);
-void init_test(int size, char *test_name, size_t test_name_len,
-		int *transfer_size, int *iterations);
+void init_test(struct cs_opts *opts, char *test_name, size_t test_name_len);
 int wait_for_data_completion(struct fid_cq *cq, int num_completions);
 int wait_for_completion(struct fid_cq *cq, int num_completions);
 void cq_readerr(struct fid_cq *cq, char *cq_str);

--- a/include/shared.h
+++ b/include/shared.h
@@ -101,10 +101,16 @@ int ft_getdestaddr(char *node, char *service, struct fi_info *hints);
 char *size_str(char str[FT_STR_LEN], long long size);
 char *cnt_str(char str[FT_STR_LEN], long long cnt);
 int size_to_count(int size);
+
 void init_test(struct cs_opts *opts, char *test_name, size_t test_name_len);
+int ft_finalize(struct fid_ep *tx_ep, struct fid_cq *scq, struct fid_cq *rcq,
+		fi_addr_t addr);
+
+
 int wait_for_data_completion(struct fid_cq *cq, int num_completions);
 int wait_for_completion(struct fid_cq *cq, int num_completions);
 void cq_readerr(struct fid_cq *cq, char *cq_str);
+
 int64_t get_elapsed(const struct timespec *b, const struct timespec *a, 
 		enum precision p);
 void show_perf(char *name, int tsize, int iters, struct timespec *start, 

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -555,7 +555,8 @@ int main(int argc, char *argv[])
 	hints->mode = FI_LOCAL_MR | FI_PROV_MR_ATTR;
 	hints->addr_format = FI_SOCKADDR;
 
-	asprintf(&service, "%d", port);
+	if (asprintf(&service, "%d", port) < 0)
+		return 1;
 	if (!servername) {
 		flags |= FI_SOURCE;
 	} else {

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -495,6 +495,11 @@ static int run_client(void)
 				goto disc;
 		}
 
+		printf("completing sends\n");
+		ret = poll_cqs(SEND_CQ_INDEX);
+		if (ret)
+			goto disc;
+
 		printf("data transfers complete\n");
 	}
 
@@ -580,7 +585,6 @@ int main(int argc, char **argv)
 		goto exit0;
 	}
 
-	fi_freeinfo(hints);
 	printf("using provider: %s\n", info->fabric_attr->prov_name);
 	ret = fi_fabric(info->fabric_attr, &fabric, NULL);
 	if (ret) {
@@ -612,6 +616,7 @@ exit2:
 exit1:
 	fi_freeinfo(info);
 exit0:
+	fi_freeinfo(hints);
 	printf("return status %d\n", ret);
 	return ret;
 }

--- a/scripts/ft_runall
+++ b/scripts/ft_runall
@@ -143,7 +143,7 @@ sleep 3
 echo Running fi_cmatose
 fi_cmatose &
 sleep 3
-fi_cmatose 127.0.0.1
+fi_cmatose -s 127.0.0.1
 echo ...done 
 sleep 3
 echo fabtest

--- a/scripts/ft_runall
+++ b/scripts/ft_runall
@@ -1,3 +1,8 @@
+if [ $# -eq 0 ] ; then
+   echo "Server address required"
+   exit 1
+fi
+
 echo Running fi_info
 fi_info
 echo ...done
@@ -5,121 +10,121 @@ sleep 3
 echo Running fi_msg
 fi_msg &
 sleep 3
-fi_msg 127.0.0.1
+fi_msg $1
 echo ...done 
 sleep 3
 echo Running fi_msg_pingpong
-fi_msg_pingpong &
+fi_msg_pingpong -I 5 &
 sleep 3
-fi_msg_pingpong 127.0.0.1
+fi_msg_pingpong -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_msg_rma
-fi_msg_rma &
+fi_msg_rma -I 5 &
 sleep 3
-fi_msg_rma 127.0.0.1
+fi_msg_rma -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_rdm
 fi_rdm &
 sleep 3
-fi_rdm 127.0.0.1
+fi_rdm $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_rma_simple
 fi_rdm_rma_simple &
 sleep 3
-fi_rdm_rma_simple 127.0.0.1
+fi_rdm_rma_simple $1
 echo ...done 
 sleep 3
 echo Running fi_dgram
 fi_dgram &
 sleep 3
-fi_dgram 127.0.0.1
+fi_dgram $1
 echo ...done 
 sleep 3
 echo Running fi_dgram_waitset
 fi_dgram_waitset &
 sleep 3
-fi_dgram_waitset 127.0.0.1
+fi_dgram_waitset $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_pingpong
-fi_rdm_pingpong &
+fi_rdm_pingpong -I 5 &
 sleep 3
-fi_rdm_pingpong 127.0.0.1
+fi_rdm_pingpong -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_tagged_pingpong
-fi_rdm_tagged_pingpong &
+fi_rdm_tagged_pingpong -I 5 &
 sleep 3
-fi_rdm_tagged_pingpong 127.0.0.1
+fi_rdm_tagged_pingpong -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_tagged_search
 fi_rdm_tagged_search &
 sleep 3
-fi_rdm_tagged_search 127.0.0.1
+fi_rdm_tagged_search $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_cntr_pingpong
-fi_rdm_cntr_pingpong &
+fi_rdm_cntr_pingpong -I 5 &
 sleep 3
-fi_rdm_cntr_pingpong 127.0.0.1
+fi_rdm_cntr_pingpong -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_rma
-fi_rdm_rma &
+fi_rdm_rma -I 5 &
 sleep 3
-fi_rdm_rma 127.0.0.1
+fi_rdm_rma -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_atomic
-fi_rdm_atomic &
+fi_rdm_atomic -I 5 &
 sleep 3
-fi_rdm_atomic 127.0.0.1
+fi_rdm_atomic -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_ud_pingpong
-fi_ud_pingpong &
+fi_ud_pingpong -I 5 &
 sleep 3
-fi_ud_pingpong 127.0.0.1
+fi_ud_pingpong -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_cq_data
 fi_cq_data &
 sleep 3
-fi_cq_data 127.0.0.1
+fi_cq_data $1
 echo ...done 
 sleep 3
 echo Running fi_poll
 fi_poll &
 sleep 3
-fi_poll 127.0.0.1
+fi_poll $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_inject_pingpong
-fi_rdm_inject_pingpong &
+fi_rdm_inject_pingpong -I 5 &
 sleep 3
-fi_rdm_inject_pingpong 127.0.0.1
+fi_rdm_inject_pingpong -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_multi_recv
 fi_rdm_multi_recv &
 sleep 3
-fi_rdm_multi_recv 127.0.0.1
+fi_rdm_multi_recv $1
 echo ...done 
 sleep 3
 echo Running fi_scalable_ep
 fi_scalable_ep &
 sleep 3
-fi_scalable_ep 127.0.0.1
+fi_scalable_ep $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_shared_ctx
 fi_rdm_shared_ctx &
 sleep 3
-fi_rdm_shared_ctx 127.0.0.1
+fi_rdm_shared_ctx $1
 echo ...done 
 sleep 3
 echo Running fi_eq_test
@@ -135,19 +140,19 @@ fi_size_left_test
 echo ...done 
 sleep 3
 echo Running fi_rc_pingpong
-fi_rc_pingpong &
+fi_rc_pingpong -n 5 &
 sleep 3
-fi_rc_pingpong 127.0.0.1
+fi_rc_pingpong -n 5 $1
 echo ...done 
 sleep 3
 echo Running fi_cmatose
-fi_cmatose &
+fi_cmatose -C 5 &
 sleep 3
-fi_cmatose -s 127.0.0.1
+fi_cmatose -s $1 -C 5 
 echo ...done 
 sleep 3
 echo fabtest
 fabtest -x &
 sleep 3
-fabtest 127.0.0.1
+fabtest $1
 echo ...done

--- a/scripts/ft_runall
+++ b/scripts/ft_runall
@@ -110,9 +110,9 @@ fi_rdm_inject_pingpong -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_multi_recv
-fi_rdm_multi_recv &
+fi_rdm_multi_recv -I 5 &
 sleep 3
-fi_rdm_multi_recv $1
+fi_rdm_multi_recv -I 5 $1
 echo ...done 
 sleep 3
 echo Running fi_scalable_ep

--- a/scripts/ft_runall
+++ b/scripts/ft_runall
@@ -1,153 +1,153 @@
 echo Running fi_info
 fi_info
 echo ...done
-sleep 1
+sleep 3
 echo Running fi_msg
 fi_msg &
-sleep 1
+sleep 3
 fi_msg 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_msg_pingpong
 fi_msg_pingpong &
-sleep 1
+sleep 3
 fi_msg_pingpong 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_msg_rma
 fi_msg_rma &
-sleep 1
+sleep 3
 fi_msg_rma 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm
 fi_rdm &
-sleep 1
+sleep 3
 fi_rdm 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_rma_simple
 fi_rdm_rma_simple &
-sleep 1
+sleep 3
 fi_rdm_rma_simple 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_dgram
 fi_dgram &
-sleep 1
+sleep 3
 fi_dgram 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_dgram_waitset
 fi_dgram_waitset &
-sleep 1
+sleep 3
 fi_dgram_waitset 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_pingpong
 fi_rdm_pingpong &
-sleep 1
+sleep 3
 fi_rdm_pingpong 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_tagged_pingpong
 fi_rdm_tagged_pingpong &
-sleep 1
+sleep 3
 fi_rdm_tagged_pingpong 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_tagged_search
 fi_rdm_tagged_search &
-sleep 1
+sleep 3
 fi_rdm_tagged_search 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_cntr_pingpong
 fi_rdm_cntr_pingpong &
-sleep 1
+sleep 3
 fi_rdm_cntr_pingpong 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_rma
 fi_rdm_rma &
-sleep 1
+sleep 3
 fi_rdm_rma 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_atomic
 fi_rdm_atomic &
-sleep 1
+sleep 3
 fi_rdm_atomic 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_ud_pingpong
 fi_ud_pingpong &
-sleep 1
+sleep 3
 fi_ud_pingpong 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_cq_data
 fi_cq_data &
-sleep 1
+sleep 3
 fi_cq_data 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_poll
 fi_poll &
-sleep 1
+sleep 3
 fi_poll 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_inject_pingpong
 fi_rdm_inject_pingpong &
-sleep 1
+sleep 3
 fi_rdm_inject_pingpong 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_multi_recv
 fi_rdm_multi_recv &
-sleep 1
+sleep 3
 fi_rdm_multi_recv 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_scalable_ep
 fi_scalable_ep &
-sleep 1
+sleep 3
 fi_scalable_ep 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rdm_shared_ctx
 fi_rdm_shared_ctx &
-sleep 1
+sleep 3
 fi_rdm_shared_ctx 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_eq_test
 fi_eq_test
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_av_test
 fi_av_test
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_size_left_test
 fi_size_left_test
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_rc_pingpong
 fi_rc_pingpong &
-sleep 1
+sleep 3
 fi_rc_pingpong 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo Running fi_cmatose
 fi_cmatose &
-sleep 1
+sleep 3
 fi_cmatose 127.0.0.1
 echo ...done 
-sleep 1
+sleep 3
 echo fabtest
 fabtest -x &
-sleep 1
+sleep 3
 fabtest 127.0.0.1
 echo ...done

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -475,6 +475,7 @@ static int run(void)
 
 	run_test();
 
+	ft_finalize(ep, scq, rcq, FI_ADDR_UNSPEC);
 	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -183,11 +183,7 @@ static int bind_ep_res(void)
 	ret = fi_enable(ep);
 	if (ret)
 		return ret;
-
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
-	if (ret)
-		FT_PRINTERR("fi_recv", ret);
-
+	
 	return ret;
 }
 
@@ -273,6 +269,9 @@ static int server_connect(void)
 		goto err1;
 	}
 
+	/* Add FI_REMOTE_COMPLETE flag to ensure completion */
+	info->tx_attr->op_flags = FI_REMOTE_COMPLETE;
+	
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
@@ -350,6 +349,9 @@ static int client_connect(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
+	
+	/* Add FI_REMOTE_COMPLETE flag to ensure completion */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
@@ -475,7 +477,6 @@ static int run(void)
 
 	run_test();
 
-	ft_finalize(ep, scq, rcq, FI_ADDR_UNSPEC);
 	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -181,13 +181,6 @@ static int bind_ep_res(void)
 		return ret;
 	 }
 
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0,
-			&fi_ctx_recv);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-
 	return ret;
 }
 
@@ -228,9 +221,11 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
+	
+	/* Add FI_REMOTE_COMPLETE flag to ensure completion */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 
 	/* Open endpoint */
-	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -181,6 +181,13 @@ static int bind_ep_res(void)
 		return ret;
 	 }
 
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0,
+			&fi_ctx_recv);
+	if (ret) {
+		FT_PRINTERR("fi_recv", ret);
+		return ret;
+	}
+
 	return ret;
 }
 
@@ -191,7 +198,7 @@ static int init_fabric(void)
 	
 	/* Set FI_SOURCE flag to enforce the port number to be the local port 
 	 * the server will be bound to */
-	if(!dst_addr) 
+	if (!dst_addr)
 		flags = FI_SOURCE;
 	
 	/* Get fabric info */
@@ -202,7 +209,7 @@ static int init_fabric(void)
 	}
 	
 	/* Get remote address of the server */
-	if(dst_addr){
+	if (dst_addr) {
 		addrlen = fi->dest_addrlen;
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, fi->dest_addr, addrlen);
@@ -223,6 +230,7 @@ static int init_fabric(void)
 	}
 
 	/* Open endpoint */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
@@ -239,7 +247,7 @@ static int init_fabric(void)
 	if (ret)
 		goto err5;
 	
-	if(dst_addr){
+	if (dst_addr) {
 		/* Insert address to the AV and get the fabric address back */ 	
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
@@ -355,7 +363,6 @@ int main(int argc, char **argv)
 	/* Exchange data */
 	ret = send_recv();
 
-	/* Tear down */
 	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -204,6 +204,12 @@ static int bind_ep_res(void)
 		return ret;
 	}
 
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0,
+			&fi_ctx_recv);
+	if (ret) {
+		FT_PRINTERR("fi_recv", ret);
+		return ret;
+	}
 	return ret;
 }
 
@@ -488,7 +494,7 @@ int main(int argc, char **argv)
 	/* Exchange data */
 	ret = send_recv();
 
-	/* Tear down */
+	ft_finalize(ep, scq, rcq, remote_fi_addr);
 	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -204,12 +204,6 @@ static int bind_ep_res(void)
 		return ret;
 	}
 
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0,
-			&fi_ctx_recv);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
 	return ret;
 }
 
@@ -286,7 +280,10 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
-
+	
+	/* Add FI_REMOTE_COMPLETE flag to ensure completion */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
+	
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
@@ -494,7 +491,6 @@ int main(int argc, char **argv)
 	/* Exchange data */
 	ret = send_recv();
 
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
 	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -258,9 +258,11 @@ static int server_connect(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
+	
+	/* Add FI_REMOTE_COMPLETE flag to ensure completion */
+	info->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 
 	/* Open the endpoint */
-	info->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
@@ -339,9 +341,11 @@ static int client_connect(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
+	
+	/* Add FI_REMOTE_COMPLETE flag to ensure completion */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 
 	/* Open endpoint */
-	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -468,7 +468,7 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:h")) != -1) {
 		switch (op) {					
 		case 'f':
-			hints->fabric_attr->prov_name = optarg;
+			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		case '?':
 		case 'h':

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -260,6 +260,7 @@ static int server_connect(void)
 	}
 
 	/* Open the endpoint */
+	info->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_endpoint(dom, info, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
@@ -340,6 +341,7 @@ static int client_connect(void)
 	}
 
 	/* Open endpoint */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
@@ -494,7 +496,6 @@ int main(int argc, char **argv)
 	/* Exchange data */
 	ret = send_recv();
 
-	/* Tear down */
 	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -264,9 +264,12 @@ static int bind_ep_res(void)
 	}
 
 	ret = fi_enable(ep);
-	if (ret)
+	if (ret) {
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
+	}
 
+	/* Post the first recv buffer */
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
 		FT_PRINTERR("fi_recv", ret);
@@ -526,6 +529,7 @@ static int run(void)
 	}
 
 	ret = wait_for_completion(scq, max_credits - credits);
+	/* Finalize before closing ep */
 	ft_finalize(ep, scq, rcq, FI_ADDR_UNSPEC);
 out:
 	fi_shutdown(ep, 0);

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -520,10 +520,6 @@ static int run(void)
 	}
 
 	ret = wait_for_completion(scq, max_credits - credits);
-	if (ret) {
-		return ret;
-	}
-	credits = max_credits;
 
 	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -191,7 +191,8 @@ static int alloc_ep_res(void)
 	struct fi_cq_attr cq_attr;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
+	buffer_size = opts.user_options & FT_OPT_SIZE ?
+			opts.transfer_size : test_size[TEST_CNT - 1].size;
 	buf = malloc(buffer_size);
 	if (!buf) {
 		perror("malloc");
@@ -506,21 +507,25 @@ static int run(void)
 		return ret;
 	}
 
-	if (!opts.custom) {
+	if (!(opts.user_options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
-			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &opts.transfer_size,
-					&opts.iterations);
-			run_test();
+			opts.transfer_size = test_size[i].size;
+			init_test(&opts, test_name, sizeof(test_name));
+			ret = run_test();
+			if (ret)
+				goto out;
 		}
 	} else {
+		init_test(&opts, test_name, sizeof(test_name));
 		ret = run_test();
+		if (ret)
+			goto out;
 	}
 
 	ret = wait_for_completion(scq, max_credits - credits);
-
+out:
 	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -104,6 +104,7 @@ static int recv_xfer(int size)
 		}
 	} while (!ret);
 
+
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
 		FT_PRINTERR("fi_recv", ret);
@@ -525,6 +526,7 @@ static int run(void)
 	}
 
 	ret = wait_for_completion(scq, max_credits - credits);
+	ft_finalize(ep, scq, rcq, FI_ADDR_UNSPEC);
 out:
 	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -367,9 +367,12 @@ static int bind_ep_res(void)
 	}
 
 	ret = fi_enable(ep);
-	if (ret)
+	if (ret) {
+		FT_PRINTERR("fi_enable", ret);
 		return ret;
-
+	}
+	
+	/* Post the first recv buffer */
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)
 		FT_PRINTERR("fi_recv", ret);
@@ -642,6 +645,7 @@ static int run(void)
 
 	sync_test();
 	wait_for_data_completion(scq, max_credits - credits);
+	/* Finalize before closing ep */
 	ft_finalize(ep, scq, rcq, FI_ADDR_UNSPEC);
 out:
 	fi_shutdown(ep, 0);

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -587,7 +587,7 @@ err0:
 
 static int exchange_addr_key(void)
 {
-	local.addr = (uint64_t)buf;
+	local.addr = (uintptr_t) buf;
 	local.key = fi_mr_key(mr);
 
 	if (opts.dst_addr) {

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -281,8 +281,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	uint64_t access_mode;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : 
-		opts.transfer_size;
+	buffer_size = opts.user_options & FT_OPT_SIZE ?
+			opts.transfer_size : test_size[TEST_CNT - 1].size;
 	buf = malloc(MAX(buffer_size, sizeof(uint64_t)));
 	if (!buf) {
 		perror("malloc");
@@ -623,19 +623,21 @@ static int run(void)
 	if (ret)
 		return ret;
 
-	if (!opts.custom) {
+	if (!(opts.user_options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
-			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &opts.transfer_size,
-					&opts.iterations);
+			opts.transfer_size = test_size[i].size;
+			init_test(&opts, test_name, sizeof(test_name));
 			ret = run_test();
-			if(ret)
+			if (ret)
 				goto out;
 		}
 	} else {
+		init_test(&opts, test_name, sizeof(test_name));
 		ret = run_test();
+		if (ret)
+			goto out;
 	}
 
 	sync_test();

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -642,6 +642,7 @@ static int run(void)
 
 	sync_test();
 	wait_for_data_completion(scq, max_credits - credits);
+	ft_finalize(ep, scq, rcq, FI_ADDR_UNSPEC);
 out:
 	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -639,7 +639,7 @@ static int run(void)
 	}
 
 	sync_test();
-
+	wait_for_data_completion(scq, max_credits - credits);
 out:
 	fi_shutdown(ep, 0);
 	fi_close(&ep->fid);

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -512,7 +512,7 @@ int main(int argc, char **argv)
 	/* Exchange data */
 	ret = send_recv();
 
-	/* Tear down */
+	ft_finalize(ep, scq, rcq, remote_fi_addr);
 	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -284,7 +284,9 @@ static int init_fabric(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
-
+	
+	/* Add FI_REMOTE_COMPLETE flag to ensure completion */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
@@ -512,7 +514,6 @@ int main(int argc, char **argv)
 	/* Exchange data */
 	ret = send_recv();
 
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
 	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -221,9 +221,11 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
+	
+	/* Add FI_REMOTE_COMPLETE flag to ensure completion */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 
 	/* Open endpoint */
-	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -191,7 +191,7 @@ static int init_fabric(void)
 	
 	/* Set FI_SOURCE flag to enforce the port number to be the local port 
 	 * the server will be bound to */
-	if(!dst_addr) 
+	if (!dst_addr)
 		flags = FI_SOURCE;
 	
 	/* Get fabric info */
@@ -202,7 +202,7 @@ static int init_fabric(void)
 	}
 	
 	/* Get remote address of the server */
-	if(dst_addr){
+	if (dst_addr) {
 		addrlen = fi->dest_addrlen;
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, fi->dest_addr, addrlen);
@@ -223,6 +223,7 @@ static int init_fabric(void)
 	}
 
 	/* Open endpoint */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
@@ -239,7 +240,7 @@ static int init_fabric(void)
 	if (ret)
 		goto err5;
 	
-	if(dst_addr){
+	if (dst_addr) {
 		/* Insert address to the AV and get the fabric address back */ 	
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
 				&fi_ctx_av);
@@ -352,7 +353,6 @@ int main(int argc, char **argv)
 	/* Exchange data */
 	ret = send_recv();
 
-	/* Tear down */
 	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -486,6 +486,17 @@ static int bind_ep_res(void)
 	}
 
 	ret = fi_enable(ep);
+	if(ret) {
+		FT_PRINTERR("fi_enable", ret);
+		return ret;
+	}
+	
+	/* Post the first recv buffer */
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
+	if (ret) {
+		FT_PRINTERR("fi_recv", ret);
+		return ret;
+	}
 
 	return ret;
 }
@@ -627,7 +638,7 @@ static int init_av(void)
 		if (ret)
 			return ret;
 	}
-	
+
 	return ret;	
 }
 
@@ -696,7 +707,7 @@ static int run(void)
 		if (ret)
 			goto out;
 	}
-
+	/* Finalize before closing ep */
 	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -697,8 +697,7 @@ static int run(void)
 			goto out;
 	}
 
-	sync_test();
-
+	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -636,7 +636,7 @@ static int exchange_addr_key(void)
 	int ret;
 	int len = sizeof(local);
 
-	local.addr = (uint64_t)buf;
+	local.addr = (uintptr_t) buf;
 	local.key = fi_mr_key(mr);
 
 	if (opts.dst_addr) {

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -369,8 +369,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : 
-		opts.transfer_size;
+	buffer_size = opts.user_options & FT_OPT_SIZE ?
+			opts.transfer_size : test_size[TEST_CNT - 1].size;
 	buf = malloc(MAX(buffer_size, sizeof(uint64_t)));
 	if (!buf) {
 		perror("malloc");
@@ -680,26 +680,22 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!opts.custom) {
+	if (!(opts.user_options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
-			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &opts.transfer_size,
-					&opts.iterations);
+			opts.transfer_size = test_size[i].size;
+			init_test(&opts, test_name, sizeof(test_name));
 			ret = run_test();
-			if (ret) {
-				fprintf(stderr, "Test failed at iteration %d, "
-						"msg size %d\n", i, 
-						opts.transfer_size);
+			if (ret)
 				goto out;
-			}
 		}
 	} else {
+		init_test(&opts, test_name, sizeof(test_name));
 		ret = run_test();
 		if (ret)
 			goto out;
-	}	
+	}
 
 	sync_test();
 

--- a/simple/rdm_atomic.c
+++ b/simple/rdm_atomic.c
@@ -300,14 +300,13 @@ static int run_op(void)
 		goto out;
 
 	if (opts.machr)
-		show_perf(test_name, opts.transfer_size, opts.iterations, 
-				&start, &end, op_type == FI_CSWAP ? 1 : 2);
-	else
 		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end,
 				op_type == FI_CSWAP ? 1 : 2, opts.argc, opts.argv);
+	else
+		show_perf(test_name, opts.transfer_size, opts.iterations, 
+				&start, &end, op_type == FI_CSWAP ? 1 : 2);
 
 	ret = 0;
-
 out:
 	free(count);
 	return ret;

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -229,7 +229,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
+	buffer_size = opts.user_options & FT_OPT_SIZE ?
+			opts.transfer_size : test_size[TEST_CNT - 1].size;
 	buf = malloc(buffer_size);
 	if (!buf) {
 		perror("malloc");
@@ -474,17 +475,21 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!opts.custom) {
+	if (!(opts.user_options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
-			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &opts.transfer_size,
-					&opts.iterations);
-			run_test();
+			opts.transfer_size = test_size[i].size;
+			init_test(&opts, test_name, sizeof(test_name));
+			ret = run_test();
+			if (ret)
+				goto out;
 		}
 	} else {
+		init_test(&opts, test_name, sizeof(test_name));
 		ret = run_test();
+		if (ret)
+			goto out;
 	}
 
 	get_send_completions();

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -493,6 +493,7 @@ static int run(void)
 	}
 
 	get_send_completions();
+	/* TODO: need support for finalize operation to sync test */
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_cntr_pingpong.c
+++ b/simple/rdm_cntr_pingpong.c
@@ -487,10 +487,7 @@ static int run(void)
 		ret = run_test();
 	}
 
-	ret = get_send_completions();
-	if (ret)
-		goto out;
-
+	get_send_completions();
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -470,6 +470,7 @@ static int run(void)
 			goto out;
 	}
 
+	/* Finalize before closing ep */
 	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -470,6 +470,7 @@ static int run(void)
 			goto out;
 	}
 
+	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -193,7 +193,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
+	buffer_size = opts.user_options & FT_OPT_SIZE ?
+			opts.transfer_size : test_size[TEST_CNT - 1].size;
 	send_buf = malloc(buffer_size);
 	recv_buf = malloc(buffer_size);
 	if (!send_buf || !recv_buf) {
@@ -309,7 +310,8 @@ static int init_fabric(void)
 	
 	/* check max msg size */
 	max_inject_size = fi->tx_attr->inject_size;
-	if (opts.custom && opts.transfer_size > max_inject_size) {
+	if ((opts.user_options & FT_OPT_SIZE) &&
+	    (opts.transfer_size > max_inject_size)) {
 		fprintf(stderr, "Msg size greater than max inject size\n");
 		ret = -FI_EINVAL;
 		goto err0;
@@ -451,17 +453,21 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!opts.custom) {
+	if (!(opts.user_options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
-			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &opts.transfer_size,
-					&opts.iterations);
-			run_test();
+			opts.transfer_size = test_size[i].size;
+			init_test(&opts, test_name, sizeof(test_name));
+			ret = run_test();
+			if (ret)
+				goto out;
 		}
 	} else {
+		init_test(&opts, test_name, sizeof(test_name));
 		ret = run_test();
+		if (ret)
+			goto out;
 	}
 
 out:

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -572,12 +572,7 @@ static int run(void)
 
 	ret = run_test();	
 	
-	//synchronize before exiting
-	ret = sync_test();
-	if (ret) {
-		fprintf(stderr, "sync_test failed!\n");
-		goto out;
-	}
+	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -571,7 +571,7 @@ static int run(void)
 		goto out;
 
 	ret = run_test();	
-	
+	/* Finalize before closing ep */
 	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -215,7 +215,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
+	buffer_size = opts.user_options & FT_OPT_SIZE ?
+			opts.transfer_size : test_size[TEST_CNT - 1].size;
 	buf = malloc(buffer_size);
 	if (!buf) {
 		perror("malloc");
@@ -460,17 +461,21 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!opts.custom) {
+	if (!(opts.user_options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
-			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &opts.transfer_size,
-					&opts.iterations);
-			run_test();
+			opts.transfer_size = test_size[i].size;
+			init_test(&opts, test_name, sizeof(test_name));
+			ret = run_test();
+			if (ret)
+				goto out;
 		}
 	} else {
+		init_test(&opts, test_name, sizeof(test_name));
 		ret = run_test();
+		if (ret)
+			goto out;
 	}
 
 	wait_for_completion(scq, max_credits - credits);

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -479,6 +479,7 @@ static int run(void)
 	}
 
 	wait_for_completion(scq, max_credits - credits);
+	/* Finalize before closing ep */
 	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -479,6 +479,7 @@ static int run(void)
 	}
 
 	wait_for_completion(scq, max_credits - credits);
+	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -473,12 +473,7 @@ static int run(void)
 		ret = run_test();
 	}
 
-	ret = wait_for_completion(scq, max_credits - credits);
-	if (ret) {
-		goto out;
-	}
-	credits = max_credits;
-
+	wait_for_completion(scq, max_credits - credits);
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -488,7 +488,7 @@ static int init_av(void)
 
 static int exchange_addr_key(void)
 {
-	local.addr = (uint64_t)buf;
+	local.addr = (uintptr_t) buf;
 	local.key = fi_mr_key(mr);
 
 	if (opts.dst_addr) {

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -540,8 +540,7 @@ static int run(void)
 			goto out;
 	}
 
-	sync_test();
-
+	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -246,7 +246,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	uint64_t access_mode;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
+	buffer_size = opts.user_options & FT_OPT_SIZE ?
+			opts.transfer_size : test_size[TEST_CNT - 1].size;
 	buf = malloc(MAX(buffer_size, sizeof(uint64_t)));
 	if (!buf) {
 		perror("malloc");
@@ -522,19 +523,21 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!opts.custom) {
+	if (!(opts.user_options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
-			init_test(test_size[i].size, test_name, 
-					sizeof(test_name), &opts.transfer_size, 
-					&opts.iterations);
+			opts.transfer_size = test_size[i].size;
+			init_test(&opts, test_name, sizeof(test_name));
 			ret = run_test();
-			if(ret)
+			if (ret)
 				goto out;
 		}
 	} else {
+		init_test(&opts, test_name, sizeof(test_name));
 		ret = run_test();
+		if (ret)
+			goto out;
 	}
 
 	sync_test();

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -483,6 +483,13 @@ static int init_av(void)
 		if (ret)
 			return ret;
 	}
+	
+	/* Post the first recv buffer */
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
+	if (ret) {
+		FT_PRINTERR("fi_recv", ret);
+		return ret;
+	}
 
 	return ret;
 }
@@ -539,7 +546,7 @@ static int run(void)
 		if (ret)
 			goto out;
 	}
-
+	/* Finalize before closing ep */
 	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -313,11 +313,11 @@ static int run_test(void)
 		fprintf(stdout, "Received data from Client: %s\n", (char *)buf);
 	}
 
+	/* TODO: need support for finalize operation to sync test */
 	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);
 	fi_close(&fab->fid);
-
 	return 0;
 }
 

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -345,7 +345,7 @@ int main(int argc, char **argv)
 		dst_addr = argv[optind];
 
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_MSG | FI_RMA | FI_REMOTE_COMPLETE;
+	hints->caps = FI_MSG | FI_RMA;
 	// FI_PROV_MR_ATTR flag is not set
 	hints->mode = FI_CONTEXT;
 

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -241,7 +241,10 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
-
+	
+	/* Add FI_REMOTE_COMPLETE flag to ensure completion */
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
+	
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -498,7 +498,8 @@ static int run(void)
 		goto out;
 
 	run_test();
-	ft_finalize(ep[0], scq, rcq, remote_fi_addr[0]);
+	/* TODO: Add a local finalize applicable to shared ctx */
+	//ft_finalize(ep[0], scq, rcq, remote_fi_addr[0]);
 out:
 	free_ep_res();
 	FT_CLOSEV(ep, ep_cnt);

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -498,7 +498,7 @@ static int run(void)
 		goto out;
 
 	run_test();
-
+	ft_finalize(ep[0], scq, rcq, remote_fi_addr[0]);
 out:
 	free_ep_res();
 	FT_CLOSEV(ep, ep_cnt);

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -40,11 +40,13 @@
 #include <rdma/fi_cm.h>
 #include <shared.h>
 
-#define FI_CLOSEV(FID_C, NUM)				\
-	do {						\
-		int i;					\
-		for (i = 0; i < NUM; i++)		\
-			fi_close(&FID_C[i]->fid);	\
+#define FT_CLOSEV(FID_C, NUM)			\
+	do {					\
+		int i;				\
+		for (i = 0; i < NUM; i++) {	\
+			if (FID_C[i])		\
+				fi_close(&FID_C[i]->fid); \
+		}				\
 	} while (0)
 
 static void *buf;
@@ -351,7 +353,7 @@ static int init_fabric(void)
 	fi->ep_attr->tx_ctx_cnt = FI_SHARED_CONTEXT;
 	fi->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;
 
-	ep = (struct fid_ep **)malloc(sizeof(*ep) * ep_cnt);
+	ep = calloc(ep_cnt, sizeof(*ep));
 	for (i = 0; i < ep_cnt; i++) {
 		if (!ep) {
 			perror("malloc");
@@ -378,7 +380,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	FI_CLOSEV(ep, ep_cnt);
+	FT_CLOSEV(ep, ep_cnt);
 err2:
 	fi_close(&dom->fid);
 err1:
@@ -499,7 +501,7 @@ static int run(void)
 
 out:
 	free_ep_res();
-	FI_CLOSEV(ep, ep_cnt);
+	FT_CLOSEV(ep, ep_cnt);
 	fi_close(&dom->fid);
 	fi_close(&fab->fid);
 	return ret;

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -328,8 +328,8 @@ static int bind_ep_res(void)
 		return ret;
 	}
 
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0,
-			&fi_ctx_recv);
+	/* Post the first recv buffer */
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
 		return ret;
@@ -517,6 +517,7 @@ static int run(void)
 	}
 
 	wait_for_completion_tagged(scq, max_credits - credits);
+	/* Finalize before closing ep */
 	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -503,12 +503,7 @@ static int run(void)
 		ret = run_test();
 	}
 
-	ret = wait_for_completion_tagged(scq, max_credits - credits);
-	if (ret) {
-		goto out;
-	}
-	credits = max_credits;
-
+	wait_for_completion_tagged(scq, max_credits - credits);
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -244,7 +244,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
+	buffer_size = opts.user_options & FT_OPT_SIZE ?
+			opts.transfer_size : test_size[TEST_CNT - 1].size;
 	buf = malloc(buffer_size);
 	if (!buf) {
 		perror("malloc");
@@ -490,17 +491,21 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!opts.custom) {
+	if (!(opts.user_options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
-			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &opts.transfer_size,
-					&opts.iterations);
-			run_test();
+			opts.transfer_size = test_size[i].size;
+			init_test(&opts, test_name, sizeof(test_name));
+			ret = run_test();
+			if (ret)
+				goto out;
 		}
 	} else {
+		init_test(&opts, test_name, sizeof(test_name));
 		ret = run_test();
+		if (ret)
+			goto out;
 	}
 
 	wait_for_completion_tagged(scq, max_credits - credits);

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -440,7 +440,7 @@ static int run(void)
 		goto out;
 	
 	// Receiver
-	if(dst_addr) {
+	if (dst_addr) {
 		// search for initial tag, it should fail since the sender 
 		// hasn't sent anyting
 		fprintf(stdout, "Searching msg with tag [%" PRIu64 "]\n", tag_data);
@@ -449,7 +449,7 @@ static int run(void)
 		fprintf(stdout, "Posting buffer for msg with tag [%" PRIu64 "]\n", 
 				tag_data + 1);
 		ret = post_recv(tag_data + 1);
-		if(ret)
+		if (ret)
 			goto out;
 		
 		// synchronize with sender
@@ -460,7 +460,7 @@ static int run(void)
 		
 		// wait for the completion event of the next tag
 		ret = wait_for_tagged_completion(rcq, 1);
-		if(ret)
+		if (ret)
 			goto out;
 		fprintf(stdout, "Received completion event for msg with tag "
 				"[%" PRIu64 "]\n", tag_data + 1);
@@ -473,7 +473,7 @@ static int run(void)
 		
 		// wait for the completion event of the initial tag
 		ret = recv_msg(tag_data);	
-		if(ret)
+		if (ret)
 			goto out;
 		fprintf(stdout, "Posted buffer and received completion event for"
 			       " msg with tag [%" PRIu64 "]\n", tag_data);
@@ -488,20 +488,17 @@ static int run(void)
 		fprintf(stdout, "Sending msg with tag [%" PRIu64 "]\n",
 			tag_data);
 		ret = send_msg(16, tag_data);
-		if(ret)
+		if (ret)
 			goto out;
 
 		fprintf(stdout, "Sending msg with tag [%" PRIu64 "]\n",
 			tag_data + 1);
 		ret = send_msg(16, tag_data + 1);
-		if(ret)
+		if (ret)
 			goto out;
 	}
 	
-	// sychronize before exiting
-	ret = sync_test();
-	if (ret)
-		goto out;
+	sync_test();
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -498,7 +498,7 @@ static int run(void)
 			goto out;
 	}
 	
-	sync_test();
+	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);
 	free_ep_res();

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -258,6 +258,13 @@ static int bind_ep_res(void)
 		return ret;
 	}
 
+	/* Post a recv buffer for synchronization */
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
+	if (ret) {
+		FT_PRINTERR("fi_recv", ret);
+		return ret;
+	}
+
 	return ret;
 }
 
@@ -308,7 +315,8 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
-
+	
+	fi->tx_attr->op_flags = FI_REMOTE_COMPLETE;
 	ret = fi_endpoint(dom, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
@@ -497,7 +505,7 @@ static int run(void)
 		if (ret)
 			goto out;
 	}
-	
+	/* Finalize before closing ep */
 	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	fi_close(&ep->fid);

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -497,6 +497,7 @@ static int run(void)
 		goto out;
 
 	run_test();
+	ft_finalize(tx_ep[0], scq[0], rcq[0], remote_rx_addr[0]);
 out:
 	free_ep_res();
 	fi_close(&sep->fid);

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -497,7 +497,8 @@ static int run(void)
 		goto out;
 
 	run_test();
-	ft_finalize(tx_ep[0], scq[0], rcq[0], remote_rx_addr[0]);
+	/*TODO: Add a local finalize applicable for scalable ep */
+	//ft_finalize(tx_ep[0], scq[0], rcq[0], remote_rx_addr[0]);
 out:
 	free_ep_res();
 	fi_close(&sep->fid);

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -206,7 +206,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = !opts.custom ? test_size[TEST_CNT - 1].size : opts.transfer_size;
+	buffer_size = opts.user_options & FT_OPT_SIZE ?
+			opts.transfer_size : test_size[TEST_CNT - 1].size;
 	if (max_msg_size > 0 && buffer_size > max_msg_size) {
 		buffer_size = max_msg_size;
 	}
@@ -485,25 +486,27 @@ static int run(void)
 	if (ret)
 		return ret;
 
-	if (!opts.custom) {
+	if (!(opts.user_options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
-			if (test_size[i].option > opts.size_option ||
-				(max_msg_size && test_size[i].size > max_msg_size)) {
+			if (test_size[i].option > opts.size_option)
 				continue;
-			}
-			init_test(test_size[i].size, test_name,
-					sizeof(test_name), &opts.transfer_size,
-					&opts.iterations);
-			run_test();
+			opts.transfer_size = test_size[i].size;
+			init_test(&opts, test_name, sizeof(test_name));
+			ret = run_test();
+			if (ret)
+				goto out;
 		}
 	} else {
-
+		init_test(&opts, test_name, sizeof(test_name));
 		ret = run_test();
+		if (ret)
+			goto out;
 	}
 
 	while (credits < max_credits)
 		poll_all_sends();
 
+out:
 	ret = fi_close(&ep->fid);
 	if (ret != 0) {
 		FT_PRINTERR("fi_close", ret);

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -296,6 +296,7 @@ static int bind_ep_res(void)
 		return ret;
 	}
 
+	/* Post the first recv buffer */
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
@@ -505,6 +506,7 @@ static int run(void)
 
 	while (credits < max_credits)
 		poll_all_sends();
+	
 	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	ret = fi_close(&ep->fid);

--- a/simple/ud_pingpong.c
+++ b/simple/ud_pingpong.c
@@ -59,7 +59,7 @@ static size_t prefix_len;
 static size_t max_msg_size = 0;
 
 static struct fi_info *hints;
-static fi_addr_t rem_addr;
+static fi_addr_t remote_fi_addr;
 
 static struct fi_info *fi;
 static struct fid_fabric *fab;
@@ -104,7 +104,7 @@ static int send_xfer(int size)
 	credits--;
 post:
 	ret = fi_send(ep, buf_ptr, (size_t) size, fi_mr_desc(mr),
-			rem_addr, NULL);
+			remote_fi_addr, NULL);
 	if (ret)
 		FT_PRINTERR("fi_send", ret);
 
@@ -393,7 +393,7 @@ static int client_connect(void)
 	if (ret != 0)
 		goto err;
 
-	ret = fi_av_insert(av, hints->dest_addr, 1, &rem_addr, 0, NULL);
+	ret = fi_av_insert(av, hints->dest_addr, 1, &remote_fi_addr, 0, NULL);
 	if (ret != 1) {
 		FT_PRINTERR("fi_av_insert", ret);
 		goto err;
@@ -446,7 +446,7 @@ static int server_connect(void)
 		}
 	} while (ret == 0);
 
-	ret = fi_av_insert(av, buf_ptr, 1, &rem_addr, 0, NULL);
+	ret = fi_av_insert(av, buf_ptr, 1, &remote_fi_addr, 0, NULL);
 	if (ret != 1) {
 		if (ret == 0) {
 			fprintf(stderr, "Unable to resolve remote address 0x%x 0x%x\n",
@@ -505,7 +505,7 @@ static int run(void)
 
 	while (credits < max_credits)
 		poll_all_sends();
-
+	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	ret = fi_close(&ep->fid);
 	if (ret != 0) {

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -79,13 +79,13 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:p:n:")) != -1) {
 		switch (op) {
 		case 'f':
-			fabric_hints.name = optarg;
+			fabric_hints.name = strdup(optarg);
 			break;
 		case 'n':
 			num_domains = atoi(optarg);
 			break;
 		case 'p':
-			fabric_hints.prov_name = optarg;
+			fabric_hints.prov_name = strdup(optarg);
 			break;
 		default:
 			printf("usage: %s\n", argv[0]);


### PR DESCRIPTION
This PR is based on @shefty 's PR on synchronization issue:
- Fixed missing FI_REMOTE_COMPLETE flag for simple tests
- Added missing posting buffer required for ft_finalize call before closing ep
- Added missing stdup for string assignment
- Corrected function call for machine readable print

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>