### PR TITLE
Don't allow fi_ud_pingpong to make sends larger than the buffer_size

### DIFF
--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -519,7 +519,11 @@ static int run(void)
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
+
 			opts.transfer_size = test_size[i].size;
+			if (opts.transfer_size > buffer_size)
+				continue;
+
 			init_test(&opts, test_name, sizeof(test_name));
 			ret = run_test();
 			if (ret)
@@ -583,6 +587,8 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->ep_attr->type = FI_EP_DGRAM;
+	if (opts.user_options & FT_OPT_SIZE)
+		hints->ep_attr->max_msg_size = opts.transfer_size;
 	hints->caps = FI_MSG;
 	hints->mode = FI_LOCAL_MR | FI_MSG_PREFIX;
 	hints->addr_format = FI_SOCKADDR;


### PR DESCRIPTION
The size of the buffer is equal to the lesser of `opts.transfer_size` and `max_msg_size` (MTU). The current code allows the buffer to be limited to the `max_msg_size` if it is smaller than `opts.transfer_size` but will still attempt to send a message of size `opts.transfer_size`. 

This fix skips over test cases where the transfer size is larger than the buffer size (MTU). I'm not sure how to define the error case behavior. It makes sense to skip the test cases when doing the built in set of test cases, but should an error message be given when a transfer size specified with `-S` is larger than the MTU?

@shefty @goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>