### PR TITLE
simple/poll: Make use of common code for address options.

### DIFF
--- a/simple/poll.c
+++ b/simple/poll.c
@@ -48,14 +48,13 @@ enum comp_type {
 	CQ_RECV = 2
 };
 
+static struct cs_opts opts;
 static void *buf;
 static size_t buffer_size = 1024;
 static int transfer_size = 1000;
 static int rx_depth = 512;
 
 static struct fi_info *fi, *hints;
-static char *dst_addr, *src_addr;
-static char *dst_port = "5300", *src_port = "5300";
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
@@ -70,26 +69,6 @@ static fi_addr_t remote_fi_addr;
 struct fi_context fi_ctx_send;
 struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_av;
-
-void print_usage(char *name, char *desc)
-{
-	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "  %s [OPTIONS]\t\tstart server\n", name);
-	fprintf(stderr, "  %s [OPTIONS] <host>\tconnect to server \t\n", name);
-	
-	if (desc)
-		fprintf(stderr, "\n%s\n", desc);
-
-	fprintf(stderr, "\nOptions:\n");
-	fprintf(stderr, "  -n <domain>\tdomain name\n");
-	fprintf(stderr, "  -b <src_port>\tnon default source port number\n");
-	fprintf(stderr, "  -p <dst_port>\tnon default destination port number\n");
-	fprintf(stderr, "  -f <provider>\tspecific provider name eg IP, verbs\n");
-	fprintf(stderr, "  -s <address>\tsource address\n");
-	fprintf(stderr, "  -h\t\tdisplay this help output\n");
-	
-	return;
-}
 
 static void free_ep_res(void)
 {
@@ -263,22 +242,13 @@ static int recv_msg(void)
 
 static int init_fabric(void)
 {
-	struct fi_info *fi;
 	uint64_t flags = 0;
 	char *node, *service;
 	int ret;
 
-	if (dst_addr) {
-		ret = ft_getsrcaddr(src_addr, src_port, hints);
-		if (ret)
-			return ret;
-		node = dst_addr;
-		service = dst_port;
-	} else {
-		node = src_addr;
-		service = src_port;
-		flags = FI_SOURCE;
-	}
+	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
+	if (ret)
+		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
@@ -287,7 +257,7 @@ static int init_fabric(void)
 	}
 
 	/* Get remote address */
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		addrlen = fi->dest_addrlen;
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, fi->dest_addr, addrlen);
@@ -332,7 +302,7 @@ static int init_av(void)
 {
 	int ret;
 
-	if (dst_addr) {
+	if (opts.dst_addr) {
 		/* Get local address blob. Find the addrlen first. We set addrlen 
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
@@ -469,34 +439,27 @@ static int send_recv()
 int main(int argc, char **argv)
 {
 	int op, ret = 0;
+	opts = INIT_OPTS;
 	
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "b:p:s:h" INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" ADDR_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
-		case 'b':
-			src_port = optarg;
-			break;
-		case 'p':
-			dst_port = optarg;
-			break;
-		case 's':
-			src_addr = optarg;
-			break;
 		default:
+			ft_parse_addr_opts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints);
 			break;
 		case '?':
 		case 'h':
-			print_usage(argv[0], "A MSG client-server example that uses poll.\n");
+			ft_usage(argv[0], "A client-server example that uses poll.\n");
 			return EXIT_FAILURE;
 		}
 	}
 
 	if (optind < argc)
-		dst_addr = argv[optind];
+		opts.dst_addr = argv[optind];
 	
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;


### PR DESCRIPTION
This example was parsing the address options. Updated it to use the common code.