### PR TITLE
runfabtests.sh: Fix is_excluded function to only match full test names.

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -155,13 +155,14 @@ function compute_duration {
 }
 
 function is_excluded {
-    local e=$(echo $EXCLUDE | sed -e s/$1//)
-    if [[ "$EXCLUDE" != "$e" ]]; then
-        echo 1
-    else
-        echo 0
-    fi
-    return
+	for i in $(echo "$EXCLUDE" | tr -s "," " "); do
+		if [[ "$i" = "$1" ]]; then
+			echo 1
+			return
+		fi
+	done
+
+	echo 0
 }
 
 function unit_test {
@@ -173,7 +174,7 @@ function unit_test {
 	local end_time
 	local test_time
 
-	local e=$(is_excluded $test)
+	local e=$(is_excluded $(echo "fi_${test}" | cut -d " " -f 1))
 	if [ $e -eq 1 ]; then
 		print_results "$test_exe" "Notrun" "0" "" ""
 		skip_count+=1
@@ -215,7 +216,7 @@ function cs_test {
 	local end_time
 	local test_time
 
-	local e=$(is_excluded $test)
+	local e=$(is_excluded $(echo "fi_${test}" | cut -d " " -f 1))
 	if [ $e -eq 1 ]; then
 		print_results "$test_exe" "Notrun" "0" "" ""
 		skip_count+=1


### PR DESCRIPTION
Fixes issue where test names that are a substring of an excluded test name get excluded.
Changed to `test_exe` since it includes the `fi` prefix. In the function `$1` will only expand to the first part of `test_exe` which is `fi_test`. 

Example:
```bash
$ EXCLUDE="fi_cq_data,fi_dgram_waitset,fi_msg_poll,fi_poll,fi_cmatose,fi_rdm_cntr_pingpong"
$ function old_is_excluded {
>   local e=$(echo $EXCLUDE | sed -e s/$1//)
>   if [[ "$EXCLUDE" != "$e" ]]; then
>     echo 1
>   else
>     echo 0
>   fi
>   return
> }
$ function new_is_excluded {
>   local i
>   for i in $(echo "$EXCLUDE" | tr -s "," " "); do
>     if [[ "$i" = "$1" ]]; then
>       echo 1
>       return
>     fi
>   done
>   echo 0
> }
$ old_is_excluded fi_dgram
1
$ new_is_excluded fi_dgram
0
$ old_is_excluded fi_dgram_waitset
1
$ new_is_excluded fi_dgram_waitset
1
```

@pmmccorm @goodell @shefty @jsquyres 
Please review.

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>