### PR TITLE
Fixed a double-free bug in server setup error handling path

### DIFF
--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -439,7 +439,7 @@ static int server_connect(void)
 
 	ret = common_setup();
 	if (ret != 0)
-		goto err;
+		return ret;
 
 	clock_gettime(CLOCK_REALTIME_COARSE, &a);
 	do {


### PR DESCRIPTION
Function common_setup() frees resources when returning failure. But the
calling function server_connect() tries to double free the resources
upon failure.

Signed-off-by: Xuyang Wang <xuywang@cisco.com>