### PR TITLE
fi_poll: fix bad cleanup logic

### DIFF
--- a/simple/poll.c
+++ b/simple/poll.c
@@ -99,6 +99,7 @@ static void free_ep_res(void)
 	fi_close(&rcq->fid);
 	fi_close(&scq->fid);
 	free(buf);
+	fi_close(&ep->fid);
 }
 
 static int alloc_ep_res(struct fi_info *fi)
@@ -137,8 +138,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&poll_attr, 0, sizeof poll_attr);
 	ret = fi_poll_open(dom, &poll_attr, &pollset);
 	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		goto err3;
+		FT_PRINTERR("fi_poll_open", ret);
+		goto err2;
 	}
 	
 	/* Add send CQ to the polling set */
@@ -318,7 +319,6 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&ep->fid);
 	fi_close(&dom->fid);
 err1:
 	fi_close(&fab->fid);
@@ -513,7 +513,6 @@ int main(int argc, char **argv)
 	/* Exchange data */
 	ret = send_recv();
 
-	fi_close(&ep->fid);
 	free_ep_res();
 	fi_close(&dom->fid);
 	fi_close(&fab->fid);


### PR DESCRIPTION
The usnic provider returns -FI_ENOSYS for several of these fi_poll
operations, which was triggering the cleanup logic.  The cleanup logic
would SEGV in at least two places as it was written.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>