### PR TITLE
fabtest: Fix unconnected bandwidth tests

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -227,7 +227,8 @@ int ft_send_msg();
 int ft_send_dgram();
 int ft_send_dgram_done();
 int ft_recv_dgram();
-int ft_recv_dgram_flood();
+int ft_recv_dgram_flood(size_t *recv_cnt);
+int ft_send_dgram_flood();
 int ft_sendrecv_dgram();
 
 int ft_run_test();

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -47,7 +47,8 @@ static struct ft_set test_sets[] = {
 		.service = "2224",
 		.prov_name = "sockets",
 		.test_type = {
-			FT_TEST_LATENCY
+			FT_TEST_LATENCY,
+			FT_TEST_BANDWIDTH
 		},
 		.class_function = {
 			FT_FUNC_SEND,

--- a/complex/ft_endpoint.c
+++ b/complex/ft_endpoint.c
@@ -139,6 +139,8 @@ int ft_reset_ep(void)
 			return ret;
 	}
 
+	memset(ft_tx.buf, 0, ft_tx.msg_size);
+	memset(ft_rx.buf, 0, ft_rx.msg_size);
 	ret = ft_post_recv_bufs();
 	if (ret)
 		return ret;


### PR DESCRIPTION
The UD data streaming test will hang if packets are lost.
Update the test to work if this occurs, which is likely
when running over true datagrams.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>