### PR TITLE
tests: check for epoll_create1()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,6 @@ bin_PROGRAMS = \
 	simple/fi_msg\
 	simple/fi_msg_pingpong \
 	simple/fi_msg_rma \
-	simple/fi_msg_epoll \
 	simple/fi_rdm \
 	simple/fi_rdm_rma_simple \
 	simple/fi_dgram \
@@ -31,6 +30,10 @@ bin_PROGRAMS = \
 	ported/libibverbs/fi_rc_pingpong \
 	ported/librdmacm/fi_cmatose \
 	complex/fabtest
+
+if HAVE_EPOLL
+bin_PROGRAMS += simple/fi_msg_epoll
+endif
 
 noinst_LTLIBRARIES = libfabtests.la
 libfabtests_la_SOURCES = common/shared.c

--- a/configure.ac
+++ b/configure.ac
@@ -77,5 +77,8 @@ AC_CHECK_HEADER(valgrind/memcheck.h, [],
     AC_MSG_ERROR([valgrind requested but <valgrind/memcheck.h> not found.]))
 fi
 
+AC_CHECK_FUNC([epoll_create1], [HAVE_EPOLL=1], [HAVE_EPOLL=0])
+AM_CONDITIONAL(HAVE_EPOLL, [test $HAVE_EPOLL -eq 1])
+
 AC_CONFIG_FILES([Makefile fabtests.spec])
 AC_OUTPUT


### PR DESCRIPTION
Don't build the simple/fi_msg_epoll test if we don't have it.

Fixes #211 

@jithinjosepkl please verify

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>