### PR TITLE
complex/fabtest: add verbs test set + bug fixes

### DIFF
--- a/complex/fabtest.c
+++ b/complex/fabtest.c
@@ -81,9 +81,14 @@ static char *ft_strptr(char *str)
 
 static void ft_show_test_info(void)
 {
+	printf("[%s] ", test_info.prov_name);
+
 	switch (test_info.test_type) {
 	case FT_TEST_LATENCY:
 		printf("latency");
+		break;
+	case FT_TEST_BANDWIDTH:
+		printf("bandwidth");
 		break;
 	default:
 		break;

--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -47,6 +47,7 @@
 extern "C" {
 #endif
 
+#define FT_SREAD_TO 10000 // milliseconds
 
 extern int listen_sock, sock;
 

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -241,6 +241,7 @@ void fts_next(struct ft_series *series)
 
 	if (set->test_type[++series->cur_type])
 		return;
+	series->cur_type = 0;
 
 	series->cur_set++;
 }

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -78,6 +78,33 @@ static struct ft_set test_sets[] = {
 		},
 		.test_flags = FT_FLAG_QUICKTEST
 	},
+	{
+		.node = "127.0.0.1",
+		.service = "2224",
+		.prov_name = "verbs",
+		.test_type = {
+			FT_TEST_LATENCY,
+			FT_TEST_BANDWIDTH
+		},
+		.class_function = {
+			FT_FUNC_SEND,
+			FT_FUNC_SENDV,
+			FT_FUNC_SENDMSG
+		},
+		.ep_type = {
+			FI_EP_MSG,
+		},
+		.comp_type = {
+			FT_COMP_QUEUE
+		},
+		.mode = {
+			FT_MODE_ALL
+		},
+		.caps = {
+			FT_CAP_MSG,
+		},
+		.test_flags = FT_FLAG_QUICKTEST
+	},
 };
 
 static struct ft_series test_series;

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -96,7 +96,7 @@ ssize_t ft_get_event(uint32_t *event, void *buf, size_t len,
 {
 	ssize_t ret;
 
-	ret = fi_eq_sread(eq, event, buf, len, -1, 0);
+	ret = fi_eq_sread(eq, event, buf, len, FT_SREAD_TO, 0);
 	if (ret == -FI_EAVAIL) {
 		return ft_eq_readerr();
 	} else if (ret < 0) {

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -157,13 +157,9 @@ void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt)
 		ctrl->iov_iter = 0;
 }
 
-static int ft_sync_test(int value)
+static int ft_sync(int value)
 {
-	int ret, result = -FI_EOTHER;
-
-	ret = ft_reset_ep();
-	if (ret)
-		return ret;
+	int result = -FI_EOTHER;
 
 	if (listen_sock < 0) {
 		ft_fw_send(sock, &value,  sizeof value);
@@ -174,6 +170,17 @@ static int ft_sync_test(int value)
 	}
 
 	return result;
+}
+
+static int ft_sync_test(int value)
+{
+	int ret;
+
+	ret = ft_reset_ep();
+	if (ret)
+		return ret;
+
+	return ft_sync(value);
 }
 
 static int ft_pingpong(void)
@@ -416,6 +423,8 @@ int ft_run_test()
 		ret = ft_open_active();
 	if (ret)
 		goto cleanup;
+
+	ft_sync(0);
 
 	ret = ft_enable_comm();
 	if (ret)

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -404,22 +404,22 @@ int ft_run_test()
 
 	ret = ft_init_control();
 	if (ret)
-		return ret;
+		goto cleanup;
 
 	ret = ft_open_control();
 	if (ret)
-		return ret;
+		goto cleanup;
 
 	if (test_info.ep_type == FI_EP_MSG && listen_sock >= 0)
 		ret = ft_open_passive();
 	else
 		ret = ft_open_active();
 	if (ret)
-		return ret;
+		goto cleanup;
 
 	ret = ft_enable_comm();
 	if (ret)
-		return ret;
+		goto cleanup;
 
 	switch (test_info.test_type) {
 	case FT_TEST_LATENCY:
@@ -434,6 +434,7 @@ int ft_run_test()
 	}
 
 	ft_sync_test(0);
+cleanup:
 	ft_cleanup();
 
 	return ret ? ret : -ft.error;


### PR DESCRIPTION
* Add a test set for verbs provider
* Add server timeout when waiting for incoming connection request from client.
* Fix race condition in fabtest when run over verbs
* Show provider info in results and reset current test type index to 0 after iterating though all types.