### PR TITLE
Ensure that the information given to fi_av_insert has a valid port nu…

### DIFF
--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -226,7 +226,8 @@ av_create_addr_sockaddr_in(char *first_address, int index, void *addr)
 	}
 
 	hints.ai_family = AF_INET;
-	ret = getaddrinfo(first_address, NULL, &hints, &ai);
+	/* port doesn't matter, set port to discard port */
+	ret = getaddrinfo(first_address, "discard", &hints, &ai);
 	if (ret != 0) {
 		sprintf(err_buf, "getaddrinfo: %s", gai_strerror(ret));
 		return -1;


### PR DESCRIPTION
…mber.

Since the port number isn't important for the purposes of this test, use the
discard service port.

This was causing the usnic provider to fail `fi_av_test`.

@goodell @shefty @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>