### PR TITLE
Removed FI_REMOTE_CQ_DATA flag from capability as per libfabric change

### DIFF
--- a/simple/msg_rma.c
+++ b/simple/msg_rma.c
@@ -699,9 +699,6 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_MSG;
 	hints->caps = FI_MSG | FI_RMA;
-	if (op_type == FT_RMA_WRITEDATA) {
-		hints->caps |= FI_REMOTE_CQ_DATA;
-	}
 	hints->mode = FI_LOCAL_MR | FI_PROV_MR_ATTR;
 	hints->addr_format = FI_SOCKADDR;
 

--- a/simple/rdm_rma.c
+++ b/simple/rdm_rma.c
@@ -597,9 +597,6 @@ int main(int argc, char **argv)
 	
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_RMA;
-	if (op_type == FT_RMA_WRITEDATA) {
-		hints->caps |= FI_REMOTE_CQ_DATA;
-	}
 	hints->mode = FI_CONTEXT | FI_PROV_MR_ATTR;
 	
 	if (opts.prhints) {


### PR DESCRIPTION
FI_REMOTE_CQ_DATA is removed from capability. RMA tests are updated to match the latest libfabric.

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>