### PR TITLE
Returned error if fi_send fails

### DIFF
--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -135,8 +135,10 @@ static int send_msg(int size)
 	
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr, 
 			&fi_ctx_send);
-	if (ret)
+	if (ret) {
 		FT_PRINTERR("fi_send", ret);
+		return ret;
+	}
 
 	return wait_for_completion(scq, 1);
 }


### PR DESCRIPTION
If fi_send is failed, rdm_atomic was still waiting for completion. Added a return to gracefully exit.

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>