### PR TITLE
shared.c: pass hints when calling fi_getinfo()

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -98,7 +98,7 @@ static int getaddr(char *node, char *service,
 		return 0;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, service, flags, NULL, &fi);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_ERR("fi_getinfo error %s\n", fi_strerror(ret));
 		return ret;


### PR DESCRIPTION
Make a copy of the passed-in hints and pass that copy down to fi_getinfo() when resolving addresses.  The hints contain user-specified details already (e.g., "-f providername"), and that should be preserved when calling fi_getinfo().

Otherwise, other providers get activated (and can emit warning messages).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>