### PR TITLE
runfabtests: force ssh to get /dev/null as stdin

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -12,7 +12,7 @@ declare GOOD_ADDR="192.168.10.1"
 declare -i VERBOSE=0
 
 # base ssh,  "short" and "long" timeout variants:
-declare -r bssh="ssh -o StrictHostKeyChecking=no -o ConnectTimeout=2 -o BatchMode=yes"
+declare -r bssh="ssh -n -o StrictHostKeyChecking=no -o ConnectTimeout=2 -o BatchMode=yes"
 declare -r sssh="timeout 60s ${bssh}"
 declare -r lssh="timeout 90s ${bssh}"
 declare ssh=${sssh}


### PR DESCRIPTION
Hitting extraneous input during runfabtests runs could cause the ssh'ed cleanup commands to get confused and hang (and eventually be killed by "timeout").  Instead, force the ssh's to tie /dev/null to stdin via the -n parameter.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>