### PR TITLE
Use gettimeofday() on OS X

### DIFF
--- a/common/osx/osd.c
+++ b/common/osx/osd.c
@@ -32,18 +32,18 @@
 
 #include "osx/osd.h"
 
+// clock_gettime() does not exist on OS X.  Instead, simply use
+// gettimeofday(), which is apparently fairly efficient on OS X (i.e.,
+// ignore the clk_id that is passed in and always return the system
+// clock time).
 int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 	int retval;
+	struct timeval tv;
 
-	clock_serv_t cclock;
-	mach_timespec_t mts;
+	retval = gettimeofday(&tv, NULL);
 
-	host_get_clock_service(mach_host_self(), clk_id, &cclock);
-	retval = clock_get_time(cclock, &mts);
-	mach_port_deallocate(mach_task_self(), cclock);
-
-	tp->tv_sec = mts.tv_sec;
-	tp->tv_nsec = mts.tv_nsec;
+	tp->tv_sec = tv.tv_sec;
+	tp->tv_nsec = tv.tv_usec * 1000;
 
 	return retval;
 }

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -36,8 +36,9 @@
 #include <sys/time.h>
 #include <time.h>
 
-#define CLOCK_REALTIME CALENDAR_CLOCK
-#define CLOCK_MONOTONIC SYSTEM_CLOCK
+#define CLOCK_REALTIME 0
+#define CLOCK_REALTIME_COARSE 0
+#define CLOCK_MONOTONIC 0
 
 typedef int clockid_t;
 

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _MACH_CLOCK_GETTIME_H_
-#define _MACH_CLOCK_GETTIME_H_
+#ifndef _FABTESTS_OSX_OSD_H_
+#define _FABTESTS_OSX_OSD_H_
 
 #include <sys/time.h>
 #include <time.h>
@@ -51,4 +51,4 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp);
 }
 #endif
 
-#endif
+#endif // FABTESTS_OSX_OSD_H

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -35,8 +35,6 @@
 
 #include <sys/time.h>
 #include <time.h>
-#include <mach/clock.h>
-#include <mach/mach.h>
 
 #define CLOCK_REALTIME CALENDAR_CLOCK
 #define CLOCK_MONOTONIC SYSTEM_CLOCK


### PR DESCRIPTION
We emulate `clock_gettime()` on OS X.  However, according to http://stackoverflow.com/a/21352348/1120009, `host_get_clock_service()` should not be used -- it's inaccurate and slow.

This PR updates the `clock_gettime` emulation on OS X to use `gettimeofday()` instead.

It also makes a minor tweak to `osx/osd.h`, and adds support for emulating `CLOCK_REALTIME_COARSE` (in anticipation of PR #269).

@bturrubiates Please review.