### PR TITLE
scripts/runfabtests.sh: Pass -s option to msg_sockets

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -30,7 +30,7 @@ simple_tests=(
 	"dgram_waitset"
 	"msg"
 	"msg_epoll"
-	"msg_sockets"
+	"msg_sockets -s CLIENT_ADDR"
 	"poll"
 	"rdm"
 	"rdm_rma_simple"
@@ -212,7 +212,8 @@ function cs_test {
 	local test=$1
 	local ret1=0
 	local ret2=0
-	local test_exe="fi_${test} -f $PROV"
+	local test_exe=$(echo "fi_${test} -f $PROV" | \
+	    sed -e "s/CLIENT_ADDR/${CLIENT}/g")
 	local start_time
 	local end_time
 	local test_time


### PR DESCRIPTION
This fixes an issue that was introduced in PR #304.

The msg_sockets tool requires that the -s option is specified even on
the client side, since it tests the functionality of `fi_setname`.
This was forgotten when the test was added to runfabtests.sh in commit
ae3d7e6c8341ae51264111bcb5bf7190e9bc73a8.

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>