### PR TITLE
EQ and CQ readerr additions + fixes

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -245,11 +245,33 @@ void cq_readerr(struct fid_cq *cq, char *cq_str)
 	int ret;
 
 	ret = fi_cq_readerr(cq, &cq_err, 0);
-	if (ret < 0)
+	if (ret < 0) {
 		FT_PRINTERR("fi_cq_readerr", ret);
+	} else {
+		err_str = fi_cq_strerror(cq, cq_err.prov_errno, cq_err.err_data, NULL, 0);
+		fprintf(stderr, "%s: %d %s\n", cq_str, cq_err.err,
+				fi_strerror(cq_err.err));
+		fprintf(stderr, "%s: prov_err: %s (%d)\n", cq_str, err_str,
+				cq_err.prov_errno);
+	}
+}
 
-	err_str = fi_cq_strerror(cq, cq_err.prov_errno, cq_err.err_data, NULL, 0);
-	fprintf(stderr, "%s %s (%d)\n", cq_str, err_str, cq_err.prov_errno);
+void eq_readerr(struct fid_eq *eq, char *eq_str)
+{
+	struct fi_eq_err_entry eq_err;
+	const char *err_str;
+	int rd;
+
+	rd = fi_eq_readerr(eq, &eq_err, 0);
+	if (rd != sizeof(eq_err)) {
+		FT_PRINTERR("fi_eq_readerr", rd);
+	} else {
+		err_str = fi_eq_strerror(eq, eq_err.prov_errno, eq_err.err_data, NULL, 0);
+		fprintf(stderr, "%s: %d %s\n", eq_str, eq_err.err,
+				fi_strerror(eq_err.err));
+		fprintf(stderr, "%s: prov_err: %s (%d)\n", eq_str, err_str,
+				eq_err.prov_errno);
+	}
 }
 
 int ft_finalize(struct fid_ep *tx_ep, struct fid_cq *scq, struct fid_cq *rcq,

--- a/include/shared.h
+++ b/include/shared.h
@@ -122,6 +122,7 @@ int ft_finalize(struct fid_ep *tx_ep, struct fid_cq *scq, struct fid_cq *rcq,
 int wait_for_data_completion(struct fid_cq *cq, int num_completions);
 int wait_for_completion(struct fid_cq *cq, int num_completions);
 void cq_readerr(struct fid_cq *cq, char *cq_str);
+void eq_readerr(struct fid_eq *eq, char *eq_str);
 
 int64_t get_elapsed(const struct timespec *b, const struct timespec *a, 
 		enum precision p);
@@ -135,6 +136,21 @@ void show_perf_mr(int tsize, int iters, struct timespec *start,
 
 #define FT_ERR(fmt, ...) \
 	do { fprintf(stderr, "%s:%d: " fmt, __FILE__, __LINE__, ##__VA_ARGS__); } while (0)
+
+#define FT_PROCESS_QUEUE_ERR(readerr, rd, queue, fn, str)	\
+	do {							\
+		if (rd == -FI_EAVAIL) {				\
+			readerr(queue, fn " " str);		\
+		} else {					\
+			FT_PRINTERR(fn, rd);			\
+		}						\
+	} while (0)
+
+#define FT_PROCESS_EQ_ERR(rd, eq, fn, str) \
+	FT_PROCESS_QUEUE_ERR(eq_readerr, rd, eq, fn, str)
+
+#define FT_PROCESS_CQ_ERR(rd, cq, fn, str) \
+	FT_PROCESS_QUEUE_ERR(cq_readerr, rd, cq, fn, str)
 
 #define FT_PRINT_OPTS_USAGE(opt, desc) fprintf(stderr, " %-20s %s\n", opt, desc)
 

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -376,7 +376,7 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
+		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "listen");
 		return (int) rd;
 	}
 
@@ -409,7 +409,8 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
+		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "accept");
+		ret = (int) rd;
 		goto err3;
 	}
 
@@ -436,7 +437,6 @@ err1:
 static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
-	struct fi_eq_err_entry err;
 	uint32_t event;
 	struct fi_info *fi;
 	ssize_t rd;
@@ -480,17 +480,7 @@ static int client_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		if (rd == -FI_EAVAIL) {
-			rd = fi_eq_readerr(cmeq, &err, 0);
-			if (rd != sizeof(err)) {
-				FT_PRINTERR("fi_eq_sread", rd);
-			} else {
-				fprintf(stderr, "EQ report error %d %s\n", err.err,
-						fi_strerror(err.err));
-			}
-		} else {
-			FT_PRINTERR("fi_eq_sread", rd);
-		}
+		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "connect");
 		ret = (int) rd;
 		goto err4;
 	}

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -170,11 +170,11 @@ static int pp_accept_ctx(struct pingpong_context *ctx)
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
 	int rc = 0;
-	int rd = 0;
+	ssize_t rd;
 
 	rd = fi_eq_sread(ctx->eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
+		FT_PROCESS_EQ_ERR(rd, ctx->eq, "fi_eq_sread", "listen");
 		goto err;
 	}
 
@@ -228,7 +228,7 @@ static int pp_accept_ctx(struct pingpong_context *ctx)
 
 	rd = fi_eq_sread(ctx->eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
+		FT_PROCESS_EQ_ERR(rd, ctx->eq, "fi_eq_sread", "accept");
 		goto err;
 	}
 
@@ -251,6 +251,7 @@ static int pp_connect_ctx(struct pingpong_context *ctx)
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
 	int rc = 0;
+	ssize_t rd;
 
 	/* Open domain */
 	rc = fi_domain(ctx->fabric, ctx->info, &ctx->dom, NULL);
@@ -303,9 +304,9 @@ static int pp_connect_ctx(struct pingpong_context *ctx)
 		goto err;
 	}
 
-	rc = fi_eq_sread(ctx->eq, &event, &entry, sizeof entry, -1, 0);
-	if (rc != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rc);
+	rd = fi_eq_sread(ctx->eq, &event, &entry, sizeof entry, -1, 0);
+	if (rd != sizeof entry) {
+		FT_PROCESS_EQ_ERR(rd, ctx->eq, "fi_eq_sread", "connect");
 		goto err;
 	}
 

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -354,17 +354,13 @@ static int connect_events(void)
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
 	int ret = 0;
+	ssize_t rd;
 
 	while (connects_left && !ret) {
-		ret = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
-		
-		if (ret < 0) {
-			FT_PRINTERR("fi_eq_sread", ret);
-			break;
-		}
-
-		if (ret != sizeof entry) {
+		rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
+		if (rd != sizeof entry) {
 			printf("unexpected event during connect\n");
+			FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "connect");
 			ret = -FI_EIO;
 			break;
 		}
@@ -380,16 +376,13 @@ static int shutdown_events(void)
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
 	int ret = 0;
+	ssize_t rd;
 
 	while (disconnects_left && !ret) {
-		ret = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
-		if (ret < 0) {
-			FT_PRINTERR("fi_eq_sread", ret);
-			break;
-		}
-
-		if (ret != sizeof entry) {
+		rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
+		if (rd != sizeof entry) {
 			printf("unexpected event during shutdown\n");
+			FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "shutdown");
 			ret = -FI_EIO;
 			break;
 		}

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -245,7 +245,7 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
+		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "listen");
 		return (int) rd;
 	}
 
@@ -279,7 +279,8 @@ static int server_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
+		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "accept");
+		ret = (int) rd;
 		goto err3;
 	}
 
@@ -349,8 +350,9 @@ static int client_connect(void)
 
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
-		return (int) rd;
+		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "connect");
+		ret = (int) rd;
+		goto err5;
 	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -227,7 +227,7 @@ static int server_connect(void)
 	/* Wait for connection request from client */
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
+		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "listen");
 		return (int) rd;
 	}
 
@@ -262,7 +262,8 @@ static int server_connect(void)
 	/* Wait for the connection to be established */
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
+		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "accept");
+		ret = (int) rd;
 		goto err3;
 	}
 
@@ -334,8 +335,9 @@ static int client_connect(void)
 	/* Wait for the connection to be established */
 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PRINTERR("fi_eq_sread", rd);
-		return (int) rd;
+		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "connect");
+		ret = (int) rd;
+		goto err6;
 	}
 
 	if (event != FI_CONNECTED || entry.fid != &ep->fid) {


### PR DESCRIPTION
* Add eq_readerr common function.
* In cq_readerr, exit if fi_cq_readerr fails. Print error string.
* Update examples to make use of eq_readerr

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>