### PR TITLE
runfabtests.sh: quote grep args for zsh

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -96,8 +96,8 @@ function print_results {
 }
 
 function cleanup {
-	$ssh ${CLIENT} "ps -eo comm,pid | grep ^fi_ | awk '{print \$2}' | xargs -r kill -9" > /dev/null
-	$ssh ${SERVER} "ps -eo comm,pid | grep ^fi_ | awk '{print \$2}' | xargs -r kill -9" > /dev/null
+	$ssh ${CLIENT} "ps -eo comm,pid | grep '^fi_' | awk '{print \$2}' | xargs -r kill -9"
+	$ssh ${SERVER} "ps -eo comm,pid | grep '^fi_' | awk '{print \$2}' | xargs -r kill -9"
 	rm -f $c_outp $s_outp
 }
 


### PR DESCRIPTION
If zsh is used as the default shell and the user has `setopt extendedglob`
in their settings, this `grep` command will generate some
very different output than expected, breaking the rest of the pipeline.
The "^" is the problem in this particular instance.  Single quoting the
argument fixes the issue.

Also, kill the incorrect redirection to /dev/null.  That pipeline
shouldn't be generating stdout messages anyway, and we probably *do*
want to see stderr messages (that's how I found this issue).

Signed-off-by: Dave Goodell <dgoodell@cisco.com>