### PR TITLE
Update fabtests.sh script and add features.

### DIFF
--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -523,7 +523,7 @@ int main(int argc, char *argv[])
 	rc = fi_getinfo(FI_VERSION(1, 0), node, service, flags, hints, &info);
 	if (rc) {
 		FT_PRINTERR("fi_getinfo", rc);
-		return 1;
+		return -rc;
 	}
 	fi_freeinfo(hints);
 

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -616,6 +616,5 @@ exit1:
 	fi_freeinfo(info);
 exit0:
 	fi_freeinfo(hints);
-	printf("return status %d\n", ret);
-	return ret;
+	return -ret;
 }

--- a/scripts/runFabtests.sh
+++ b/scripts/runFabtests.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-if [ $# != 5 ]; then
-	echo "Usage: $0 <test_bin_path> <provider_name> <all|quick> <server_addr> <client_addr>"
+# TODO: parse all this stuff in standard fashion
+if [[ $# < 5 ]]; then
+	echo "Usage: $0 [-v] <test_bin_path> <provider_name> <all|quick> <server_addr> <client_addr>"
 	exit 1
+fi
+
+if [[ "$1" == "-v" ]]; then
+	VERBOSE=1
+	shift;
+else
+	VERBOSE=0
 fi
 
 BIN_PATH=$1
@@ -20,70 +28,79 @@ fi
 declare -r ssh="ssh -o StrictHostKeyChecking=no -o ConnectTimeout=2 -o BatchMode=yes"
 declare -r tssh="timeout ${TO} ${ssh}"
 
-output=""
-pass_count=0
-fail_count=0
+declare -r c_outp=$(mktemp)
+declare -r s_outp=$(mktemp)
+
+declare -i skip_count=0
+declare -i pass_count=0
+declare -i fail_count=0
 
 simple_tests=(
-    "cq_data"
-    "dgram"
-    "dgram_waitset"
-    "msg"
-    "msg_epoll"
-    "poll"
-    "rdm"
-    "rdm_rma_simple"
-    "rdm_shared_ctx"
-    "rdm_tagged_search"
-    "scalable_ep"
-    "cmatose"
+	"cq_data"
+	"dgram"
+	"dgram_waitset"
+	"msg"
+	"msg_epoll"
+	"poll"
+	"rdm"
+	"rdm_rma_simple"
+	"rdm_shared_ctx"
+	"rdm_tagged_search"
+	"scalable_ep"
+	"cmatose"
 )
 
 quick_tests=(
-    "msg_pingpong -I 100 -S 1024"
-    "msg_rma -o write -I 100 -S 1024"
-    "msg_rma -o read -I 100 -S 1024"
-    "msg_rma -o writedata -I 100 -S 1024"
-    "rdm_atomic -I 100 -S 1024 -o all"
-    "rdm_cntr_pingpong -I 100 -S 1024"
-    "rdm_inject_pingpong -I 100 -S 128"
-    "rdm_multi_recv -I 100 -S 1024"
-    "rdm_pingpong -I 100 -S 1024"
-    "rdm_rma -o write -I 100 -S 1024"
-    "rdm_rma -o read -I 100 -S 1024"
-    "rdm_rma -o writedata -I 100 -S 1024"
-    "rdm_tagged_pingpong -I 100 -S 1024"
-    "ud_pingpong -I 100 -S 1024"
-    "rc_pingpong -n 100 -S 1024"
+	"msg_pingpong -I 100 -S 1024"
+	"msg_rma -o write -I 100 -S 1024"
+	"msg_rma -o read -I 100 -S 1024"
+	"msg_rma -o writedata -I 100 -S 1024"
+	"rdm_atomic -I 100 -S 1024 -o all"
+	"rdm_cntr_pingpong -I 100 -S 1024"
+	"rdm_inject_pingpong -I 100 -S 128"
+	"rdm_multi_recv -I 100 -S 1024"
+	"rdm_pingpong -I 100 -S 1024"
+	"rdm_rma -o write -I 100 -S 1024"
+	"rdm_rma -o read -I 100 -S 1024"
+	"rdm_rma -o writedata -I 100 -S 1024"
+	"rdm_tagged_pingpong -I 100 -S 1024"
+	"ud_pingpong -I 100 -S 1024"
+	"rc_pingpong -n 100 -S 1024"
 )
 
 all_tests=(
-    "msg_pingpong"
-    "msg_rma -o write"
-    "msg_rma -o read"
-    "msg_rma -o writedata"
-    "rdm_atomic -o all"
-    "rdm_cntr_pingpong"
-    "rdm_inject_pingpong"
-    "rdm_multi_recv"
-    "rdm_pingpong"
-    "rdm_rma -o write"
-    "rdm_rma -o read"
-    "rdm_rma -o writedata"
-    "rdm_tagged_pingpong"
-    "ud_pingpong"
-    "rc_pingpong"
+	"msg_pingpong"
+	"msg_rma -o write"
+	"msg_rma -o read"
+	"msg_rma -o writedata"
+	"rdm_atomic -o all"
+	"rdm_cntr_pingpong"
+	"rdm_inject_pingpong"
+	"rdm_multi_recv"
+	"rdm_pingpong"
+	"rdm_rma -o write"
+	"rdm_rma -o read"
+	"rdm_rma -o writedata"
+	"rdm_tagged_pingpong"
+	"ud_pingpong"
+	"rc_pingpong"
 )
 
 unit_tests=(
-    "av_test -d 192.168.10.1 -n 1"
-    "dom_test -n 2"
-    "eq_test"	
-    "size_left_test")
+	"av_test -d 192.168.10.1 -n 1"
+	"dom_test -n 2"
+	"eq_test"	
+	"size_left_test"
+)
 
-function print_border 
-{
-	echo "--------------------------------------------------------------"
+function print_border {
+	echo "# --------------------------------------------------------------"
+}
+
+# TODO: prefix with something, check for "" input
+function print_results {
+	#echo "$1" | sed ':a;N;$!ba;s/\n/\n  # /g'
+	echo "$1" | sed 's/^/  # /g'
 }
 
 function cleanup_and_exit {
@@ -92,8 +109,9 @@ function cleanup_and_exit {
 }
 
 function cleanup {
-        $ssh ${CLIENT} "ps aux | grep fi_ | grep -v grep | awk '{print \$2}' | xargs -r kill -9" > /dev/null
-        $ssh ${SERVER} "ps aux | grep fi_ | grep -v grep | awk '{print \$2}' | xargs -r kill -9" > /dev/null
+	$ssh ${CLIENT} "ps -eo comm,pid | grep ^fi_ | awk '{print \$2}' | xargs -r kill -9" > /dev/null
+	$ssh ${SERVER} "ps -eo comm,pid | grep ^fi_ | awk '{print \$2}' | xargs -r kill -9" > /dev/null
+	rm -f $c_outp $s_outp
 }
 
 function run_test {
@@ -102,22 +120,25 @@ function run_test {
 	local ret1=0
 	local ret2=0
 	local test_exe="fi_${test} -f $PROV"
+	local SO=""
+	local CO=""
 
 	if [ "${type}" = 'unit' ]; then
-		echo "Running test $test_exe"
-		(set -x; $tssh $SERVER "${BIN_PATH}/fi_${test} -f $PROV") &
-		
+		$tssh $SERVER "${BIN_PATH}/fi_${test} -f $PROV" &> $s_outp &
 		p1=$!
 
 		wait $p1
 		ret1=$?
 
+		SO=$(cat $s_outp)
+
 	elif [ "${type}" = 'client-server' ]; then
-		echo "Running test $test_exe"
-		(set -x; $tssh $SERVER "${BIN_PATH}/fi_${test} -f $PROV -s $SERVER") &
+
+		$tssh $SERVER "${BIN_PATH}/fi_${test} -f $PROV -s $SERVER" &> $s_outp &
 		p1=$!
 		sleep 1s
-		(set -x; $tssh $CLIENT "${BIN_PATH}/fi_${test} $SERVER -f $PROV") &
+
+		$tssh $CLIENT "${BIN_PATH}/fi_${test} $SERVER -f $PROV" &> $c_outp &
 		p2=$!
 
 		wait $p1
@@ -125,35 +146,40 @@ function run_test {
 
 		wait $p2
 		ret2=$?
+
+		SO=$(cat $s_outp)
+		CO=$(cat $c_outp)
 	fi
 
-	if [ $ret1 != 0 -o $ret1 != 0 ]; then
+	if [ "$ret1" == "61" -o "$ret1" == "61" ]; then
+		printf "%-50s%10s\n" "$test_exe:" "Notrun"
+		skip_count+=1
+	
+	elif [ "$ret1" != "0" -o "$ret1" != "0" ]; then
 		if [ $ret1 == 124 -o $ret2 == 124 ]; then
-			echo "Test timed out."
 			cleanup
 		fi
-		printf -v output "%s%-50s%10s\n" "$output" "$test_exe:" "Fail"
-		fail_count=$((fail_count + 1))
+		printf "%-50s%10s\n" "$test_exe:" "Fail"
+		fail_count+=1
+		[ "$VERBOSE" == "1" ] && print_results "$SO" && print_results "$CO"
 	else
-		printf -v output "%s%-50s%10s\n" "$output" "$test_exe:" "Pass"
-		pass_count=$((pass_count + 1))
+		printf "%-50s%10s\n" "$test_exe:" "Pass"
+		pass_count+=1
 	fi
-	echo ""
 }
 
 trap cleanup_and_exit SIGINT
 
-#unit tests
-testset=("${unit_tests[@]}")  
+printf "# %-50s%10s\n" "Test" "Result"
+print_border
 
-for test in "${testset[@]}"; do
+#unit tests
+for test in "${unit_tests[@]}"; do
 	run_test "unit" "$test"
 done
 
 #simple tests
-testset=("${simple_tests[@]}")  
-
-for test in "${testset[@]}"; do
+for test in "${simple_tests[@]}"; do
 	run_test "client-server" "$test"
 done
 
@@ -171,17 +197,12 @@ done
 
 total=$(( $pass_count + $fail_count ))
 
-printf "\n%-50s%10s\n" "Test" "Result"
 print_border
 
-printf "$output"
+printf "# %-50s%10d\n" "Total Pass" $pass_count
+printf "# %-50s%10d\n" "Total Fail" $fail_count
+printf "# %-50s%10.2f\n" "Percentage of Pass" `echo "scale=2; $pass_count * 100 / $total" | bc`
 print_border
 
-printf "%-50s%10d\n" "Total Pass" $pass_count
-printf "%-50s%10d\n" "Total Fail" $fail_count
-printf "%-50s%10.2f\n" "Percentage of Pass" `echo "scale=2; $pass_count * 100 / $total" | bc`
-print_border
-
-if (( $fail_count )); then
-	exit 1
-fi
+cleanup
+exit $fail_count

--- a/scripts/runFabtests.sh
+++ b/scripts/runFabtests.sh
@@ -151,7 +151,7 @@ function run_test {
 		CO=$(cat $c_outp)
 	fi
 
-	if [ "$ret1" == "61" -o "$ret1" == "61" ]; then
+	if [ "$ret1" == "61" -a "$ret1" == "61" ]; then
 		printf "%-50s%10s\n" "$test_exe:" "Notrun"
 		skip_count+=1
 	
@@ -201,7 +201,11 @@ print_border
 
 printf "# %-50s%10d\n" "Total Pass" $pass_count
 printf "# %-50s%10d\n" "Total Fail" $fail_count
-printf "# %-50s%10.2f\n" "Percentage of Pass" `echo "scale=2; $pass_count * 100 / $total" | bc`
+
+if [[ "$total" > "0" ]]; then
+	printf "# %-50s%10.2f\n" "Percentage of Pass" `echo "scale=2; $pass_count * 100 / $total" | bc`
+fi
+
 print_border
 
 cleanup

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -525,12 +525,12 @@ int main(int argc, char **argv)
 	if (!opts.dst_addr) {
 		ret = server_listen();
 		if (ret)
-			return ret;
+			return -ret;
 	}
 
 	ret = opts.dst_addr ? client_connect() : server_connect();
 	if (ret) {
-		return ret;
+		return -ret;
 	}
 
 	/* Exchange data */

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -261,12 +261,19 @@ out:
 
 static void free_ep_res(void)
 {
-	fi_close(&ep->fid);
-	fi_close(&av->fid);
-	fi_close(&mr->fid);
-	fi_close(&mr_multi_recv->fid);
-	fi_close(&rcq->fid);
-	fi_close(&scq->fid);
+	if (ep)
+		fi_close(&ep->fid);
+	if (av)
+		fi_close(&av->fid);
+	if (mr)
+		fi_close(&mr->fid);
+	if (mr_multi_recv)
+		fi_close(&mr_multi_recv->fid);
+	if (rcq)
+		fi_close(&rcq->fid);
+	if (scq)
+		fi_close(&scq->fid);
+
 	free(ctx_send);
 	free(ctx_multi_recv);
 	free(send_buf);
@@ -577,8 +584,12 @@ static int run(void)
 	ft_finalize(ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+
+	if (dom)
+		fi_close(&dom->fid);
+	if (fab)
+		fi_close(&fab->fid);
+
 	return ret;
 }
 

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1057,7 +1057,7 @@ int main(int argc, char **argv)
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	if (ret != 0) {
 		printf("fi_getinfo %s\n", fi_strerror(-ret));
-		exit(1);
+		exit(-ret);
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -167,5 +167,5 @@ err:
 			       fi_strerror(-ret));
 		}
 	}
-	exit(EXIT_FAILURE);
+	return -ret;
 }

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	if (ret != 0) {
 		printf("fi_getinfo %s\n", fi_strerror(-ret));
-		exit(1);
+		exit(-ret);
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -378,7 +378,7 @@ int main(int argc, char **argv)
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	if (ret != 0) {
 		printf("fi_getinfo %s\n", fi_strerror(-ret));
-		exit(1);
+		exit(-ret);
 	}
 
 	DEBUG("using provider \"%s\" and fabric \"%s\"\n",


### PR DESCRIPTION
Make output yaml-parsable.
Add -v switch to see output when test fails.
Check if test is not supported (return FI-ENODATA) and skip (vs fail).
Clean up more correct and quiet.

Output now looks like this without the verbose switch:
```
# Test                                                  Result
# --------------------------------------------------------------
fi_av_test -d 192.168.10.1 -n 1 -f usnic:               Fail
fi_dom_test -n 2 -f usnic:                              Fail
fi_eq_test -f usnic:                                    Fail
fi_size_left_test -f usnic:                             Fail
fi_cq_data -f usnic:                                  Notrun
fi_dgram -f usnic:                                    Notrun
fi_dgram_waitset -f usnic:                            Notrun
fi_msg -f usnic:                                      Notrun
fi_msg_epoll -f usnic:                                  Fail
fi_poll -f usnic:                                     Notrun
fi_rdm -f usnic:                                      Notrun
fi_rdm_rma_simple -f usnic:                           Notrun
fi_rdm_shared_ctx -f usnic:                           Notrun
fi_rdm_tagged_search -f usnic:                        Notrun
fi_scalable_ep -f usnic:                              Notrun
fi_cmatose -f usnic:                                    Fail
fi_msg_pingpong -I 100 -S 1024 -f usnic:              Notrun
fi_msg_rma -o write -I 100 -S 1024 -f usnic:          Notrun
fi_msg_rma -o read -I 100 -S 1024 -f usnic:           Notrun
fi_msg_rma -o writedata -I 100 -S 1024 -f usnic:      Notrun
fi_rdm_atomic -I 100 -S 1024 -o all -f usnic:         Notrun
fi_rdm_cntr_pingpong -I 100 -S 1024 -f usnic:         Notrun
fi_rdm_inject_pingpong -I 100 -S 128 -f usnic:        Notrun
fi_rdm_multi_recv -I 100 -S 1024 -f usnic:              Fail
fi_rdm_pingpong -I 100 -S 1024 -f usnic:              Notrun
fi_rdm_rma -o write -I 100 -S 1024 -f usnic:          Notrun
fi_rdm_rma -o read -I 100 -S 1024 -f usnic:           Notrun
fi_rdm_rma -o writedata -I 100 -S 1024 -f usnic:      Notrun
fi_rdm_tagged_pingpong -I 100 -S 1024 -f usnic:       Notrun
fi_ud_pingpong -I 100 -S 1024 -f usnic:                 Fail
fi_rc_pingpong -n 100 -S 1024 -f usnic:                 Fail
# --------------------------------------------------------------
# Total Pass                                                 0
# Total Fail                                                 9
# Percentage of Pass                                      0.00
# --------------------------------------------------------------
```

And with the -v switch:
```
# Test                                                  Result
# --------------------------------------------------------------
fi_av_test -d 192.168.10.1 -n 1 -f usnic:               Fail
  # fi_getinfo No data available
  #
fi_dom_test -n 2 -f usnic:                              Fail
  # fi_getinfo No data available
  #
fi_eq_test -f usnic:                                    Fail
  # fi_getinfo No data available
  #
fi_size_left_test -f usnic:                             Fail
  # fi_getinfo No data available
  #
fi_cq_data -f usnic:                                  Notrun
fi_dgram -f usnic:                                    Notrun
fi_dgram_waitset -f usnic:                            Notrun
fi_msg -f usnic:                                      Notrun
fi_msg_epoll -f usnic:                                  Fail
  # fi_getinfo(): 225, -61 (No data available)
  # fi_getinfo(): 354, -61 (No data available)
fi_poll -f usnic:                                     Notrun
fi_rdm -f usnic:                                      Notrun
fi_rdm_rma_simple -f usnic:                           Notrun
fi_rdm_shared_ctx -f usnic:                           Notrun
fi_rdm_tagged_search -f usnic:                        Notrun
fi_scalable_ep -f usnic:                              Notrun
fi_cmatose -f usnic:                                    Fail
  # return status -61
  # fi_getinfo(): 583, -61 (No data available)
  # return status -61
  # fi_getinfo(): 583, -61 (No data available)
fi_msg_pingpong -I 100 -S 1024 -f usnic:              Notrun
fi_msg_rma -o write -I 100 -S 1024 -f usnic:          Notrun
...
```


Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>