### PR TITLE
ud_pingpong: use the right dest_addr in av_insert

### DIFF
--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -397,14 +397,10 @@ static int client_connect(void)
 	if (ret != 0)
 		return ret;
 
-	ret = ft_getdestaddr(opts.dst_addr, opts.dst_port, hints);
-	if (ret != 0)
-		goto err1;
-
-	ret = fi_av_insert(av, hints->dest_addr, 1, &remote_fi_addr, 0, NULL);
+	ret = fi_av_insert(av, fi->dest_addr, 1, &remote_fi_addr, 0, NULL);
 	if (ret != 1) {
 		FT_PRINTERR("fi_av_insert", ret);
-		goto err2;
+		goto err;
 	}
 
 	// send initial message to server with our local address
@@ -417,18 +413,16 @@ static int client_connect(void)
 
 	ret = send_xfer(addrlen);
 	if (ret != 0)
-		goto err2;
+		goto err;
 
 	// wait for reply to know server is ready
 	ret = recv_xfer(4);
 	if (ret != 0)
-		goto err2;
+		goto err;
 
 	return 0;
 
-err2:
-	free(hints->dest_addr);
-err1:
+err:
 	free_ep_res();
 	fi_close(&av->fid);
 	fi_close(&dom->fid);


### PR DESCRIPTION
Test should use fi->dest_addr, obtained in common_setup
not hints->dest_addr.

Minor cleanup of unused label err1.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>

Extracted from PR #271 