### PR TITLE
shared.h: make the FI_PRINTERR message more clear

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -132,7 +132,7 @@ void show_perf_mr(int tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
 
 #define FT_PRINTERR(call, retv) \
-	do { fprintf(stderr, call "(): %d, %d (%s)\n", __LINE__, (int) retv, fi_strerror((int) -retv)); } while (0)
+	do { fprintf(stderr, call "(): %s:%d, ret=%d (%s)\n", __FILE__, __LINE__, (int) retv, fi_strerror((int) -retv)); } while (0)
 
 #define FT_ERR(fmt, ...) \
 	do { fprintf(stderr, "%s:%d: " fmt, __FILE__, __LINE__, ##__VA_ARGS__); } while (0)


### PR DESCRIPTION
Make it clear that the first number is a line number by also printing the filename, and put "ret=%d" for the return value output.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>