### PR TITLE
Add rdm_bw, rdm_latency and rdm_mbw_mr benchmarks.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -188,3 +188,34 @@ EXTRA_DIST = \
 
 dist-hook: fabtests.spec
 	cp fabtests.spec $(distdir)
+
+if HAVE_PMI
+AM_CFLAGS += -lpmi
+
+if HAVE_CRAY_PMI
+AM_CFLAGS += -DCRAY_PMI_COLL
+endif
+
+bin_PROGRAMS += \
+	ported/omb/rdm_bw \
+	ported/omb/rdm_latency \
+	ported/omb/rdm_mbw_mr
+
+ported_omb_rdm_bw_SOURCES = \
+	ported/omb/rdm_bw.c \
+	ported/omb/ft_utils.c
+ported_omb_rdm_bw_LDADD = libfabtests.la
+
+ported_omb_rdm_latency_SOURCES = \
+	ported/omb/rdm_latency.c \
+	ported/omb/ft_utils.c
+ported_omb_rdm_latency_LDADD = libfabtests.la
+
+ported_omb_rdm_mbw_mr_SOURCES = \
+	ported/omb/rdm_mbw_mr.c \
+	ported/omb/ft_utils.c
+ported_omb_rdm_mbw_mr_LDADD = libfabtests.la
+
+EXTRA_DIST += \
+	ft_utils.h
+endif

--- a/common/shared.c
+++ b/common/shared.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/time.h>
 
 #include <rdma/fi_errno.h>
 #include <rdma/fi_endpoint.h>
@@ -368,6 +369,19 @@ void show_perf_mr(int tsize, int iters, struct timespec *start,
 	printf(" }\n");
 }
 
+void ft_basic_usage(char *desc)
+{
+	if (desc)
+		fprintf(stderr, "\n%s\n", desc);
+
+	fprintf(stderr, "\nOptions:\n");
+	FT_PRINT_OPTS_USAGE("-n <domain>", "domain name");
+	FT_PRINT_OPTS_USAGE("-f <provider>", "specific provider name eg sockets, verbs");
+	FT_PRINT_OPTS_USAGE("-h", "display this help output");
+
+	return;
+}
+
 void ft_usage(char *name, char *desc)
 {
 	fprintf(stderr, "Usage:\n");
@@ -528,3 +542,14 @@ int ft_check_buf(void *buf, int size)
 
 	return 0;
 }
+
+uint64_t get_time_usec(void)
+{
+	struct timeval tv;
+	uint64_t usecs;
+
+	gettimeofday(&tv, NULL);
+	usecs = (tv.tv_sec * 1000000) + tv.tv_usec;
+	return usecs;
+}
+

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,19 @@ AC_ARG_WITH([libfabric],
              LDFLAGS="-L$withval/$fab_libdir $LDFLAGS"],
             [])
 
+AC_ARG_WITH([pmi],
+            AC_HELP_STRING([--with-pmi], [Specify PMI location - default NO]),
+            [AS_IF([test -d $withval/lib64], [pmi_libdir="lib64"], [pmi_libdir="lib"])
+             CPPFLAGS="-I $withval/include $CPPFLAGS"
+             CPPFLAGS="-I $withval $CPPFLAGS"
+             LDFLAGS="-L$withval/$pmi_libdir $LDFLAGS"
+             AM_CONDITIONAL([HAVE_PMI], [true])],
+            [AM_CONDITIONAL([HAVE_PMI], [false])])
+
+AC_CHECK_LIB([pmi], [PMI_Allgather],
+	     AM_CONDITIONAL([HAVE_CRAY_PMI], [true]),
+	     AM_CONDITIONAL([HAVE_CRAY_PMI], [false]))
+
 dnl Checks for libraries
 AC_CHECK_LIB([fabric], fi_getinfo, [],
     AC_MSG_ERROR([fi_getinfo() not found.  fabtests requires libfabric.]))

--- a/include/shared.h
+++ b/include/shared.h
@@ -87,6 +87,7 @@ enum {
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
 void ft_parse_addr_opts(int op, char *optarg, struct cs_opts *opts);
 void ft_parsecsopts(int op, char *optarg, struct cs_opts *opts);
+void ft_basic_usage(char *desc);
 void ft_usage(char *name, char *desc);
 void ft_csusage(char *name, char *desc);
 void ft_fill_buf(void *buf, int size);
@@ -165,6 +166,8 @@ enum ft_rma_opcodes {
 	FT_RMA_WRITE,
 	FT_RMA_WRITEDATA,
 };
+
+uint64_t get_time_usec(void);
 
 #ifdef __cplusplus
 }

--- a/ported/omb/README
+++ b/ported/omb/README
@@ -1,0 +1,13 @@
+Libfabric OMB (OSU Micro-Benchmarks) Ports
+------------------------------------------
+This directory contains several tests from the OSU micro-benchmark suite ported
+to Libfabric.
+
+The original OSU micro-benchmarks can be downloaded at:
+
+http://mvapich.cse.ohio-state.edu/benchmarks/
+
+Known Issues
+-------------
+-For a more accurate comparison between MPI and Libfabric performance, the
+Libfabric tests should use tagged messaging interfaces.

--- a/ported/omb/ft_utils.c
+++ b/ported/omb/ft_utils.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <malloc.h>
+#include <sched.h>
+#include <sys/utsname.h>
+#include <dlfcn.h>
+
+#include "pmi.h"
+#include "ft_utils.h"
+
+#ifndef CRAY_PMI_COLL
+
+static int myRank;
+static char *kvsName;
+static int debug;
+
+#define ENCODE_LEN(_len)	(2 * _len + 1)
+
+static char *encode(char *buf, size_t len)
+{
+	int i;
+	char *ebuf;
+
+	ebuf = calloc(ENCODE_LEN(len), 1);
+	assert(ebuf);
+
+	for (i = 0 ; i < len; i++) {
+		ebuf[(2*i)] = (buf[i] & 0xF) + 'a';
+		ebuf[(2*i)+1] = ((buf[i] >> 4) & 0xF) + 'a';
+	}
+
+	ebuf[2*len] = '\0';
+
+	return ebuf;
+}
+
+static char *decode(char *ebuf, size_t *outlen)
+{
+	int i;
+	char *buf;
+	int len;
+
+	len = strlen(ebuf);
+
+	buf = malloc(len/2);
+	assert(buf);
+
+	for (i = 0; i < len/2; i++) {
+		buf[i] = (((ebuf[(2*i)+1] - 'a') << 4) | (ebuf[(2*i)] - 'a'));
+	}
+
+	*outlen = len;
+	return buf;
+}
+
+static void gni_pmi_send(char *kvs, void *buffer, size_t len)
+{
+	char *data;
+	char key[64];
+	int rc;
+
+	data = encode(buffer, len);
+
+	snprintf(key, 64, "%s_rank%d", kvs, myRank);
+	rc = PMI_KVS_Put(kvsName, key, data);
+
+	if (debug) {
+		fprintf(stderr, "[%d]PMI_KVS_Put key: %s data %s, rc %d\n",
+			myRank, key, data, rc);
+	}
+
+	assert(rc == PMI_SUCCESS);
+
+	rc = PMI_KVS_Commit(kvsName);
+	assert(rc == PMI_SUCCESS);
+
+	free(data);
+}
+
+static void gni_pmi_receive(char *kvs, int rank, void *buffer, size_t len)
+{
+	char *data;
+	char key[64];
+	char *keyval = calloc(ENCODE_LEN(len), 1);
+	int rc;
+	size_t outlen;
+
+	snprintf(key, 64, "%s_rank%d", kvs, rank);
+
+	rc = PMI_KVS_Get(kvsName, key, keyval, ENCODE_LEN(len));
+
+	if (debug) {
+		fprintf(stderr, "[%d]PMI_KVS_Get key: %s keyval %s, rc %d\n",
+			myRank, key, keyval, rc);
+	}
+
+	assert(rc == PMI_SUCCESS);
+
+	data = decode(keyval, &outlen);
+	assert(data != NULL);
+
+	memcpy(buffer, data, outlen < len ? outlen : len);
+
+	free(keyval);
+	free(data);
+}
+
+int PMI_Allgather(void *src, void *targ, size_t len_per_rank)
+{
+	static int cnt;
+	int i, nranks;
+	char *ptr;
+	char idstr[64];
+
+	snprintf(idstr, 64, "allg%d", cnt++);
+	gni_pmi_send(idstr, src, len_per_rank);
+	PMI_Barrier();
+	PMI_Get_size(&nranks);
+
+	for (i = 0; i < nranks; i++) {
+		ptr = ((char *)targ) + (i*len_per_rank);
+		gni_pmi_receive(idstr, i, ptr, len_per_rank);
+	}
+
+	return PMI_SUCCESS;
+}
+
+int PMI_Bcast(void *buf, int len)
+{
+	static int cnt;
+	char idstr[64];
+
+	snprintf(idstr, 64, "bcst%d", cnt++);
+
+	if (!myRank) {
+		gni_pmi_send(idstr, buf, len);
+		PMI_Barrier();
+	} else {
+		PMI_Barrier();
+		gni_pmi_receive(idstr, 0, buf, len);
+	}
+
+	PMI_Barrier();
+
+	return PMI_SUCCESS;
+}
+
+static void pmi_coll_init(void)
+{
+	int len;
+	int rank;
+	int rc;
+
+	rc = PMI_Get_rank(&rank);
+	assert(rc == PMI_SUCCESS);
+
+	myRank = rank;
+
+	rc = PMI_KVS_Get_name_length_max(&len);
+	assert(rc == PMI_SUCCESS);
+
+	kvsName = calloc(len, sizeof(char));
+	rc = PMI_KVS_Get_my_name(kvsName, len);
+	assert(rc == PMI_SUCCESS);
+
+	PMI_Barrier();
+}
+#else
+#define pmi_coll_init()
+#endif /* CRAY_PMI_COLL */
+
+static void allgather(void *in, void *out, int len)
+{
+	static int *ivec_ptr, already_called, job_size;
+	int i, rc;
+	int my_rank;
+	char *tmp_buf, *out_ptr;
+
+	if (!already_called) {
+		rc = PMI_Get_size(&job_size);
+		assert(rc == PMI_SUCCESS);
+		rc = PMI_Get_rank(&my_rank);
+		assert(rc == PMI_SUCCESS);
+
+		ivec_ptr = (int *)malloc(sizeof(int) * job_size);
+		assert(ivec_ptr != NULL);
+
+		rc = PMI_Allgather(&my_rank, ivec_ptr, sizeof(int));
+		assert(rc == PMI_SUCCESS);
+
+		already_called = 1;
+	}
+
+	tmp_buf = malloc(job_size * len);
+	assert(tmp_buf);
+
+	rc = PMI_Allgather(in, tmp_buf, len);
+	assert(rc == PMI_SUCCESS);
+
+	out_ptr = out;
+
+	for (i = 0; i < job_size; i++) {
+		memcpy(&out_ptr[len * ivec_ptr[i]], &tmp_buf[i * len], len);
+	}
+
+	free(tmp_buf);
+}
+
+void FT_Exit(void)
+{
+	PMI_Abort(0, "Terminating application successfully");
+}
+
+void FT_Abort(void)
+{
+	PMI_Abort(-1, "pmi abort called");
+}
+
+void FT_Barrier(void)
+{
+	int rc;
+
+	rc = PMI_Barrier();
+	assert(rc == PMI_SUCCESS);
+}
+
+void FT_Init(int *argc, char ***argv)
+{
+	int rc, first_spawned;
+	void *libpmi_handle;
+
+	libpmi_handle = dlopen("libpmi.so.0", RTLD_LAZY | RTLD_GLOBAL);
+	if (libpmi_handle == NULL) {
+		perror("Unabled to open libpmi.so check your LD_LIBRARY_PATH");
+		abort();
+	}
+
+	rc = PMI_Init(&first_spawned);
+	assert(rc == PMI_SUCCESS);
+
+	pmi_coll_init();
+}
+
+void FT_Rank(int *rank)
+{
+	int rc;
+
+	rc = PMI_Get_rank(rank);
+	assert(rc == PMI_SUCCESS);
+}
+
+void FT_Finalize(void)
+{
+	PMI_Finalize();
+}
+
+void FT_Job_size(int *nranks)
+{
+	int rc;
+
+	rc = PMI_Get_size(nranks);
+	assert(rc == PMI_SUCCESS);
+}
+
+void FT_Allgather(void *src, size_t len_per_rank, void *targ)
+{
+	allgather(src, targ, len_per_rank);
+}
+
+void FT_Bcast(void *buffer, size_t len)
+{
+	int rc;
+
+	rc = PMI_Bcast(buffer, len);
+	assert(rc == PMI_SUCCESS);
+}
+

--- a/ported/omb/ft_utils.h
+++ b/ported/omb/ft_utils.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FT_UTILS_H
+#define _FT_UTILS_H
+
+#include <sys/utsname.h>
+
+#include "pmi.h"
+
+void FT_Init(int *, char ***);
+void FT_Abort(void);
+void FT_Exit(void);
+void FT_Rank(int *);
+void FT_Finalize(void);
+void FT_Barrier(void);
+void FT_Job_size(int *);
+void FT_Allgather(void *src, size_t, void *dest);
+void FT_Bcast(void *, size_t);
+
+#endif /* _FT_UTILS_H */

--- a/ported/omb/rdm_bw.c
+++ b/ported/omb/rdm_bw.c
@@ -1,0 +1,480 @@
+/*
+ * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
+ * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <string.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_rma.h>
+
+#include "ft_utils.h"
+#include "shared.h"
+
+#define MAX_ALIGNMENT 65536
+#define MAX_MSG_SIZE (1<<22)
+#define MYBUFSIZE (MAX_MSG_SIZE + MAX_ALIGNMENT)
+
+#define TEST_DESC "Libfabric Bandwidth Test"
+#define HEADER "# " TEST_DESC " \n"
+#ifndef FIELD_WIDTH
+#   define FIELD_WIDTH 20
+#endif
+#ifndef FLOAT_PRECISION
+#   define FLOAT_PRECISION 2
+#endif
+
+int loop = 100;
+int window_size = 64;
+int skip = 10;
+
+int loop_large = 20;
+int window_size_large = 64;
+int skip_large = 2;
+
+int large_message_size = 8192;
+
+char s_buf_original[MYBUFSIZE];
+char r_buf_original[MYBUFSIZE];
+
+static int rx_depth = 512;
+
+struct fi_info *fi, *hints;
+struct fid_fabric *fab;
+struct fid_domain *dom;
+struct fid_ep *ep;
+struct fid_av *av;
+struct fid_cq *rcq, *scq;
+struct fid_mr *r_mr, *l_mr;
+struct fi_context fi_ctx_send;
+struct fi_context fi_ctx_recv;
+struct fi_context fi_ctx_av;
+
+void *addrs;
+fi_addr_t *fi_addrs;
+
+typedef struct buf_desc {
+	uint64_t addr;
+	uint64_t key;
+} buf_desc_t;
+
+buf_desc_t *rbuf_descs;
+
+int myid, numprocs;
+
+void print_usage(void)
+{
+	if (!myid)
+		ft_basic_usage(TEST_DESC);
+}
+
+static void free_ep_res(void)
+{
+	fi_close(&av->fid);
+	fi_close(&rcq->fid);
+	fi_close(&scq->fid);
+}
+
+static int alloc_ep_res(void)
+{
+	struct fi_cq_attr cq_attr;
+	struct fi_av_attr av_attr;
+	int ret;
+
+	memset(&cq_attr, 0, sizeof(cq_attr));
+	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
+	cq_attr.wait_obj = FI_WAIT_NONE;
+	cq_attr.size = rx_depth;
+
+	/* Open completion queue for send completions */
+	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_cq_open", ret);
+		goto err1;
+	}
+
+	/* Open completion queue for recv completions */
+	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_cq_open", ret);
+		goto err2;
+	}
+
+	memset(&av_attr, 0, sizeof(av_attr));
+	av_attr.type = fi->domain_attr->av_type ?
+			fi->domain_attr->av_type : FI_AV_TABLE;
+	av_attr.count = 2;
+	av_attr.name = NULL;
+
+	/* Open address vector (AV) for mapping address */
+	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_av_open", ret);
+		 goto err3;
+	 }
+
+	return 0;
+
+err3:
+	fi_close(&rcq->fid);
+err2:
+	fi_close(&scq->fid);
+err1:
+	return ret;
+}
+
+static int bind_ep_res(void)
+{
+	int ret;
+
+	/* Bind Send CQ with endpoint to collect send completions */
+	ret = fi_ep_bind(ep, &scq->fid, FI_SEND|FI_WRITE);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	/* Bind Recv CQ with endpoint to collect recv completions */
+	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	/* Bind AV with the endpoint to map addresses */
+	ret = fi_ep_bind(ep, &av->fid, 0);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	ret = fi_enable(ep);
+	if (ret) {
+		FT_PRINTERR("fi_enable", ret);
+		return ret;
+	 }
+
+	return ret;
+}
+
+static int init_fabric(void)
+{
+	int ret;
+	uint64_t flags = 0;
+
+	/* Get fabric info */
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, flags, hints, &fi);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		return ret;
+	}
+
+	/* Open fabric */
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_fabric", ret);
+		goto err1;
+	}
+
+	/* Open domain */
+	ret = fi_domain(fab, fi, &dom, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_domain", ret);
+		goto err2;
+	}
+
+	/* Open endpoint */
+	ret = fi_endpoint(dom, fi, &ep, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_endpoint", ret);
+		goto err3;
+	}
+
+	/* Allocate endpoint resources */
+	ret = alloc_ep_res();
+	if (ret)
+		goto err4;
+
+	/* Bind EQs and AVs with endpoint */
+	ret = bind_ep_res();
+	if (ret)
+		goto err5;
+
+	return 0;
+
+err5:
+	free_ep_res();
+err4:
+	fi_close(&ep->fid);
+err3:
+	fi_close(&dom->fid);
+err2:
+	fi_close(&fab->fid);
+err1:
+	return ret;
+}
+
+static int init_av(void)
+{
+	void *addr;
+	size_t addrlen = 0;
+	int ret;
+
+	fi_getname(&ep->fid, NULL, &addrlen);
+	addr = malloc(addrlen);
+	assert(addr);
+	ret = fi_getname(&ep->fid, addr, &addrlen);
+	if (ret != 0) {
+		FT_PRINTERR("fi_getname", ret);
+		return ret;
+	}
+
+	addrs = malloc(numprocs * addrlen);
+	assert(addrs);
+
+	FT_Allgather(addr, addrlen, addrs);
+
+	fi_addrs = malloc(numprocs * sizeof(fi_addr_t));
+	assert(fi_addrs);
+
+	/* Insert address to the AV and get the fabric address back */
+	ret = fi_av_insert(av, addrs, numprocs, fi_addrs, 0, &fi_ctx_av);
+	if (ret != numprocs) {
+		FT_PRINTERR("fi_av_insert", ret);
+		return ret;
+	}
+
+	free(addr);
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, peer;
+	int size, align_size;
+	char *s_buf, *r_buf;
+	uint64_t t_start = 0, t_end = 0, t = 0;
+	int op, ret;
+	buf_desc_t lbuf_desc;
+	ssize_t fi_rc;
+
+	FT_Init(&argc, &argv);
+	FT_Rank(&myid);
+	FT_Job_size(&numprocs);
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return -1;
+
+	while ((op = getopt(argc, argv, "h" INFO_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
+			print_usage();
+			return EXIT_FAILURE;
+		}
+	}
+
+	hints->ep_attr->type	= FI_EP_RDM;
+	hints->caps		= FI_MSG | FI_DIRECTED_RECV | FI_RMA;
+	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;
+	hints->domain_attr->mr_mode = FI_MR_BASIC;
+
+	if (numprocs != 2) {
+		if (myid == 0) {
+			fprintf(stderr, "This test requires exactly two processes\n");
+		}
+		FT_Finalize();
+		return -1;
+	}
+
+	/* Fabric initialization */
+	ret = init_fabric();
+	if (ret) {
+		fprintf(stderr, "Problem in fabric initialization\n");
+		return ret;
+	}
+
+	ret = init_av();
+	if (ret) {
+		fprintf(stderr, "Problem in AV initialization\n");
+		return ret;
+	}
+
+	/* Data initialization */
+	align_size = getpagesize();
+	assert(align_size <= MAX_ALIGNMENT);
+
+	s_buf = (char *) (((unsigned long) s_buf_original + (align_size - 1)) /
+				align_size * align_size);
+	r_buf = (char *) (((unsigned long) r_buf_original + (align_size - 1)) /
+				align_size * align_size);
+
+	ret = fi_mr_reg(dom, r_buf, MYBUFSIZE, FI_REMOTE_WRITE, 0, 0, 0, &r_mr, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_mr_reg", ret);
+		return -1;
+	}
+
+	lbuf_desc.addr = (uint64_t)r_buf;
+	lbuf_desc.key = fi_mr_key(r_mr);
+
+	rbuf_descs = (buf_desc_t *)malloc(numprocs * sizeof(buf_desc_t));
+
+	/* Distribute memory keys */
+	FT_Allgather(&lbuf_desc, sizeof(lbuf_desc), rbuf_descs);
+
+	ret = fi_mr_reg(dom, s_buf, MYBUFSIZE, FI_WRITE, 0, 0, 0, &l_mr, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_mr_reg", ret);
+		return -1;
+	}
+
+	if (myid == 0) {
+		fprintf(stdout, HEADER);
+		fprintf(stdout, "%-*s%*s\n", 10, "# Size", FIELD_WIDTH,
+				"Bandwidth (MB/s)");
+		fflush(stdout);
+	}
+
+	/* Bandwidth test */
+	for (size = 1; size <= MAX_MSG_SIZE; size *= 2) {
+		/* touch the data */
+		for (i = 0; i < size; i++) {
+			s_buf[i] = 'a';
+			r_buf[i] = 'b';
+		}
+
+		if (size > large_message_size) {
+			loop = loop_large;
+			skip = skip_large;
+			window_size = window_size_large;
+		}
+
+		FT_Barrier();
+
+		if (myid == 0) {
+			peer = 1;
+
+			for (i = 0; i < loop + skip; i++) {
+				if (i == skip) {
+					t_start = get_time_usec();
+				}
+
+				for (j = 0; j < window_size; j++) {
+					fi_rc = fi_write(ep, s_buf, size, l_mr,
+							fi_addrs[peer],
+							rbuf_descs[peer].addr,
+							rbuf_descs[peer].key,
+							(void *)(intptr_t)j);
+					if (fi_rc) {
+						FT_PRINTERR("fi_write", fi_rc);
+						return fi_rc;
+					}
+				}
+
+				wait_for_data_completion(scq, window_size);
+			}
+
+			fi_rc = fi_send(ep, s_buf, 4, NULL,
+					fi_addrs[peer],
+					NULL);
+			assert(!fi_rc);
+			wait_for_data_completion(scq, 1);
+
+			fi_rc = fi_recv(ep, s_buf, 4, NULL,
+					fi_addrs[peer],
+					NULL);
+			assert(!fi_rc);
+			wait_for_data_completion(rcq, 1);
+
+			t_end = get_time_usec();
+			t = t_end - t_start;
+		} else if (myid == 1) {
+			peer = 0;
+
+			fi_rc = fi_recv(ep, s_buf, 4, NULL,
+					fi_addrs[peer],
+					NULL);
+			assert(!fi_rc);
+			wait_for_data_completion(rcq, 1);
+
+			fi_rc = fi_send(ep, s_buf, 4, NULL,
+					fi_addrs[peer],
+					NULL);
+			assert(!fi_rc);
+			wait_for_data_completion(scq, 1);
+		}
+
+		if (myid == 0) {
+			double tmp = size / 1e6 * loop * window_size;
+
+			fprintf(stdout, "%-*d%*.*f\n", 10, size, FIELD_WIDTH,
+					FLOAT_PRECISION, tmp / (t / 1e6));
+			fflush(stdout);
+		}
+	}
+
+	FT_Barrier();
+
+	fi_close(&l_mr->fid);
+	fi_close(&r_mr->fid);
+
+	free_ep_res();
+
+	fi_close(&ep->fid);
+	fi_close(&dom->fid);
+	fi_close(&fab->fid);
+
+	fi_freeinfo(hints);
+	fi_freeinfo(fi);
+
+	FT_Barrier();
+	FT_Finalize();
+	return 0;
+}
+
+/* vi:set sw=8 sts=8 */
+

--- a/ported/omb/rdm_latency.c
+++ b/ported/omb/rdm_latency.c
@@ -1,0 +1,422 @@
+/*
+ * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
+ * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <sys/time.h>
+#include <string.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_rma.h>
+
+#include "ft_utils.h"
+#include "shared.h"
+
+#define MAX_ALIGNMENT 65536
+#define MAX_MSG_SIZE (1<<22)
+#define MYBUFSIZE (MAX_MSG_SIZE + MAX_ALIGNMENT)
+
+#define TEST_DESC "Libfabric Latency Test"
+#define HEADER "# " TEST_DESC " \n"
+#ifndef FIELD_WIDTH
+#   define FIELD_WIDTH 20
+#endif
+#ifndef FLOAT_PRECISION
+#   define FLOAT_PRECISION 2
+#endif
+
+int skip = 1000;
+int loop = 10000;
+int skip_large = 10;
+int loop_large = 100;
+int large_message_size = 8192;
+
+char s_buf_original[MYBUFSIZE];
+char r_buf_original[MYBUFSIZE];
+
+static int rx_depth = 512;
+
+struct fi_info *fi, *hints;
+struct fid_fabric *fab;
+struct fid_domain *dom;
+struct fid_ep *ep;
+struct fid_av *av;
+struct fid_cq *rcq, *scq;
+struct fid_mr *mr;
+struct fi_context fi_ctx_send;
+struct fi_context fi_ctx_recv;
+struct fi_context fi_ctx_av;
+
+void *addrs;
+fi_addr_t *fi_addrs;
+
+int myid, numprocs;
+
+void print_usage(void)
+{
+	if (!myid)
+		ft_basic_usage(TEST_DESC);
+}
+
+static void free_ep_res(void)
+{
+	fi_close(&av->fid);
+	fi_close(&rcq->fid);
+	fi_close(&scq->fid);
+}
+
+static int alloc_ep_res(void)
+{
+	struct fi_cq_attr cq_attr;
+	struct fi_av_attr av_attr;
+	int ret;
+
+	memset(&cq_attr, 0, sizeof(cq_attr));
+	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
+	cq_attr.wait_obj = FI_WAIT_NONE;
+	cq_attr.size = rx_depth;
+
+	/* Open completion queue for send completions */
+	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_cq_open", ret);
+		goto err1;
+	}
+
+	/* Open completion queue for recv completions */
+	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_cq_open", ret);
+		goto err2;
+	}
+
+	memset(&av_attr, 0, sizeof(av_attr));
+	av_attr.type = fi->domain_attr->av_type ?
+			fi->domain_attr->av_type : FI_AV_TABLE;
+	av_attr.count = 2;
+	av_attr.name = NULL;
+
+	/* Open address vector (AV) for mapping address */
+	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_av_open", ret);
+		 goto err3;
+	 }
+
+	return 0;
+
+err3:
+	fi_close(&rcq->fid);
+err2:
+	fi_close(&scq->fid);
+err1:
+	return ret;
+}
+
+static int bind_ep_res(void)
+{
+	int ret;
+
+	/* Bind Send CQ with endpoint to collect send completions */
+	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	/* Bind Recv CQ with endpoint to collect recv completions */
+	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	/* Bind AV with the endpoint to map addresses */
+	ret = fi_ep_bind(ep, &av->fid, 0);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	ret = fi_enable(ep);
+	if (ret) {
+		FT_PRINTERR("fi_enable", ret);
+		return ret;
+	 }
+
+	return ret;
+}
+
+static int init_fabric(void)
+{
+	int ret;
+	uint64_t flags = 0;
+
+	/* Get fabric info */
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, flags, hints, &fi);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		return ret;
+	}
+
+	/* Open fabric */
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_fabric", ret);
+		goto err1;
+	}
+
+	/* Open domain */
+	ret = fi_domain(fab, fi, &dom, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_domain", ret);
+		goto err2;
+	}
+
+	/* Open endpoint */
+	ret = fi_endpoint(dom, fi, &ep, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_endpoint", ret);
+		goto err3;
+	}
+
+	/* Allocate endpoint resources */
+	ret = alloc_ep_res();
+	if (ret)
+		goto err4;
+
+	/* Bind EQs and AVs with endpoint */
+	ret = bind_ep_res();
+	if (ret)
+		goto err5;
+
+	return 0;
+
+err5:
+	free_ep_res();
+err4:
+	fi_close(&ep->fid);
+err3:
+	fi_close(&dom->fid);
+err2:
+	fi_close(&fab->fid);
+err1:
+	return ret;
+}
+
+static int init_av(void)
+{
+	void *addr;
+	size_t addrlen = 0;
+	int ret;
+
+	fi_getname(&ep->fid, NULL, &addrlen);
+	addr = malloc(addrlen);
+	assert(addr);
+	ret = fi_getname(&ep->fid, addr, &addrlen);
+	if (ret != 0) {
+		FT_PRINTERR("fi_getname", ret);
+		return ret;
+	}
+
+	addrs = malloc(numprocs * addrlen);
+	assert(addrs);
+
+	FT_Allgather(addr, addrlen, addrs);
+
+	fi_addrs = malloc(numprocs * sizeof(fi_addr_t));
+	assert(fi_addrs);
+
+	/* Insert address to the AV and get the fabric address back */
+	ret = fi_av_insert(av, addrs, numprocs, fi_addrs, 0, &fi_ctx_av);
+	if (ret != numprocs) {
+		FT_PRINTERR("fi_av_insert", ret);
+		return ret;
+	}
+
+	free(addr);
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int i, peer;
+	int size, align_size;
+	char *s_buf, *r_buf;
+	uint64_t t_start = 0, t_end = 0;
+	int op, ret;
+	ssize_t fi_rc;
+
+	FT_Init(&argc, &argv);
+	FT_Rank(&myid);
+	FT_Job_size(&numprocs);
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return -1;
+
+	while ((op = getopt(argc, argv, "h" INFO_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
+			print_usage();
+			return EXIT_FAILURE;
+		}
+	}
+
+	hints->ep_attr->type	= FI_EP_RDM;
+	hints->caps		= FI_MSG | FI_DIRECTED_RECV;
+	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;
+
+	if (numprocs != 2) {
+		if (myid == 0) {
+			fprintf(stderr, "This test requires exactly two processes\n");
+		}
+		FT_Finalize();
+		return -1;
+	}
+
+	/* Fabric initialization */
+	ret = init_fabric();
+	if (ret) {
+		fprintf(stderr, "Problem in fabric initialization\n");
+		return ret;
+	}
+
+	ret = init_av();
+	if (ret) {
+		fprintf(stderr, "Problem in AV initialization\n");
+		return ret;
+	}
+
+	/* Data initialization */
+	align_size = getpagesize();
+	assert(align_size <= MAX_ALIGNMENT);
+
+	s_buf = (char *) (((unsigned long) s_buf_original + (align_size - 1)) /
+				align_size * align_size);
+
+	r_buf = (char *) (((unsigned long) r_buf_original + (align_size - 1)) /
+				align_size * align_size);
+
+	if (myid == 0) {
+		fprintf(stdout, HEADER);
+		fprintf(stdout, "%-*s%*s\n", 10, "# Size", FIELD_WIDTH, "Latency (us)");
+		fflush(stdout);
+	}
+
+	for (size = 0; size <= MAX_MSG_SIZE; size = (size ? size * 2 : 1)) {
+		for (i = 0; i < size; i++) {
+			s_buf[i] = 'a';
+			r_buf[i] = 'b';
+		}
+
+		if (size > large_message_size) {
+			loop = loop_large;
+			skip = skip_large;
+		}
+
+		FT_Barrier();
+
+		if (myid == 0) {
+			peer = 1;
+			for (i = 0; i < loop + skip; i++) {
+				if (i == skip)
+					t_start = get_time_usec();
+
+				fi_rc = fi_send(ep, s_buf, size, NULL,
+						fi_addrs[peer], NULL);
+				assert(!fi_rc);
+				wait_for_data_completion(scq, 1);
+
+				fi_rc = fi_recv(ep, r_buf, size, NULL,
+						fi_addrs[peer], NULL);
+				assert(!fi_rc);
+				wait_for_data_completion(rcq, 1);
+			}
+
+			t_end = get_time_usec();
+		} else if (myid == 1) {
+			peer = 0;
+			for (i = 0; i < loop + skip; i++) {
+				fi_rc = fi_recv(ep, r_buf, size, NULL,
+						fi_addrs[peer], NULL);
+				assert(!fi_rc);
+				wait_for_data_completion(rcq, 1);
+
+				fi_rc = fi_send(ep, s_buf, size, NULL,
+						fi_addrs[peer], NULL);
+				assert(!fi_rc);
+				wait_for_data_completion(scq, 1);
+			}
+		}
+
+		if (myid == 0) {
+			double latency = (t_end - t_start) / (2.0 * loop);
+
+			fprintf(stdout, "%-*d%*.*f\n", 10, size, FIELD_WIDTH,
+					FLOAT_PRECISION, latency);
+			fflush(stdout);
+		}
+	}
+
+	FT_Barrier();
+
+	free_ep_res();
+
+	fi_close(&ep->fid);
+	fi_close(&dom->fid);
+	fi_close(&fab->fid);
+
+	fi_freeinfo(hints);
+	fi_freeinfo(fi);
+
+	FT_Barrier();
+	FT_Finalize();
+	return 0;
+}
+
+/* vi:set sw=8 sts=8 */
+

--- a/ported/omb/rdm_mbw_mr.c
+++ b/ported/omb/rdm_mbw_mr.c
@@ -1,0 +1,627 @@
+/*
+ * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
+ * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <sys/time.h>
+#include <string.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_rma.h>
+
+#include "ft_utils.h"
+#include "shared.h"
+
+#define DEFAULT_WINDOW       (64)
+
+#define ITERS_SMALL          (100)
+#define WARMUP_ITERS_SMALL   (10)
+#define ITERS_LARGE          (20)
+#define WARMUP_ITERS_LARGE   (2)
+#define LARGE_THRESHOLD      (8192)
+
+#define WINDOW_SIZES {8, 16, 32, 64, 128}
+#define WINDOW_SIZES_COUNT   (5)
+
+#define MAX_MSG_SIZE         (1<<22)
+#define MAX_ALIGNMENT        (65536)
+#define MY_BUF_SIZE (MAX_MSG_SIZE + MAX_ALIGNMENT)
+
+#define TEST_DESC "Libfabric Multiple Bandwidth and Message Rate Test"
+#define HEADER "# " TEST_DESC " \n"
+#ifndef FIELD_WIDTH
+#   define FIELD_WIDTH 20
+#endif
+#ifndef FLOAT_PRECISION
+#   define FLOAT_PRECISION 2
+#endif
+
+int loop = 100;
+int window_size = 64;
+int skip = 10;
+
+char s_buf_original[MY_BUF_SIZE];
+char r_buf_original[MY_BUF_SIZE];
+
+static int rx_depth = 512;
+
+struct fi_info *fi, *hints;
+struct fid_fabric *fab;
+struct fid_domain *dom;
+struct fid_ep *ep;
+struct fid_av *av;
+struct fid_cq *rcq, *scq;
+struct fid_mr *mr;
+struct fi_context fi_ctx_send;
+struct fi_context fi_ctx_recv;
+struct fi_context fi_ctx_av;
+
+void *addrs;
+fi_addr_t *fi_addrs;
+
+int myid, numprocs;
+
+void print_usage(void)
+{
+	if (!myid) {
+		ft_basic_usage(TEST_DESC);
+		FT_PRINT_OPTS_USAGE("-r <0,1> ", "Print uni-directional message rate (default 1)");
+		FT_PRINT_OPTS_USAGE("-p <pairs>", "Number of pairs involved (default np / 2)");
+		FT_PRINT_OPTS_USAGE("-w <window>", "Number of messages sent before "
+				    "acknowldgement (64, 10) [cannot be used with -v]");
+		FT_PRINT_OPTS_USAGE("-v", "Vary the window size (default no) "
+				    "[cannot be used with -w]");
+		FT_PRINT_OPTS_USAGE("-h", "Print this help");
+	}
+}
+
+static void free_ep_res(void)
+{
+	fi_close(&av->fid);
+	fi_close(&rcq->fid);
+	fi_close(&scq->fid);
+}
+
+static int alloc_ep_res(void)
+{
+	struct fi_cq_attr cq_attr;
+	struct fi_av_attr av_attr;
+	int ret;
+
+	memset(&cq_attr, 0, sizeof(cq_attr));
+	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
+	cq_attr.wait_obj = FI_WAIT_NONE;
+	cq_attr.size = rx_depth;
+
+	/* Open completion queue for send completions */
+	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_cq_open", ret);
+		goto err1;
+	}
+
+	/* Open completion queue for recv completions */
+	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_cq_open", ret);
+		goto err2;
+	}
+
+	memset(&av_attr, 0, sizeof(av_attr));
+	av_attr.type = fi->domain_attr->av_type ?
+			fi->domain_attr->av_type : FI_AV_TABLE;
+	av_attr.count = numprocs;
+	av_attr.name = NULL;
+
+	/* Open address vector (AV) for mapping address */
+	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_av_open", ret);
+		 goto err3;
+	 }
+
+	return 0;
+
+err3:
+	fi_close(&rcq->fid);
+err2:
+	fi_close(&scq->fid);
+err1:
+	return ret;
+}
+
+static int bind_ep_res(void)
+{
+	int ret;
+
+	/* Bind Send CQ with endpoint to collect send completions */
+	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	/* Bind Recv CQ with endpoint to collect recv completions */
+	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	/* Bind AV with the endpoint to map addresses */
+	ret = fi_ep_bind(ep, &av->fid, 0);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	ret = fi_enable(ep);
+	if (ret) {
+		FT_PRINTERR("fi_enable", ret);
+		return ret;
+	 }
+
+	return ret;
+}
+
+static int init_fabric(void)
+{
+	int ret;
+	uint64_t flags = 0;
+
+	/* Get fabric info */
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, flags, hints, &fi);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		return ret;
+	}
+
+	/* Open fabric */
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_fabric", ret);
+		goto err1;
+	}
+
+	/* Open domain */
+	ret = fi_domain(fab, fi, &dom, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_domain", ret);
+		goto err2;
+	}
+
+	/* Open endpoint */
+	ret = fi_endpoint(dom, fi, &ep, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_endpoint", ret);
+		goto err3;
+	}
+
+	/* Allocate endpoint resources */
+	ret = alloc_ep_res();
+	if (ret)
+		goto err4;
+
+	/* Bind EQs and AVs with endpoint */
+	ret = bind_ep_res();
+	if (ret)
+		goto err5;
+
+	return 0;
+
+err5:
+	free_ep_res();
+err4:
+	fi_close(&ep->fid);
+err3:
+	fi_close(&dom->fid);
+err2:
+	fi_close(&fab->fid);
+err1:
+	return ret;
+}
+
+static int init_av(void)
+{
+	void *addr;
+	size_t addrlen = 0;
+	int ret;
+
+	fi_getname(&ep->fid, NULL, &addrlen);
+	addr = malloc(addrlen);
+	assert(addr);
+	ret = fi_getname(&ep->fid, addr, &addrlen);
+	if (ret != 0) {
+		FT_PRINTERR("fi_getname", ret);
+		return ret;
+	}
+
+	addrs = malloc(numprocs * addrlen);
+	assert(addrs);
+
+	FT_Allgather(addr, addrlen, addrs);
+
+	fi_addrs = malloc(numprocs * sizeof(fi_addr_t));
+	assert(fi_addrs);
+
+	/* Insert address to the AV and get the fabric address back */
+	ret = fi_av_insert(av, addrs, numprocs, fi_addrs, 0, &fi_ctx_av);
+	if (ret != numprocs) {
+		FT_PRINTERR("fi_av_insert", ret);
+		return ret;
+	}
+
+	free(addr);
+
+	return 0;
+}
+
+double calc_bw(int rank, int size, int num_pairs, int window_size, char *s_buf,
+		char *r_buf)
+{
+	uint64_t t_start = 0, t_end = 0, t = 0, maxtime = 0, *ts;
+	double bw = 0;
+	int i, j, target;
+	int loop, skip;
+	int mult = (DEFAULT_WINDOW / window_size) > 0 ? (DEFAULT_WINDOW /
+			window_size) : 1;
+	int fi_rc;
+
+	for (i = 0; i < size; i++) {
+		s_buf[i] = 'a';
+		r_buf[i] = 'b';
+	}
+
+	if (size > LARGE_THRESHOLD) {
+		loop = ITERS_LARGE * mult;
+		skip = WARMUP_ITERS_LARGE * mult;
+	} else {
+		loop = ITERS_SMALL * mult;
+		skip = WARMUP_ITERS_SMALL * mult;
+	}
+
+	FT_Barrier();
+
+	if (rank < num_pairs) {
+		target = rank + num_pairs;
+
+		for (i = 0; i < loop + skip; i++) {
+			if (i == skip) {
+				FT_Barrier();
+				t_start = get_time_usec();
+			}
+
+			for (j = 0; j < window_size; j++) {
+				fi_rc = fi_send(ep, s_buf, size, NULL,
+						fi_addrs[target],
+						NULL);
+				assert(!fi_rc);
+			}
+
+			wait_for_data_completion(scq, window_size);
+			fi_rc = fi_recv(ep, r_buf, 4, NULL,
+					fi_addrs[target], NULL);
+			assert(!fi_rc);
+			wait_for_data_completion(rcq, 1);
+		}
+
+		t_end = get_time_usec();
+		t = t_end - t_start;
+	} else if (rank < num_pairs * 2) {
+		target = rank - num_pairs;
+
+		for (i = 0; i < loop + skip; i++) {
+			if (i == skip) {
+				FT_Barrier();
+			}
+
+			for (j = 0; j < window_size; j++) {
+				fi_rc = fi_recv(ep, r_buf, size, NULL,
+						fi_addrs[target], NULL);
+				assert(!fi_rc);
+			}
+
+			wait_for_data_completion(rcq, window_size);
+			fi_rc = fi_send(ep, s_buf, 4, NULL,
+					fi_addrs[target], NULL);
+			assert(!fi_rc);
+			wait_for_data_completion(scq, 1);
+		}
+	} else {
+		FT_Barrier();
+	}
+
+	ts = malloc(sizeof(t) * numprocs);
+	assert(ts);
+	FT_Allgather(&t, sizeof(t), ts);
+	if (!myid) {
+		for (i = 0; i < numprocs; i++) {
+			if (ts[i] > maxtime) {
+				maxtime = ts[i];
+			}
+		}
+	}
+	free(ts);
+
+	if (rank == 0) {
+		double tmp = num_pairs * size / 1e6;
+
+		tmp = tmp * loop * window_size;
+		bw = tmp / (maxtime / 1e6);
+
+		return bw;
+	}
+
+	return 0;
+}
+
+
+int main(int argc, char *argv[])
+{
+	int op, ret;
+
+	char *s_buf, *r_buf;
+	int align_size;
+	int pairs, print_rate;
+	int window_varied;
+	int c;
+	int curr_size;
+
+	FT_Init(&argc, &argv);
+	FT_Rank(&myid);
+	FT_Job_size(&numprocs);
+
+	/* default values */
+	pairs            = numprocs / 2;
+	window_size      = DEFAULT_WINDOW;
+	window_varied    = 0;
+	print_rate       = 1;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return -1;
+
+	while ((op = getopt(argc, argv, "hp:w:vr:" INFO_OPTS)) != -1) {
+		switch (op) {
+		case 'p':
+			pairs = atoi(optarg);
+			if (pairs > (numprocs / 2)) {
+				print_usage();
+				return EXIT_FAILURE;
+			}
+			break;
+		case 'w':
+			window_size = atoi(optarg);
+			break;
+		case 'v':
+			window_varied = 1;
+			break;
+		case 'r':
+			print_rate = atoi(optarg);
+			if (0 != print_rate && 1 != print_rate) {
+				print_usage();
+				return EXIT_FAILURE;
+			}
+			break;
+		default:
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
+			print_usage();
+			return EXIT_FAILURE;
+		}
+	}
+
+	hints->ep_attr->type	= FI_EP_RDM;
+	hints->caps		= FI_MSG | FI_DIRECTED_RECV;
+	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;
+
+	if (numprocs < 2) {
+		if (!myid) {
+			fprintf(stderr, "This test requires at least two processes\n");
+		}
+		FT_Finalize();
+		return -1;
+	}
+
+	/* Fabric initialization */
+	ret = init_fabric();
+	if (ret) {
+		fprintf(stderr, "Problem in fabric initialization\n");
+		return ret;
+	}
+
+	ret = init_av();
+	if (ret) {
+		fprintf(stderr, "Problem in AV initialization\n");
+		return ret;
+	}
+
+	/* Data initialization */
+	align_size = getpagesize();
+	assert(align_size <= MAX_ALIGNMENT);
+
+	s_buf = (char *) (((unsigned long) s_buf_original + (align_size - 1)) /
+				align_size * align_size);
+	r_buf = (char *) (((unsigned long) r_buf_original + (align_size - 1)) /
+				align_size * align_size);
+
+	if (!myid) {
+		fprintf(stdout, HEADER);
+		if (window_varied) {
+			fprintf(stdout, "# [ pairs: %d ] [ window size: varied ]\n", pairs);
+			fprintf(stdout, "\n# Uni-directional Bandwidth (MB/sec)\n");
+		} else {
+			fprintf(stdout, "# [ pairs: %d ] [ window size: %d ]\n", pairs,
+					window_size);
+			if (print_rate) {
+				fprintf(stdout, "%-*s%*s%*s\n", 10, "# Size", FIELD_WIDTH,
+						"MB/s", FIELD_WIDTH, "Messages/s");
+			} else {
+				fprintf(stdout, "%-*s%*s\n", 10, "# Size", FIELD_WIDTH, "MB/s");
+			}
+		}
+		fflush(stdout);
+	}
+
+	if (window_varied) {
+		int window_array[] = WINDOW_SIZES;
+		double **bandwidth_results;
+		int log_val = 1, tmp_message_size = MAX_MSG_SIZE;
+		int i, j;
+
+		for (i = 0; i < WINDOW_SIZES_COUNT; i++) {
+			if (window_array[i] > window_size) {
+				window_size = window_array[i];
+			}
+		}
+
+		while (tmp_message_size >>= 1) {
+			log_val++;
+		}
+
+		bandwidth_results = (double **)malloc(sizeof(double *) * log_val);
+
+		for (i = 0; i < log_val; i++) {
+			bandwidth_results[i] = (double *)malloc(sizeof(double) *
+					WINDOW_SIZES_COUNT);
+		}
+
+		if (!myid) {
+			fprintf(stdout, "#      ");
+
+			for (i = 0; i < WINDOW_SIZES_COUNT; i++) {
+				fprintf(stdout, "  %10d", window_array[i]);
+			}
+
+			fprintf(stdout, "\n");
+			fflush(stdout);
+		}
+
+		for (j = 0, curr_size = 1; curr_size <= MAX_MSG_SIZE; curr_size *= 2, j++) {
+			if (!myid) {
+				fprintf(stdout, "%-7d", curr_size);
+			}
+
+			for (i = 0; i < WINDOW_SIZES_COUNT; i++) {
+				bandwidth_results[j][i] = calc_bw(myid, curr_size, pairs,
+						window_array[i], s_buf, r_buf);
+
+				if (!myid) {
+					fprintf(stdout, "  %10.*f", FLOAT_PRECISION,
+							bandwidth_results[j][i]);
+				}
+			}
+
+			if (!myid) {
+				fprintf(stdout, "\n");
+				fflush(stdout);
+			}
+		}
+
+		if (!myid && print_rate) {
+			fprintf(stdout, "\n# Message Rate Profile\n");
+			fprintf(stdout, "#      ");
+
+			for (i = 0; i < WINDOW_SIZES_COUNT; i++) {
+				fprintf(stdout, "  %10d", window_array[i]);
+			}
+
+			fprintf(stdout, "\n");
+			fflush(stdout);
+
+			for (c = 0, curr_size = 1; curr_size <= MAX_MSG_SIZE; curr_size *= 2) {
+				fprintf(stdout, "%-7d", curr_size);
+
+				for (i = 0; i < WINDOW_SIZES_COUNT; i++) {
+					double rate = 1e6 * bandwidth_results[c][i] / curr_size;
+
+					fprintf(stdout, "  %10.2f", rate);
+				}
+
+				fprintf(stdout, "\n");
+				fflush(stdout);
+				c++;
+			}
+		}
+	} else {
+		/* Just one window size */
+		for (curr_size = 1; curr_size <= MAX_MSG_SIZE; curr_size *= 2) {
+			double bw, rate;
+
+			bw = calc_bw(myid, curr_size, pairs, window_size, s_buf, r_buf);
+
+			if (!myid) {
+				rate = 1e6 * bw / curr_size;
+
+				if (print_rate) {
+					fprintf(stdout, "%-*d%*.*f%*.*f\n", 10, curr_size,
+							FIELD_WIDTH, FLOAT_PRECISION, bw, FIELD_WIDTH,
+							FLOAT_PRECISION, rate);
+					fflush(stdout);
+				} else {
+					fprintf(stdout, "%-*d%*.*f\n", 10, curr_size, FIELD_WIDTH,
+							FLOAT_PRECISION, bw);
+					fflush(stdout);
+				}
+			}
+		}
+	}
+
+	FT_Barrier();
+
+	free_ep_res();
+
+	fi_close(&ep->fid);
+	fi_close(&dom->fid);
+	fi_close(&fab->fid);
+
+	fi_freeinfo(hints);
+	fi_freeinfo(fi);
+
+	FT_Barrier();
+	FT_Finalize();
+	return 0;
+}
+
+/* vi:set sw=8 sts=8 */
+


### PR DESCRIPTION

Add rdm_bw, rdm_latency and rdm_mbw_mr benchmarks.  Add --with-pmi configure option to enable these PMI tests.

    Signed-off-by: Zach Tiffany <ztiffany@cray.com>

@shefty @jithinjosepkl