### PR TITLE
runfabtests.sh: Add prefix version of fi_ud_pingpong to standard suite.

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -72,6 +72,7 @@ standard_tests=(
 	"rdm_rma -o writedata"
 	"rdm_tagged_pingpong"
 	"ud_pingpong"
+	"ud_pingpong -P"
 	"rc_pingpong"
 )
 


### PR DESCRIPTION
Enables testing of prefix mode using jenkins. Providers who do not support prefix mode should still pass.

@goodell @shefty 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>