### PR TITLE
ud_pingpong.c: prevent segv on user CLI error

### DIFF
--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -372,8 +372,6 @@ static int common_setup(void)
 		goto err5;
 	}
 
-	free(hints->src_addr);
-
 	return 0;
 
 err5:
@@ -383,7 +381,6 @@ err4:
 err2:
 	fi_close(&fab->fid);
 err1:
-	free(hints->src_addr);
 
 	return ret;
 }


### PR DESCRIPTION
When we free it, set it to NULL so that later error recovery doesn't try to free it again.  Otherwise, a bogus command line like this can cause a segv:

    ./pingpong/fi_ud_pingpong 30.0.11.42 -s 999

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@goodell Please review