### PR TITLE
simple: pass correct modes and use FD wait obj for CQ

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -78,7 +78,7 @@ static int getaddr(char *node, char *service, void **addr,
 
 	ret = getaddrinfo(node, service, NULL, &ai);
 	if (ret) {
-		fprintf(stderr, "getaddrfino error %s\n", gai_strerror(ret));
+		FT_ERR("getaddrinfo error %s\n", gai_strerror(ret));
 		return ret;
 	}
 
@@ -86,7 +86,7 @@ static int getaddr(char *node, char *service, void **addr,
 		memcpy(*addr, ai->ai_addr, ai->ai_addrlen);
 		*len = (size_t)ai->ai_addrlen;
 	} else {
-		fprintf(stderr, "src_addr allocation failed\n");
+		FT_ERR("addr allocation failed\n");
 		ret = EAI_MEMORY;
 	}
 

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -99,7 +99,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	memset(&cq_attr, 0, sizeof cq_attr);
 	cq_attr.format = FI_CQ_FORMAT_DATA;
-	cq_attr.wait_obj = FI_WAIT_NONE;
+	cq_attr.wait_obj = FI_WAIT_UNSPEC;
 	cq_attr.size = rx_depth;
 	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
 	if (ret) {

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -329,7 +329,7 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_RMA;
 	// FI_PROV_MR_ATTR flag is not set
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_RX_CQ_DATA;
 
 	ret = run_test();
 	fi_freeinfo(hints);

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -694,7 +694,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_MSG;
 	hints->caps = FI_MSG | FI_RMA;
-	hints->mode = FI_LOCAL_MR | FI_PROV_MR_ATTR;
+	hints->mode = FI_LOCAL_MR | FI_PROV_MR_ATTR | FI_RX_CQ_DATA;
 	hints->addr_format = FI_SOCKADDR;
 
 	ret = run();

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -595,7 +595,7 @@ int main(int argc, char **argv)
 	
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_RMA;
-	hints->mode = FI_CONTEXT | FI_PROV_MR_ATTR;
+	hints->mode = FI_CONTEXT | FI_PROV_MR_ATTR | FI_RX_CQ_DATA;
 	
 	ret =run();
 


### PR DESCRIPTION
simple/cq_data: Pass correct modes in hints and use FD wait obj for CQ (for using sread).
other fixes: fix typo and use FT_ERR