### PR TITLE
simple/msg_sockets: Remove infiniband/ib.h include

### DIFF
--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -35,7 +35,6 @@
 #include <unistd.h>
 #include <netdb.h>
 
-#include <infiniband/ib.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_cm.h>
@@ -521,9 +520,6 @@ static int setup_handle(void)
 		break;
 	case AF_INET6:
 		hints->addr_format = FI_SOCKADDR_IN6;
-		break;
-	case AF_IB:
-		hints->addr_format = FI_SOCKADDR_IB;
 		break;
 	}
 


### PR DESCRIPTION
This fixes an issue reported by @hppritcha in https://github.com/ofiwg/fabtests/commit/ae3d7e6c8341ae51264111bcb5bf7190e9bc73a8#commitcomment-12448399.

Since fabtests needs to work on an IB-less system, and AF_IB is not yet
supported by the verbs provider, just remove the AF_IB support in the
test for now.  It can be added back in a more robust way once the verbs
provider gains support for AF_IB addresses.

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>