### PR TITLE
More features for runfabtests.sh.

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -1,32 +1,16 @@
 #!/bin/bash
 
-# TODO: parse all this stuff in standard fashion
-if [[ $# < 5 ]]; then
-	echo "Usage: $0 [-v] <test_bin_path> <provider_name> <all|quick> <server_addr> <client_addr>"
-	exit 1
-fi
+trap cleanup_and_exit SIGINT
 
-if [[ "$1" == "-v" ]]; then
-	VERBOSE=1
-	shift;
-else
-	VERBOSE=0
-fi
-
-BIN_PATH=$1
-PROV=$2
-TEST_TYPE=$3
-SERVER=$4
-CLIENT=$5
-
-if [ $TEST_TYPE == "quick" ]; then
-	declare -r TO=60s	
-else
-	declare -r TO=120s	
-fi
+declare BIN_PATH
+declare PROV
+declare TEST_TYPE="all"
+declare SERVER
+declare CLIENT
+declare -i VERBOSE=0
 
 declare -r ssh="ssh -o StrictHostKeyChecking=no -o ConnectTimeout=2 -o BatchMode=yes"
-declare -r tssh="timeout ${TO} ${ssh}"
+declare -r tssh="timeout 45s ${ssh}"
 
 declare -r c_outp=$(mktemp)
 declare -r s_outp=$(mktemp)
@@ -68,7 +52,7 @@ quick_tests=(
 	"rc_pingpong -n 5"
 )
 
-all_tests=(
+standard_tests=(
 	"msg_pingpong"
 	"msg_rma -o write"
 	"msg_rma -o read"
@@ -93,6 +77,13 @@ unit_tests=(
 	"size_left_test"
 )
 
+all_tests=(
+	"${unit_tests[@]}"
+	"${quick_tests[@]}"
+	"${simple_tests[@]}"
+	"${standard_tests[@]}"
+)
+
 function print_border {
 	echo "# --------------------------------------------------------------"
 }
@@ -103,110 +94,168 @@ function print_results {
 	echo "$1" | sed 's/^/  # /g'
 }
 
-function cleanup_and_exit {
-	cleanup
-	exit 1
-}
-
 function cleanup {
 	$ssh ${CLIENT} "ps -eo comm,pid | grep ^fi_ | awk '{print \$2}' | xargs -r kill -9" > /dev/null
 	$ssh ${SERVER} "ps -eo comm,pid | grep ^fi_ | awk '{print \$2}' | xargs -r kill -9" > /dev/null
 	rm -f $c_outp $s_outp
 }
 
-function run_test {
-	local type=$1
-	local test=$2
+function cleanup_and_exit {
+	cleanup
+	exit 1
+}
+
+function unit_test {
+	local test=$1
+	local ret1=0
+	local test_exe="fi_${test} -f $PROV"
+	local SO=""
+
+	${tssh} ${SERVER} ${BIN_PATH} "${test_exe}" &> $s_outp &
+	p1=$!
+
+	wait $p1
+	ret1=$?
+
+	SO=$(cat $s_outp)
+
+	if [ "$ret1" == "61" ]; then
+		printf "%-50s%10s\n" "$test_exe:" "Notrun"
+		[ "$VERBOSE" -gt "1" ] && print_results "$SO"
+		skip_count+=1
+	
+	elif [ "$ret1" != "0" ]; then
+		if [ $ret1 == 124 ]; then
+			cleanup
+		fi
+		printf "%-50s%10s\n" "$test_exe:" "Fail"
+		[ "$VERBOSE" -gt "0" ] && print_results "$SO"
+		fail_count+=1
+	else
+		printf "%-50s%10s\n" "$test_exe:" "Pass"
+		[ "$VERBOSE" -gt "2" ] && print_results "$SO"
+		pass_count+=1
+	fi
+}
+
+function cs_test {
+	local test=$1
 	local ret1=0
 	local ret2=0
 	local test_exe="fi_${test} -f $PROV"
 	local SO=""
 	local CO=""
 
-	if [ "${type}" = 'unit' ]; then
-		$tssh $SERVER "${BIN_PATH}/fi_${test} -f $PROV" &> $s_outp &
-		p1=$!
+	${tssh} ${SERVER} ${BIN_PATH} "${test_exe} -s $SERVER" &> $s_outp &
+	p1=$!
+	sleep 1s
 
-		wait $p1
-		ret1=$?
+	${tssh} ${CLIENT} ${BIN_PATH} "${test_exe} $SERVER" &> $c_outp &
+	p2=$!
 
-		SO=$(cat $s_outp)
+	wait $p1
+	ret1=$?
 
-	elif [ "${type}" = 'client-server' ]; then
+	wait $p2
+	ret2=$?
 
-		$tssh $SERVER "${BIN_PATH}/fi_${test} -f $PROV -s $SERVER" &> $s_outp &
-		p1=$!
-		sleep 1s
+	SO=$(cat $s_outp)
+	CO=$(cat $c_outp)
 
-		$tssh $CLIENT "${BIN_PATH}/fi_${test} $SERVER -f $PROV" &> $c_outp &
-		p2=$!
-
-		wait $p1
-		ret1=$?
-
-		wait $p2
-		ret2=$?
-
-		SO=$(cat $s_outp)
-		CO=$(cat $c_outp)
-	fi
-
-	if [ "$ret1" == "61" -a "$ret1" == "61" ]; then
+	if [ "$ret1" == "61" -a "$ret2" == "61" ]; then
 		printf "%-50s%10s\n" "$test_exe:" "Notrun"
+		[ "$VERBOSE" -gt "1" ] && print_results "$SO" && print_results "$CO"
 		skip_count+=1
 	
-	elif [ "$ret1" != "0" -o "$ret1" != "0" ]; then
+	elif [ "$ret1" != "0" -o "$ret2" != "0" ]; then
 		if [ $ret1 == 124 -o $ret2 == 124 ]; then
 			cleanup
 		fi
 		printf "%-50s%10s\n" "$test_exe:" "Fail"
+		[ "$VERBOSE" -gt "0" ] && print_results "$SO" && print_results "$CO"
 		fail_count+=1
-		[ "$VERBOSE" == "1" ] && print_results "$SO" && print_results "$CO"
 	else
 		printf "%-50s%10s\n" "$test_exe:" "Pass"
+		[ "$VERBOSE" -gt "2" ] && print_results "$SO" && print_results "$CO"
 		pass_count+=1
 	fi
 }
 
-trap cleanup_and_exit SIGINT
+function main {
+	local -r tests=$(echo $1 | sed 's/all/unit,simple,quick,standard/' | tr ',' ' ')
 
-printf "# %-50s%10s\n" "Test" "Result"
-print_border
+	printf "# %-50s%10s\n" "Test" "Result"
+	print_border
 
-#unit tests
-for test in "${unit_tests[@]}"; do
-	run_test "unit" "$test"
+	for ts in ${tests}; do
+	case ${ts} in
+		unit)
+			for test in "${unit_tests[@]}"; do
+				unit_test "$test"
+			done
+
+		;;
+		simple)
+			for test in "${simple_tests[@]}"; do
+				cs_test "$test"
+			done
+		;;
+		quick)
+			for test in "${quick_tests[@]}"; do
+				cs_test "$test"
+			done
+		;;
+		standard)
+			for test in "${standard_tests[@]}"; do
+				cs_test "$test"
+			done
+		;;
+		*)
+			echo "Unknown test set: ${ts}"
+			exit 1
+		;;
+	esac
+	done
+
+	total=$(( $pass_count + $fail_count ))
+
+	print_border
+
+	printf "# %-50s%10d\n" "Total Pass" $pass_count
+	printf "# %-50s%10d\n" "Total Fail" $fail_count
+
+	if [[ "$total" > "0" ]]; then
+		printf "# %-50s%10.2f\n" "Percentage of Pass" `echo "scale=2; $pass_count * 100 / $total" | bc`
+	fi
+
+	print_border
+
+	cleanup
+	exit $fail_count
+}
+
+while getopts ":vt:p:" opt; do
+case ${opt} in
+	t) TEST_TYPE=$OPTARG
+	;;
+	v) VERBOSE+=1
+	;;
+	p) BIN_PATH=PATH=${OPTARG}:${PATH}
+	;;
+	:|\?)
+	echo "Usage: $0 [-vtp] <provider_name> <server_addr> <client_addr>"
+	echo "[-vtp] verbose"
+	echo "[-t] test type(s): all,quick,unit,simple"
+	echo "[-p] path to test bins (default PATH)"
+	exit 1
+	;;
+esac
+
 done
 
-#simple tests
-for test in "${simple_tests[@]}"; do
-	run_test "client-server" "$test"
-done
+shift $((OPTIND-1 ))
+PROV=$1
+CLIENT=$2
+SERVER=$3
 
-#iterative tests
-if [ $TEST_TYPE == "all" ]; then
-	testset=("${all_tests[@]}")  
-else
-	testset=("${quick_tests[@]}")  
-fi
-
-for test in "${testset[@]}"; do
-	run_test "client-server" "$test"
-done
-
-
-total=$(( $pass_count + $fail_count ))
-
-print_border
-
-printf "# %-50s%10d\n" "Total Pass" $pass_count
-printf "# %-50s%10d\n" "Total Fail" $fail_count
-
-if [[ "$total" > "0" ]]; then
-	printf "# %-50s%10.2f\n" "Percentage of Pass" `echo "scale=2; $pass_count * 100 / $total" | bc`
-fi
-
-print_border
-
-cleanup
-exit $fail_count
+main ${TEST_TYPE}


### PR DESCRIPTION
Make path argument optional, and use $PATH when not specified.
Specifying more -v's prints failed/notrun test output for debugging.
Which test-set to run is now optional, defaulting to 'all'.
Break tests into more categories and allow to be specified.

```
./scripts/runfabtests.sh -h
Usage: ./scripts/runfabtests.sh [-vtp] <provider_name> <server_addr> <client_addr>
[-vtp] verbose
[-t] test type(s): all,quick,unit,simple
[-p] path to test bins (default PATH)
```
Example invocations:

```
# defaults to all tests:
$ runfabtests.sh sockets host1 host2

# run just unit tests from local directory:
$ runfabtests.sh -t unit -p $CWD/unit psm host1 host2

# run two different test sets:
$ runfabtests.sh -t quick,unit sockets host1 host2
```


Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>