### PR TITLE
fi_msg_socket: Use different src port for client

### DIFF
--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -633,6 +633,9 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
+	if (opts.dst_addr && (opts.src_port == opts.dst_port))
+		opts.src_port = "9229";
+
 	ret = setup_handle();
 	if (ret)
 		return -ret;


### PR DESCRIPTION
In order to support loopback testing, the client needs to
use a different source port than the server.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>