### PR TITLE
Removed fi_info's reference from runfabtests and man page

### DIFF
--- a/man/fabtests.7.md
+++ b/man/fabtests.7.md
@@ -26,7 +26,6 @@ These tests are a mix of very basic tests and major features of libfabric. All o
 	fi_cq_data: A client-server example that tranfers CQ data
 	fi_dgram: A basic DGRAM client-server example
 	fi_dgram_waitset: A basic DGRAM client-server example that uses waitset
-	fi_info: An example (non client-server) that prints fabric interface information obtained by fi_getinfo call
 	fi_msg: A basic MSG client-server example
 	fi_msg_pingpong: A ping-pong client-server example using MSG endpoints
 	fi_msg_rma: A ping pong client-server example using RMA operations between MSG endpoints

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -80,7 +80,6 @@ unit_tests=(
 	"dom_test -n 2"
 	"eq_test"
 	"size_left_test"
-	"info"
 )
 
 function errcho() {


### PR DESCRIPTION
Removed the reference of fi_info test from runfabtests and man page as a followup of #282 

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>