### PR TITLE
Fix fabtest to run over sockets provider in virtual linux

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -87,6 +87,7 @@ struct ft_xcontrol {
 	size_t			max_credits;
 	fi_addr_t		addr;
 	uint64_t		tag;
+	uint8_t			seqno;
 	enum fi_cq_format	cq_format;
 	enum fi_wait_obj	comp_wait;  /* must be NONE */
 };
@@ -110,6 +111,7 @@ extern struct ft_control ft;
 enum {
 	FT_MAX_CAPS		= 64,
 	FT_MAX_EP_TYPES		= 8,
+	FT_MAX_AV_TYPES		= 3,
 	FT_MAX_PROV_MODES	= 4,
 	FT_DEFAULT_CREDITS	= 128,
 	FT_COMP_BUF_SIZE	= 256,
@@ -147,6 +149,7 @@ struct ft_set {
 	enum ft_test_type	test_type[FT_MAX_TEST];
 	enum ft_class_function	class_function[FT_MAX_FUNCTIONS];
 	enum fi_ep_type		ep_type[FT_MAX_EP_TYPES];
+	enum fi_av_type		av_type[FT_MAX_AV_TYPES];
 	enum ft_comp_type	comp_type[FT_MAX_COMP];
 	uint64_t		mode[FT_MAX_PROV_MODES];
 	uint64_t		caps[FT_MAX_CAPS];
@@ -162,6 +165,7 @@ struct ft_series {
 	int			cur_type;
 	int			cur_func;
 	int			cur_ep;
+	int			cur_av;
 	int			cur_comp;
 	int			cur_mode;
 	int			cur_caps;
@@ -221,6 +225,7 @@ void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt);
 
 int ft_recv_msg();
 int ft_send_msg();
+int ft_send_dgram();
 int ft_recv_dgram();
 int ft_sendrecv_dgram();
 

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -59,6 +59,10 @@ static struct ft_set test_sets[] = {
 			FI_EP_DGRAM,
 			FI_EP_RDM
 		},
+		.av_type = {
+			FI_AV_TABLE,
+			FI_AV_MAP
+		},
 		.comp_type = {
 			FT_COMP_QUEUE
 		},
@@ -158,6 +162,7 @@ void fts_start(struct ft_series *series, int index)
 	series->cur_set = 0;
 	series->cur_type = 0;
 	series->cur_ep = 0;
+	series->cur_av = 0;
 	series->cur_comp = 0;
 	series->cur_mode = 0;
 	series->cur_caps = 0;
@@ -195,6 +200,13 @@ void fts_next(struct ft_series *series)
 		return;
 	series->cur_comp = 0;
 
+	if (set->ep_type[series->cur_ep] == FI_EP_RDM ||
+	    set->ep_type[series->cur_ep] == FI_EP_DGRAM) {
+		if (set->av_type[++series->cur_av])
+			return;
+	}
+	series->cur_av = 0;
+
 	if (set->ep_type[++series->cur_ep])
 		return;
 	series->cur_ep = 0;
@@ -228,6 +240,7 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->mode = (set->mode[series->cur_mode] == FT_MODE_NONE) ?
 			0 : set->mode[series->cur_mode];
 	info->ep_type = set->ep_type[series->cur_ep];
+	info->av_type = set->av_type[series->cur_av];
 	info->comp_type = set->comp_type[series->cur_comp];
 
 	memcpy(info->node, set->node, FI_NAME_MAX);

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -218,9 +218,13 @@ static int ft_pingpong_dgram(void)
 				return ret;
 		}
 	} else {
-		ret = ft_recv_dgram();
-		if (ret)
-			return ret;
+		for (i = 0; i < 1000; i++) {
+			ret = ft_recv_dgram();
+			if (!ret)
+				break;
+			else if (ret != -FI_ETIMEDOUT)
+				return ret;
+		}
 
 		for (i = 0; i < ft.xfer_iter - 1; i++) {
 			ret = ft_sendrecv_dgram();
@@ -228,7 +232,7 @@ static int ft_pingpong_dgram(void)
 				return ret;
 		}
 
-		ret = ft_send_msg();
+		ret = ft_send_dgram();
 		if (ret)
 			return ret;
 	}

--- a/scripts/ft_runall
+++ b/scripts/ft_runall
@@ -19,10 +19,22 @@ sleep 3
 fi_msg_pingpong -I 5 $1
 echo ...done 
 sleep 3
-echo Running fi_msg_rma
-fi_msg_rma -I 5 &
+echo Running fi_msg_rma write
+fi_msg_rma -I 5 -o write &
 sleep 3
-fi_msg_rma -I 5 $1
+fi_msg_rma -I 5 -o write $1
+echo ...done 
+sleep 3
+echo Running fi_msg_rma read
+fi_msg_rma -I 5 -o read &
+sleep 3
+fi_msg_rma -I 5 -o read $1
+echo ...done 
+sleep 3
+echo Running fi_msg_rma writedata
+fi_msg_rma -I 5 -o writedata &
+sleep 3
+fi_msg_rma -I 5 -o writedata $1
 echo ...done 
 sleep 3
 echo Running fi_rdm
@@ -73,10 +85,22 @@ sleep 3
 fi_rdm_cntr_pingpong -I 5 $1
 echo ...done 
 sleep 3
-echo Running fi_rdm_rma
-fi_rdm_rma -I 5 &
+echo Running fi_rdm_rma write
+fi_rdm_rma -I 5 -o write &
 sleep 3
-fi_rdm_rma -I 5 $1
+fi_rdm_rma -I 5 -o write $1
+echo ...done 
+sleep 3
+echo Running fi_rdm_rma read
+fi_rdm_rma -I 5 -o read &
+sleep 3
+fi_rdm_rma -I 5 -o read $1
+echo ...done 
+sleep 3
+echo Running fi_rdm_rma writedata
+fi_rdm_rma -I 5 -o writedata &
+sleep 3
+fi_rdm_rma -I 5 -o writedata $1
 echo ...done 
 sleep 3
 echo Running fi_rdm_atomic


### PR DESCRIPTION
Update to support the AV as part of domain attribute and handle datagram retries