### PR TITLE
fi_av_test: allow a src addr to be specified

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -249,7 +249,7 @@ function usage {
 	errcho "Run fabtests on given nodes, report pass/fail/notrun status."
 	errcho
 	errcho "Options:"
-	errcho -e " -g\tgood IP address from <client>'s perspective (default $GOOD_ADDR)"
+	errcho -e " -g\tgood IP address from <host>'s perspective (default $GOOD_ADDR)"
 	errcho -e " -v..\tprint output of failing/notrun/passing"
 	errcho -e " -t\ttest set(s): all,quick,unit,simple,standard,short (default quick)"
 	errcho -e " -p\tpath to test bins (default PATH)"

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -75,7 +75,7 @@ standard_tests=(
 )
 
 unit_tests=(
-	"av_test -d GOOD_ADDR -n 1"
+	"av_test -d GOOD_ADDR -n 1 -s SERVER_ADDR"
 	"dom_test -n 2"
 	"eq_test"	
 	"size_left_test"
@@ -110,7 +110,8 @@ function cleanup_and_exit {
 function unit_test {
 	local test=$1
 	local ret1=0
-	local test_exe=$(echo "fi_${test} -f $PROV" | sed -e "s/GOOD_ADDR/$GOOD_ADDR/")
+	local test_exe=$(echo "fi_${test} -f $PROV" | \
+	    sed -e "s/GOOD_ADDR/$GOOD_ADDR/g" -e "s/SERVER_ADDR/${SERVER}/g")
 	local SO=""
 
 	${ssh} ${SERVER} ${BIN_PATH} "${test_exe}" &> $s_outp &

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -61,6 +61,7 @@ static struct fi_eq_attr eq_attr;
 char *good_address;
 int num_good_addr;
 char *bad_address;
+static char *src_addr_str = NULL;
 
 static enum fi_av_type av_type;
 
@@ -1012,7 +1013,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:p:d:D:n:a:")) != -1) {
+	while ((op = getopt(argc, argv, "f:p:d:D:n:a:s:")) != -1) {
 		switch (op) {
 		case 'd':
 			good_address = optarg;
@@ -1029,6 +1030,9 @@ int main(int argc, char **argv)
 		case 'f':
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
+		case 's':
+			src_addr_str = strdup(optarg);
+			break;
 		default:
 			printf("usage: %s\n", argv[0]);
 			printf("\t[-d good_address]\n");
@@ -1036,6 +1040,7 @@ int main(int argc, char **argv)
 			printf("\t[-a fabric_name]\n");
 			printf("\t[-n num_good_addr (max=%d)]\n", MAX_ADDR - 1);
 			printf("\t[-f provider_name]\n");
+			printf("\t[-s source_address]\n");
 			return EXIT_FAILURE;
 			
 		}
@@ -1056,7 +1061,8 @@ int main(int argc, char **argv)
 	hints->addr_format = FI_SOCKADDR;
 
 	hints->ep_attr->type = FI_EP_RDM;
-	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	ret = fi_getinfo(FI_VERSION(1, 0), src_addr_str, 0, FI_SOURCE, hints,
+				&fi);
 	if (ret != 0 && ret != -FI_ENODATA) {
 		printf("fi_getinfo %s\n", fi_strerror(-ret));
 		goto err1;
@@ -1064,7 +1070,8 @@ int main(int argc, char **argv)
 
 	if (ret == -FI_ENODATA) {
 		hints->ep_attr->type = FI_EP_DGRAM;
-		ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+		ret = fi_getinfo(FI_VERSION(1, 0), src_addr_str, 0, FI_SOURCE,
+					hints, &fi);
 		if (ret != 0) {
 			printf("fi_getinfo %s\n", fi_strerror(-ret));
 			goto err1;


### PR DESCRIPTION
Also specify that argument in `runfabtests.sh`

This fixes the case when we want to run tests between interfaces which
are not the first items returned by libfabric's `fi_getinfo` call.
