### PR TITLE
complex: Add options to get destination address and port from command line

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -66,6 +66,7 @@ extern struct fid_pep	 *pep;
 
 extern struct ft_info test_info;
 extern struct fi_info *fabric_info;
+extern struct cs_opts opts;
 
 extern size_t sm_size_array[];
 extern size_t med_size_array[];

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -43,8 +43,6 @@
 
 static struct ft_set test_sets[] = {
 	{
-		.node = "127.0.0.1",
-		.service = "2224",
 		.prov_name = "sockets",
 		.test_type = {
 			FT_TEST_LATENCY,
@@ -79,8 +77,6 @@ static struct ft_set test_sets[] = {
 		.test_flags = FT_FLAG_QUICKTEST
 	},
 	{
-		.node = "127.0.0.1",
-		.service = "2224",
 		.prov_name = "verbs",
 		.test_type = {
 			FT_TEST_LATENCY,
@@ -272,7 +268,7 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->av_type = set->av_type[series->cur_av];
 	info->comp_type = set->comp_type[series->cur_comp];
 
-	memcpy(info->node, set->node, FI_NAME_MAX);
-	memcpy(info->service, set->service, FI_NAME_MAX);
+	memcpy(info->node, set->node[0] ? set->node : opts.dst_addr, FI_NAME_MAX);
+	memcpy(info->service, set->service[0] ? set->service : opts.dst_port, FI_NAME_MAX);
 	memcpy(info->prov_name, set->prov_name, FI_NAME_MAX);
 }


### PR DESCRIPTION
By default, the node and service options given in test config would be used.
If it is not present user provided node and service options would be used.

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>