### PR TITLE
Fixed fabtests issues with the change of cq/eq_read return value

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -182,7 +182,9 @@ int wait_for_data_completion(struct fid_cq *cq, int num_completions)
 		if (ret > 0) {
 			num_completions--;
 		} else if (ret < 0) {
-			if (ret == -FI_EAVAIL) {
+			if (ret == -FI_EAGAIN)
+				continue;
+			else if (ret == -FI_EAVAIL) {
 				cq_readerr(cq, "cq");
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);
@@ -203,7 +205,9 @@ int wait_for_completion(struct fid_cq *cq, int num_completions)
 		if (ret > 0) {
 			num_completions--;
 		} else if (ret < 0) {
-			if (ret == -FI_EAVAIL) {
+			if (ret == -FI_EAGAIN)
+				continue;
+			else if (ret == -FI_EAVAIL) {
 				cq_readerr(cq, "cq");
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);

--- a/common/shared.c
+++ b/common/shared.c
@@ -181,10 +181,8 @@ int wait_for_data_completion(struct fid_cq *cq, int num_completions)
 		ret = fi_cq_read(cq, &comp, 1);
 		if (ret > 0) {
 			num_completions--;
-		} else if (ret < 0) {
-			if (ret == -FI_EAGAIN)
-				continue;
-			else if (ret == -FI_EAVAIL) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
+			if (ret == -FI_EAVAIL) {
 				cq_readerr(cq, "cq");
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);
@@ -204,10 +202,8 @@ int wait_for_completion(struct fid_cq *cq, int num_completions)
 		ret = fi_cq_read(cq, &comp, 1);
 		if (ret > 0) {
 			num_completions--;
-		} else if (ret < 0) {
-			if (ret == -FI_EAGAIN)
-				continue;
-			else if (ret == -FI_EAVAIL) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
+			if (ret == -FI_EAVAIL) {
 				cq_readerr(cq, "cq");
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -479,7 +479,7 @@ int main(int argc, char *argv[])
 			{ 0 }
 		};
 
-		c = getopt_long(argc, argv, "p:d:i:s:m:r:n:e:",
+		c = getopt_long(argc, argv, "p:d:i:s:m:r:n:e:f:",
 							long_options, NULL);
 		if (c == -1)
 			break;
@@ -639,11 +639,7 @@ int main(int argc, char *argv[])
 		} else {
 			do {
 				rd = fi_cq_read(ctx->cq, &wc, 1);
-				if (rd == -FI_EAGAIN) {
-					rd = 0;
-					continue;
-				}
-			} while (rd == 0);
+			} while (rd == -FI_EAGAIN);
 		}
 
 		if (rd < 0) {

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -639,12 +639,16 @@ int main(int argc, char *argv[])
 		} else {
 			do {
 				rd = fi_cq_read(ctx->cq, &wc, 1);
+				if (rd == -FI_EAGAIN) {
+					rd = 0;
+					continue;
+				}
 			} while (rd == 0);
 		}
 
 		if (rd < 0) {
 			fi_cq_readerr(ctx->cq, &cq_err, 0);
-			fprintf(stderr, "cq fi_eq_readerr() %s (%d)\n", 
+			fprintf(stderr, "cq fi_cq_readerr() %s (%d)\n", 
 				fi_cq_strerror(ctx->cq, cq_err.err, cq_err.err_data, NULL, 0),
 				cq_err.err);
 			return 1;

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -554,7 +554,7 @@ int main(int argc, char **argv)
 	hints->tx_attr->size = 10;
 	hints->rx_attr->size = 10;
 
-	while ((op = getopt(argc, argv, "s:b:c:C:S:p:")) != -1) {
+	while ((op = getopt(argc, argv, "s:b:c:C:S:p:f:")) != -1) {
 		switch (op) {
 		case 's':
 			flags &= ~FI_SOURCE;

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -355,10 +355,10 @@ static int connect_events(void)
 	uint32_t event;
 	int ret = 0;
 
-	while (connects_left && ret == -FI_EAGAIN) {
+	while (connects_left && !ret) {
 		ret = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 		
-		if (ret < 0 && ret != FI_EAGAIN) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_eq_sread", ret);
 			break;
 		}
@@ -383,9 +383,7 @@ static int shutdown_events(void)
 
 	while (disconnects_left && !ret) {
 		ret = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
-		if (ret == -FI_EAGAIN)
-			continue;
-		else if (ret < 0) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_eq_sread", ret);
 			break;
 		}

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -355,12 +355,10 @@ static int connect_events(void)
 	uint32_t event;
 	int ret = 0;
 
-	while (connects_left && !ret) {
+	while (connects_left && ret == -FI_EAGAIN) {
 		ret = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 		
-		if (ret == -FI_EAGAIN)
-			continue;
-		else if (ret < 0) {
+		if (ret < 0 && ret != FI_EAGAIN) {
 			FT_PRINTERR("fi_eq_sread", ret);
 			break;
 		}

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -277,7 +277,10 @@ static int poll_cqs(enum CQ_INDEX index)
 
 		for (done = 0; done < hints->tx_attr->size; done += ret) {
 			ret = fi_cq_read(nodes[i].cq[index], entry, 8);
-			if (ret < 0) {
+			if (ret == -FI_EAGAIN) {
+				ret = 0;
+				continue;
+			} else if (ret < 0) {
 				printf("cmatose: failed polling CQ: %d\n", ret);
 				return ret;
 			}
@@ -354,7 +357,10 @@ static int connect_events(void)
 
 	while (connects_left && !ret) {
 		ret = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
-		if (ret < 0) {
+		
+		if (ret == -FI_EAGAIN)
+			continue;
+		else if (ret < 0) {
 			FT_PRINTERR("fi_eq_sread", ret);
 			break;
 		}
@@ -379,7 +385,9 @@ static int shutdown_events(void)
 
 	while (disconnects_left && !ret) {
 		ret = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
-		if (ret < 0) {
+		if (ret == -FI_EAGAIN)
+			continue;
+		else if (ret < 0) {
 			FT_PRINTERR("fi_eq_sread", ret);
 			break;
 		}

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -419,7 +419,7 @@ static int run_test()
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
-				FT_PRINTERR("fi_cq_read", ret);
+				FT_PRINTERR("fi_cq_sread", ret);
 			}
 			return ret;
 		}

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -288,7 +288,11 @@ static int send_recv()
 		/* Read send queue */
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
-			if (ret < 0) {
+			if (ret == -FI_EAGAIN) { 
+				ret = 0;
+				continue;
+			}
+			else if (ret < 0) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
@@ -309,7 +313,11 @@ static int send_recv()
 		fprintf(stdout, "Waiting for client...\n");
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
-			if (ret < 0) {
+			if (ret == -FI_EAGAIN) {
+				ret = 0;
+				continue;
+			}
+			else if (ret < 0) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -288,15 +288,11 @@ static int send_recv()
 		/* Read send queue */
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
-			if (ret == -FI_EAGAIN) { 
-				ret = 0;
-				continue;
-			}
-			else if (ret < 0) {
+			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
-		} while (!ret);
+		} while (ret == -FI_EAGAIN);
 
 		fprintf(stdout, "Send completion received\n");
 	} else {
@@ -313,15 +309,11 @@ static int send_recv()
 		fprintf(stdout, "Waiting for client...\n");
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
-			if (ret == -FI_EAGAIN) {
-				ret = 0;
-				continue;
-			}
-			else if (ret < 0) {
+			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
-		} while (!ret);
+		} while (ret == -FI_EAGAIN);
 
 		fprintf(stdout, "Received data from client: %s\n", (char *)buf);
 	}

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -415,9 +415,7 @@ static int send_recv()
 		if(ret > 0) {
 			send_pending--;
 			fprintf(stdout, "Received send completion event!\n");
-		} else if (ret == -FI_EAGAIN) {
-			continue;
-		} else if (ret < 0) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
@@ -432,9 +430,7 @@ static int send_recv()
 		if(ret > 0) {
 			recv_pending--;
 			fprintf(stdout, "Received recv completion event!\n");
-		} else if (ret == -FI_EAGAIN) {
-			continue;
-		} else if (ret < 0) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -415,6 +415,8 @@ static int send_recv()
 		if(ret > 0) {
 			send_pending--;
 			fprintf(stdout, "Received send completion event!\n");
+		} else if (ret == -FI_EAGAIN) {
+			continue;
 		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
@@ -430,6 +432,8 @@ static int send_recv()
 		if(ret > 0) {
 			recv_pending--;
 			fprintf(stdout, "Received recv completion event!\n");
+		} else if (ret == -FI_EAGAIN) {
+			continue;
 		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -425,15 +425,11 @@ static int send_recv()
 		/* Read send queue */
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
-			if (ret == -FI_EAGAIN) {
-				ret = 0;
-				continue;
-			}
-			else if (ret < 0) {
+			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
-		} while (!ret);
+		} while (ret == -FI_EAGAIN);
 
 		fprintf(stdout, "Send completion received\n");
 	} else {
@@ -449,15 +445,11 @@ static int send_recv()
 		fprintf(stdout, "Waiting for client...\n");
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
-			if (ret == -FI_EAGAIN) {
-				ret = 0;
-				continue;
-			}
-			else if (ret < 0) {
+			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
-		} while (!ret);
+		} while (ret == -FI_EAGAIN);
 
 		fprintf(stdout, "Received data from client: %s\n", (char *)buf);
 	}

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -425,7 +425,11 @@ static int send_recv()
 		/* Read send queue */
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
-			if (ret < 0) {
+			if (ret == -FI_EAGAIN) {
+				ret = 0;
+				continue;
+			}
+			else if (ret < 0) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
@@ -445,7 +449,11 @@ static int send_recv()
 		fprintf(stdout, "Waiting for client...\n");
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
-			if (ret < 0) {
+			if (ret == -FI_EAGAIN) {
+				ret = 0;
+				continue;
+			}
+			else if (ret < 0) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -68,10 +68,7 @@ static int send_xfer(int size)
 		ret = fi_cq_read(scq, &comp, 1);
 		if (ret > 0) {
 			goto post;
-		} else if (ret == -FI_EAGAIN) {
-			ret = 0;
-			continue;
-		} else if (ret < 0) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
@@ -97,11 +94,7 @@ static int recv_xfer(int size)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret == -FI_EAGAIN) {
-			ret = 0;
-			continue;
-		}
-		else if (ret < 0) {
+		if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
@@ -109,7 +102,7 @@ static int recv_xfer(int size)
 			}
 			return ret;
 		}
-	} while (!ret);
+	} while (ret == -FI_EAGAIN);
 
 
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);

--- a/simple/msg_pingpong.c
+++ b/simple/msg_pingpong.c
@@ -68,6 +68,9 @@ static int send_xfer(int size)
 		ret = fi_cq_read(scq, &comp, 1);
 		if (ret > 0) {
 			goto post;
+		} else if (ret == -FI_EAGAIN) {
+			ret = 0;
+			continue;
 		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
@@ -94,7 +97,11 @@ static int recv_xfer(int size)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret < 0) {
+		if (ret == -FI_EAGAIN) {
+			ret = 0;
+			continue;
+		}
+		else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {

--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -72,6 +72,8 @@ static int send_xfer(int size)
 		ret = fi_cq_read(scq, &comp, 1);
 		if (ret > 0) {
 			goto post;
+		} else if (ret == -FI_EAGAIN) {
+			continue;
 		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
@@ -98,7 +100,10 @@ static int recv_xfer(int size)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret < 0) {
+		if (ret == -FI_EAGAIN) {
+			ret = 0;
+			continue;
+		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
@@ -180,7 +185,10 @@ static int wait_remote_writedata_completion(void)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret < 0) {
+		if (ret == -FI_EAGAIN) {
+			ret = 0;
+			continue;
+		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -285,7 +285,10 @@ static int send_recv()
 		/* Read send queue */
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
-			if (ret < 0) {
+			if (ret == -FI_EAGAIN) {
+				ret = 0;
+				continue;
+			} else if (ret < 0) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
@@ -306,7 +309,10 @@ static int send_recv()
 		fprintf(stdout, "Waiting for client...\n");
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
-			if (ret < 0) {
+			if (ret == -FI_EAGAIN) {
+				ret = 0;
+				continue;
+			} else if (ret < 0) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -285,14 +285,11 @@ static int send_recv()
 		/* Read send queue */
 		do {
 			ret = fi_cq_read(scq, &comp, 1);
-			if (ret == -FI_EAGAIN) {
-				ret = 0;
-				continue;
-			} else if (ret < 0) {
+			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
-		} while (!ret);
+		} while (ret == -FI_EAGAIN);
 
 		fprintf(stdout, "Send completion received\n");
 	} else {
@@ -309,14 +306,11 @@ static int send_recv()
 		fprintf(stdout, "Waiting for client...\n");
 		do {
 			ret = fi_cq_read(rcq, &comp, 1);
-			if (ret == -FI_EAGAIN) {
-				ret = 0;
-				continue;
-			} else if (ret < 0) {
+			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
 			}
-		} while (!ret);
+		} while (ret == -FI_EAGAIN);
 
 		fprintf(stdout, "Received data from client: %s\n", (char *)buf);
 	}

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -84,10 +84,7 @@ static int recv_xfer(int size)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret == -FI_EAGAIN) {
-			ret = 0;
-			continue;
-		} else if (ret < 0) {
+		if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
@@ -95,7 +92,7 @@ static int recv_xfer(int size)
 			}
 			return ret;
 		}
-	} while (!ret);
+	} while (ret == -FI_EAGAIN);
 
 	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_recv);

--- a/simple/rdm_inject_pingpong.c
+++ b/simple/rdm_inject_pingpong.c
@@ -84,7 +84,10 @@ static int recv_xfer(int size)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret < 0) {
+		if (ret == -FI_EAGAIN) {
+			ret = 0;
+			continue;
+		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -92,6 +92,8 @@ int wait_for_send_completion(int num_completions)
 		ret = fi_cq_read(scq, &comp, 1);
 		if (ret > 0) {
 			num_completions--;
+		} else if (ret == -FI_EAGAIN) {
+			continue;
 		} else if (ret < 0) {
 			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
@@ -135,6 +137,8 @@ int wait_for_recv_completion(void **recv_data, enum data_type type,
 					*recv_data = comp.buf;
 				}
 			}
+		} else if (ret == -FI_EAGAIN) {
+			continue;
 		} else if (ret < 0) {
 			FT_PRINTERR("fi_cq_read", ret);
 			return ret;

--- a/simple/rdm_multi_recv.c
+++ b/simple/rdm_multi_recv.c
@@ -92,9 +92,7 @@ int wait_for_send_completion(int num_completions)
 		ret = fi_cq_read(scq, &comp, 1);
 		if (ret > 0) {
 			num_completions--;
-		} else if (ret == -FI_EAGAIN) {
-			continue;
-		} else if (ret < 0) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
@@ -137,9 +135,7 @@ int wait_for_recv_completion(void **recv_data, enum data_type type,
 					*recv_data = comp.buf;
 				}
 			}
-		} else if (ret == -FI_EAGAIN) {
-			continue;
-		} else if (ret < 0) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}

--- a/simple/rdm_pingpong.c
+++ b/simple/rdm_pingpong.c
@@ -74,6 +74,8 @@ static int send_xfer(int size)
 		ret = fi_cq_read(scq, &comp, 1);
 		if (ret > 0) {
 			goto post;
+		} else if (ret == -FI_EAGAIN) {
+			continue;
 		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
@@ -101,7 +103,10 @@ static int recv_xfer(int size)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret < 0) {
+		if (ret == -FI_EAGAIN) {
+			ret = 0;
+			continue;
+		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -150,7 +150,10 @@ static int wait_remote_writedata_completion(void)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret < 0) {
+		if (ret == -FI_EAGAIN) {
+			ret = 0;
+			continue;
+		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -150,10 +150,7 @@ static int wait_remote_writedata_completion(void)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret == -FI_EAGAIN) {
-			ret = 0;
-			continue;
-		} else if (ret < 0) {
+		if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
@@ -161,7 +158,7 @@ static int wait_remote_writedata_completion(void)
 			}
 			return ret;
 		}
-	} while (!ret);
+	} while (ret == -FI_EAGAIN);
 
 	ret = 0;
 	if (comp.data != cq_data) {

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -77,7 +77,9 @@ int wait_for_completion_tagged(struct fid_cq *cq, int num_completions)
 
 	while (num_completions > 0) {
 		ret = fi_cq_read(cq, &comp, 1);
-		if (ret > 0) {
+		if (ret == -FI_EAGAIN)
+			continue;
+		else if (ret > 0) {
 			num_completions--;
 		} else if (ret < 0) {
 			FT_PRINTERR("fi_cq_read", ret);
@@ -96,6 +98,8 @@ static int send_xfer(int size)
 		ret = fi_cq_read(scq, &comp, 1);
 		if (ret > 0) {
 			goto post;
+		} else if (ret == -FI_EAGAIN) {
+			continue;
 		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
@@ -123,7 +127,10 @@ static int recv_xfer(int size)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret < 0) {
+		if (ret == -FI_EAGAIN) {
+			ret = 0;
+			continue;
+		} else if (ret < 0) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {

--- a/simple/rdm_tagged_pingpong.c
+++ b/simple/rdm_tagged_pingpong.c
@@ -77,11 +77,9 @@ int wait_for_completion_tagged(struct fid_cq *cq, int num_completions)
 
 	while (num_completions > 0) {
 		ret = fi_cq_read(cq, &comp, 1);
-		if (ret == -FI_EAGAIN)
-			continue;
-		else if (ret > 0) {
+		if (ret > 0) {
 			num_completions--;
-		} else if (ret < 0) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}
@@ -98,9 +96,7 @@ static int send_xfer(int size)
 		ret = fi_cq_read(scq, &comp, 1);
 		if (ret > 0) {
 			goto post;
-		} else if (ret == -FI_EAGAIN) {
-			continue;
-		} else if (ret < 0) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(scq, "scq");
 			} else {
@@ -127,10 +123,7 @@ static int recv_xfer(int size)
 
 	do {
 		ret = fi_cq_read(rcq, &comp, 1);
-		if (ret == -FI_EAGAIN) {
-			ret = 0;
-			continue;
-		} else if (ret < 0) {
+		if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
 				cq_readerr(rcq, "rcq");
 			} else {
@@ -138,7 +131,7 @@ static int recv_xfer(int size)
 			}
 			return ret;
 		}
-	} while (!ret);
+	} while (ret == -FI_EAGAIN);
 
 	/* Posting recv for next send. Hence tag_data + 1 */
 	ret = fi_trecv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -96,11 +96,9 @@ int wait_for_tagged_completion(struct fid_cq *cq, int num_completions)
 
 	while (num_completions > 0) {
 		ret = fi_cq_read(cq, &comp, 1);
-		if (ret == -FI_EAGAIN)
-			continue;
-		else if (ret > 0) {
+		if (ret > 0) {
 			num_completions--;
-		} else if (ret < 0) {
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			FT_PRINTERR("fi_cq_read", ret);
 			return ret;
 		}

--- a/simple/rdm_tagged_search.c
+++ b/simple/rdm_tagged_search.c
@@ -96,7 +96,9 @@ int wait_for_tagged_completion(struct fid_cq *cq, int num_completions)
 
 	while (num_completions > 0) {
 		ret = fi_cq_read(cq, &comp, 1);
-		if (ret > 0) {
+		if (ret == -FI_EAGAIN)
+			continue;
+		else if (ret > 0) {
 			num_completions--;
 		} else if (ret < 0) {
 			FT_PRINTERR("fi_cq_read", ret);

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -335,7 +335,7 @@ eq_wait_fd_sread()
 	/* timed sread on empty EQ, 2s timeout */
 	clock_gettime(CLOCK_MONOTONIC, &before);
 	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), 2000, 0);
-	if (ret != -FI_ETIMEDOUT) {
+	if (ret != -FI_EAGAIN) {
 		sprintf(err_buf, "fi_eq_read of empty EQ returned %d", ret);
 		goto fail;
 	}


### PR DESCRIPTION
- Allowed wait_for_completion to continue when fi_cq/eq_read returns -FI_EAGAIN
- Fixed the loop issue which was based on "0" return value from fi_cq/eq_read 
- Fixed a missing -f option in option list for ported/librdmacm/cmatose

Fixes #192 @patrickmacarthur @bturrubiates @jithinjosepkl, can you please review?

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>