### PR TITLE
Fixes for fabtests to be consistent with latest commit

### DIFF
--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -414,6 +414,7 @@ int main(int argc, char **argv)
 {
 	int op, ret = 0;
 
+	opts = INIT_OPTS;
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -305,6 +305,7 @@ int main(int argc, char **argv)
 {
 	int op, ret;
 		
+	opts = INIT_OPTS;
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -89,16 +89,16 @@ static int teardown_ep_fixture(struct fid_ep *ep)
 		}
 	}
 	if (wcq != NULL) {
-		ret = fi_close(&rcq->fid);
+		ret = fi_close(&wcq->fid);
 		if (ret != 0) {
-			printf("fi_close(rcq) %s\n", fi_strerror(-ret));
+			printf("fi_close(wcq) %s\n", fi_strerror(-ret));
 			teardown_ret = ret;
 		}
 	}
 	if (rcq != NULL) {
-		ret = fi_close(&wcq->fid);
+		ret = fi_close(&rcq->fid);
 		if (ret != 0) {
-			printf("fi_close(wcq) %s\n", fi_strerror(-ret));
+			printf("fi_close(rcq) %s\n", fi_strerror(-ret));
 			teardown_ret = ret;
 		}
 	}
@@ -373,6 +373,7 @@ int main(int argc, char **argv)
 	}
 
 	hints->mode = ~0;
+	hints->ep_attr->type = FI_EP_RDM;
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	if (ret != 0) {


### PR DESCRIPTION
- Fixed runFabtests.sh script to be consistent with #200. Added a missing unit test and adjusted timeout value for quick validation.
- Fixed the missing unit test. It was using av but taking the default ep_type which was MSG. Changed it to use RDM
- Added missing initialization for options

"Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>"