### PR TITLE
Update fabtests to support libfabric 1.1

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -107,9 +107,6 @@ struct ft_control {
 extern struct ft_xcontrol ft_rx, ft_tx;
 extern struct ft_control ft;
 
-/* Test must support all available versions */
-#define FT_VERSION	FI_VERSION(1, 0)
-
 enum {
 	FT_MAX_CAPS		= 64,
 	FT_MAX_EP_TYPES		= 8,

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -323,7 +323,7 @@ static int ft_fw_server(void)
 		printf("Starting test %d-%d: ", test_info.test_index,
 			test_info.test_subindex);
 		ft_show_test_info();
-		ret = fi_getinfo(FT_VERSION, ft_strptr(test_info.node),
+		ret = fi_getinfo(FT_FIVERSION, ft_strptr(test_info.node),
 				 ft_strptr(test_info.service), FI_SOURCE,
 				 hints, &info);
 		if (ret) {
@@ -409,7 +409,7 @@ static int ft_fw_client(void)
 		ft_fw_convert_info(hints, &test_info);
 
 		printf("Starting test %d / %d\n", test_info.test_index, series->test_count);
-		ret = fi_getinfo(FT_VERSION, ft_strptr(test_info.node),
+		ret = fi_getinfo(FT_FIVERSION, ft_strptr(test_info.node),
 				 ft_strptr(test_info.service), 0, hints, &info);
 		if (ret) {
 			FT_PRINTERR("fi_getinfo", ret);

--- a/include/shared.h
+++ b/include/shared.h
@@ -45,8 +45,10 @@
 extern "C" {
 #endif
 
-/* all tests should work with 1.0 API */
-#define FT_FIVERSION FI_VERSION(1,0)
+/* all tests should work with 1.0 API or newer */
+#ifndef FT_FIVERSION
+#define FT_FIVERSION FI_VERSION(1,1)
+#endif
 
 #ifdef __APPLE__
 #include "osx/osd.h"

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -514,7 +514,7 @@ int main(int argc, char *argv[])
 	if (rc)
 		return 1;
 	
-	rc = fi_getinfo(FI_VERSION(1, 0), node, service, flags, hints, &info);
+	rc = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &info);
 	if (rc) {
 		FT_PRINTERR("fi_getinfo", rc);
 		return -rc;

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1062,8 +1062,7 @@ int main(int argc, char **argv)
 	hints->addr_format = FI_SOCKADDR;
 
 	hints->ep_attr->type = FI_EP_RDM;
-	ret = fi_getinfo(FI_VERSION(1, 0), src_addr_str, 0, FI_SOURCE, hints,
-				&fi);
+	ret = fi_getinfo(FT_FIVERSION, src_addr_str, 0, FI_SOURCE, hints, &fi);
 	if (ret != 0 && ret != -FI_ENODATA) {
 		printf("fi_getinfo %s\n", fi_strerror(-ret));
 		goto err1;
@@ -1071,8 +1070,7 @@ int main(int argc, char **argv)
 
 	if (ret == -FI_ENODATA) {
 		hints->ep_attr->type = FI_EP_DGRAM;
-		ret = fi_getinfo(FI_VERSION(1, 0), src_addr_str, 0, FI_SOURCE,
-					hints, &fi);
+		ret = fi_getinfo(FT_FIVERSION, src_addr_str, 0, FI_SOURCE, hints, &fi);
 		if (ret != 0) {
 			printf("fi_getinfo %s\n", fi_strerror(-ret));
 			goto err1;

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 	hints->fabric_attr = &fabric_hints;
 	hints->mode = ~0;
 
-	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
 	if (ret != 0) {
 		printf("fi_getinfo %s\n", fi_strerror(-ret));
 		goto err;

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -439,7 +439,7 @@ int main(int argc, char **argv)
 
 	hints->mode = ~0;
 
-	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
 	if (ret != 0) {
 		printf("fi_getinfo %s\n", fi_strerror(-ret));
 		exit(-ret);

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -375,7 +375,7 @@ int main(int argc, char **argv)
 	hints->mode = ~0;
 	hints->ep_attr->type = FI_EP_RDM;
 
-	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
 	if (ret != 0) {
 		printf("fi_getinfo %s\n", fi_strerror(-ret));
 		exit(-ret);


### PR DESCRIPTION
The 1.1 release doesn't change anything used by fabtests.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>