### PR TITLE
Fix RPM build errors.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ if HAVE_EPOLL
 bin_PROGRAMS += simple/fi_msg_epoll
 endif
 
-bin_SCRIPTS=scripts/runfabtests.sh
+dist_bin_SCRIPTS=scripts/runfabtests.sh
 
 noinst_LTLIBRARIES = libfabtests.la
 libfabtests_la_SOURCES = common/shared.c


### PR DESCRIPTION
Using dist prefix for bin_SCRIPTS would make scripts built as part of make dist.

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>