### PR TITLE
ud_pingpong: remove addr_format specification

### DIFF
--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -591,7 +591,6 @@ int main(int argc, char **argv)
 		hints->ep_attr->max_msg_size = opts.transfer_size;
 	hints->caps = FI_MSG;
 	hints->mode = FI_LOCAL_MR | FI_MSG_PREFIX;
-	hints->addr_format = FI_SOCKADDR;
 
 	ret = run();
 


### PR DESCRIPTION
There is no need for this test to specify the address
format. The test doesn't interpret addresses, and not
specifying the address format makes the test more portable.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>