### PR TITLE
ft_finalize: respect FI_MSG_PREFIX if selected

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -117,8 +117,8 @@ char *cnt_str(char str[FT_STR_LEN], long long cnt);
 int size_to_count(int size);
 
 void init_test(struct cs_opts *opts, char *test_name, size_t test_name_len);
-int ft_finalize(struct fid_ep *tx_ep, struct fid_cq *scq, struct fid_cq *rcq,
-		fi_addr_t addr);
+int ft_finalize(struct fi_info *fi, struct fid_ep *tx_ep, struct fid_cq *scq,
+		struct fid_cq *rcq, fi_addr_t addr);
 
 
 int wait_for_data_completion(struct fid_cq *cq, int num_completions);

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -51,6 +51,7 @@ static void *send_buf;
 static size_t buffer_size;
 
 static struct fi_info *hints;
+static struct fi_info *fi = NULL;
 
 static struct fid_fabric *fab;
 static struct fid_pep *pep;
@@ -315,7 +316,6 @@ static int bind_ep_res(void)
 
 static int server_listen(void)
 {
-	struct fi_info *fi;
 	int ret;
 
 	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.src_port, FI_SOURCE,
@@ -438,7 +438,6 @@ static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *fi;
 	ssize_t rd;
 	int ret;
 
@@ -541,7 +540,7 @@ static int run(void)
 
 	ret = wait_for_completion(scq, max_credits - credits);
 	/* Finalize before closing ep */
-	ft_finalize(ep, scq, rcq, FI_ADDR_UNSPEC);
+	ft_finalize(fi, ep, scq, rcq, FI_ADDR_UNSPEC);
 out:
 	fi_shutdown(ep, 0);
 	free_ep_res();

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -459,7 +459,7 @@ static int run(void)
 	}
 
 	/* Finalize before closing ep */
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -468,7 +468,7 @@ static int run(void)
 
 	wait_for_completion(scq, max_credits - credits);
 	/* Finalize before closing ep */
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -506,7 +506,7 @@ static int run(void)
 
 	wait_for_completion_tagged(scq, max_credits - credits);
 	/* Finalize before closing ep */
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -526,7 +526,7 @@ static int run(void)
 	while (credits < max_credits)
 		poll_all_sends();
 
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
 	ret2 = fi_close(&av->fid);

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -491,7 +491,7 @@ static int run(void)
 
 	run_test();
 	/* TODO: Add a local finalize applicable to shared ctx */
-	//ft_finalize(ep[0], scq, rcq, remote_fi_addr[0]);
+	//ft_finalize(ep[0], scq, rcq, remote_fi_addr[0], 0);
 out:
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -464,7 +464,7 @@ static int run(void)
 			goto out;
 	}
 	/* Finalize before closing ep */
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -464,7 +464,7 @@ static int run(void)
 
 	run_test();
 	/*TODO: Add a local finalize applicable for scalable ep */
-	//ft_finalize(tx_ep[0], scq[0], rcq[0], remote_rx_addr[0]);
+	//ft_finalize(fi, tx_ep[0], scq[0], rcq[0], remote_rx_addr[0]);
 out:
 	free_ep_res();
 	fi_close(&sep->fid);

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -55,6 +55,7 @@ static uint64_t cq_data = 1;
 static enum fi_mr_mode mr_mode;
 
 static struct fi_info *hints;
+static struct fi_info *fi = NULL;
 
 static struct fid_fabric *fab;
 static struct fid_pep *pep;
@@ -384,7 +385,6 @@ static int bind_ep_res(void)
 
 static int server_listen(void)
 {
-	struct fi_info *fi;
 	int ret;
 
 	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.src_port, FI_SOURCE,
@@ -513,7 +513,6 @@ static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *fi;
 	ssize_t rd;
 	int ret;
 
@@ -652,7 +651,7 @@ static int run(void)
 	sync_test();
 	wait_for_data_completion(scq, max_credits - credits);
 	/* Finalize before closing ep */
-	ft_finalize(ep, scq, rcq, FI_ADDR_UNSPEC);
+	ft_finalize(fi, ep, scq, rcq, FI_ADDR_UNSPEC);
 out:
 	fi_shutdown(ep, 0);
 	free_ep_res();

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -705,7 +705,7 @@ static int run(void)
 			goto out;
 	}
 	/* Finalize before closing ep */
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
 	fi_close(&dom->fid);

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -573,7 +573,7 @@ static int run(void)
 
 	ret = run_test();	
 	/* Finalize before closing ep */
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
 

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -551,7 +551,7 @@ static int run(void)
 			goto out;
 	}
 	/* Finalize before closing ep */
-	ft_finalize(ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
 	fi_close(&dom->fid);


### PR DESCRIPTION
Without this ud_pingpong could SEGV at ft_finalize time or report
truncation errors.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>