### PR TITLE
use ft_read_addr_opts when possible

### DIFF
--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -327,17 +327,9 @@ static int init_fabric(void)
 	char *node, *service;
 	int ret;
 
-	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
-		if (ret)
-			return ret;
-		node = opts.dst_addr;
-		service = opts.dst_port;
-	} else {
-		node = opts.src_addr;
-		service = opts.src_port;
-		flags = FI_SOURCE;
-	}
+	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
+	if (ret)
+		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -299,17 +299,9 @@ static int init_fabric(void)
 	char *node, *service;
 	int ret;
 
-	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
-		if (ret)
-			return ret;
-		node = opts.dst_addr;
-		service = opts.dst_port;
-	} else {
-		node = opts.src_addr;
-		service = opts.src_port;
-		flags = FI_SOURCE;
-	}
+	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
+	if (ret)
+		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -316,17 +316,9 @@ static int init_fabric(void)
 	char *node, *service;
 	int ret;
 
-	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
-		if (ret)
-			return ret;
-		node = opts.dst_addr;
-		service = opts.dst_port;
-	} else {
-		node = opts.src_addr;
-		service = opts.src_port;
-		flags = FI_SOURCE;
-	}
+	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
+	if (ret)
+		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -354,17 +354,9 @@ static int init_fabric(void)
 	char *node, *service;
 	int ret;
 
-	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
-		if (ret)
-			return ret;
-		node = opts.dst_addr;
-		service = opts.dst_port;
-	} else {
-		node = opts.src_addr;
-		service = opts.src_port;
-		flags = FI_SOURCE;
-	}
+	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
+	if (ret)
+		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -337,17 +337,9 @@ static int common_setup(void)
 	uint64_t flags = 0;
 	char *node, *service;
 
-	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
-		if (ret)
-			return ret;
-		node = opts.dst_addr;
-		service = opts.dst_port;
-	} else {
-		node = opts.src_addr;
-		service = opts.src_port;
-		flags = FI_SOURCE;
-	}
+	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
+	if (ret)
+		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -520,17 +520,9 @@ static int init_fabric(void)
 	char *node, *service;
 	int ret;
 
-	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
-		if (ret)
-			return ret;
-		node = opts.dst_addr;
-		service = opts.dst_port;
-	} else {
-		node = opts.src_addr;
-		service = opts.src_port;
-		flags = FI_SOURCE;
-	}
+	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
+	if (ret)
+		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -429,17 +429,9 @@ static int init_fabric(void)
 	char *node, *service;
 	int ret;
 
-	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
-		if (ret)
-			return ret;
-		node = opts.dst_addr;
-		service = opts.dst_port;
-	} else {
-		node = opts.src_addr;
-		service = opts.src_port;
-		flags = FI_SOURCE;
-	}
+	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
+	if (ret)
+		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -353,17 +353,9 @@ static int init_fabric(void)
 	char *node, *service;
 	int ret;
 
-	if (opts.dst_addr) {
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
-		if (ret)
-			return ret;
-		node = opts.dst_addr;
-		service = opts.dst_port;
-	} else {
-		node = opts.src_addr;
-		service = opts.src_port;
-		flags = FI_SOURCE;
-	}
+	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
+	if (ret)
+		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {


### PR DESCRIPTION
ft_read_addr_opts is a function used by a lot of the fabtests.
These tests were replicating the function and not calling it.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>