### PR TITLE
Move fabric variable declarations into common file

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -36,6 +36,16 @@
 
 #include <shared.h>
 
+struct fi_info *fi, *hints;
+struct fid_fabric *fab, *fabric; /* dups */
+struct fid_domain *dom, *domain; /* dups */
+struct fid_pep *pep;
+struct fid_ep *ep;
+struct fid_cq *rcq, *scq, *txcq, *rxcq; /* dups */
+struct fid_mr *mr;
+struct fid_av *av;
+struct fid_eq *cmeq, *eq; /* dups */
+
 struct test_size_param test_size[] = {
 	{ 1 <<  1, 1 }, { (1 <<  1) + (1 <<  0), 2},
 	{ 1 <<  2, 2 }, { (1 <<  2) + (1 <<  1), 2},
@@ -126,7 +136,7 @@ int ft_getdestaddr(char *node, char *service, struct fi_info *hints)
 	return getaddr(node, service, hints, 0);
 }
 
-int ft_read_addr_opts(char **node, char **service, struct fi_info *hints, 
+int ft_read_addr_opts(char **node, char **service, struct fi_info *hints,
 		uint64_t *flags, struct cs_opts *opts)
 {
 	int ret;
@@ -257,7 +267,7 @@ int wait_for_completion(struct fid_cq *cq, int num_completions)
 }
 
 void cq_readerr(struct fid_cq *cq, char *cq_str)
-{ 
+{
 	struct fi_cq_err_entry cq_err;
 	const char *err_str;
 	int ret;
@@ -354,7 +364,7 @@ int64_t get_elapsed(const struct timespec *b, const struct timespec *a,
     return elapsed / p;
 }
 
-void show_perf(char *name, int tsize, int iters, struct timespec *start, 
+void show_perf(char *name, int tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter)
 {
 	static int header = 1;

--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -51,16 +51,9 @@ extern "C" {
 
 extern int listen_sock, sock;
 
-extern struct fid_fabric *fabric;
-extern struct fid_domain *domain;
-extern struct fid_av	 *av;
 //extern struct fid_wait	 *waitset;
 //extern struct fid_poll	 *pollset;
-extern struct fid_eq	 *eq;
-extern struct fid_cq	 *txcq, *rxcq;
 //extern struct fid_cntr	 *txcntr, *rxcntr;
-extern struct fid_ep	 *ep;
-extern struct fid_pep	 *pep;
 //extern struct fid_stx	 *stx;
 //extern struct fid_sep	 *sep;
 

--- a/complex/ft_comp.c
+++ b/complex/ft_comp.c
@@ -32,7 +32,6 @@
 #include "fabtest.h"
 
 
-struct fid_cq *txcq, *rxcq;
 //struct fid_cntr *txcntr, *rxcntr;
 
 static size_t comp_entry_cnt[] = {

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -35,7 +35,6 @@
 struct fid_fabric *fabric;
 struct fid_domain *domain;
 struct fid_eq *eq;
-struct fid_av *av;
 
 
 static int ft_open_fabric(void)

--- a/complex/ft_endpoint.c
+++ b/complex/ft_endpoint.c
@@ -32,8 +32,6 @@
 #include "fabtest.h"
 
 
-struct fid_ep	*ep;
-struct fid_pep	*pep;
 //struct fid_stx	 *stx;
 //struct fid_sep	 *sep;
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -86,6 +86,18 @@ enum {
 	FT_OPT_SIZE = 1 << 1
 };
 
+
+extern struct fi_info *fi, *hints;
+extern struct fid_fabric *fab, *fabric; /* dups */
+extern struct fid_domain *dom, *domain; /* dups */
+extern struct fid_pep *pep;
+extern struct fid_ep *ep;
+extern struct fid_cq *rcq, *scq, *txcq, *rxcq; /* dups */
+extern struct fid_mr *mr;
+extern struct fid_av *av;
+extern struct fid_eq *cmeq, *eq; /* dups */
+
+
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
 void ft_parse_addr_opts(int op, char *optarg, struct cs_opts *opts);
 void ft_parsecsopts(int op, char *optarg, struct cs_opts *opts);
@@ -110,7 +122,7 @@ const unsigned int test_cnt;
 
 int ft_getsrcaddr(char *node, char *service, struct fi_info *hints);
 int ft_getdestaddr(char *node, char *service, struct fi_info *hints);
-int ft_read_addr_opts(char **node, char **service, struct fi_info *hints, 
+int ft_read_addr_opts(char **node, char **service, struct fi_info *hints,
 		uint64_t *flags, struct cs_opts *opts);
 char *size_str(char str[FT_STR_LEN], long long size);
 char *cnt_str(char str[FT_STR_LEN], long long cnt);
@@ -126,11 +138,11 @@ int wait_for_completion(struct fid_cq *cq, int num_completions);
 void cq_readerr(struct fid_cq *cq, char *cq_str);
 void eq_readerr(struct fid_eq *eq, char *eq_str);
 
-int64_t get_elapsed(const struct timespec *b, const struct timespec *a, 
+int64_t get_elapsed(const struct timespec *b, const struct timespec *a,
 		enum precision p);
-void show_perf(char *name, int tsize, int iters, struct timespec *start, 
+void show_perf(char *name, int tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter);
-void show_perf_mr(int tsize, int iters, struct timespec *start, 
+void show_perf_mr(int tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
 
 #define FT_PRINTERR(call, retv) \

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -50,15 +50,6 @@ static void *recv_buf;
 static void *send_buf;
 static size_t buffer_size;
 
-static struct fi_info *hints;
-static struct fi_info *fi = NULL;
-
-static struct fid_fabric *fab;
-static struct fid_pep *pep;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_eq *cmeq;
-static struct fid_cq *rcq, *scq;
 static struct fid_mr *recv_mr;
 static struct fid_mr *send_mr;
 

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -51,14 +51,7 @@ static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
 
-static struct fi_info *fi, *hints;
-
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
 static struct fid_cntr *rcntr, *scntr;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -94,7 +87,7 @@ static int send_xfer(int size)
 	}
 
 	credits--;
-	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr, 
+	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_send);
 	if (ret) {
 		FT_PRINTERR("fi_send", ret);
@@ -115,7 +108,7 @@ static int recv_xfer(int size)
 		return ret;
 	}
 
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr, 
+	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
 			&fi_ctx_recv);
 	if (ret)
 		FT_PRINTERR("fi_recv", ret);
@@ -144,7 +137,7 @@ static int send_msg(int size)
 	return ret;
 }
 
-static int recv_msg(void) 
+static int recv_msg(void)
 {
 	int ret;
 
@@ -381,7 +374,7 @@ static int init_av(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen 
+		/* Get local address blob. Find the addrlen first. We set addrlen
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
@@ -397,7 +390,7 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -426,7 +419,7 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -50,15 +50,6 @@ static struct timespec start, end;
 static void *send_buf, *recv_buf;
 static size_t buffer_size;
 
-static struct fi_info *fi, *hints;
-
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_cq *rcq;
-static struct fid_cq *scq;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -145,7 +136,7 @@ static int run_test(void)
 {
 	int ret, i;
 
-	if (opts.transfer_size > max_inject_size) 
+	if (opts.transfer_size > max_inject_size)
 		return 0;
 
 	ret = sync_test();
@@ -308,7 +299,7 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
-	
+
 	/* check max msg size */
 	max_inject_size = fi->tx_attr->inject_size;
 	if ((opts.user_options & FT_OPT_SIZE) &&
@@ -362,7 +353,7 @@ static int init_av(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen 
+		/* Get local address blob. Find the addrlen first. We set addrlen
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
@@ -378,7 +369,7 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -407,7 +398,7 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, recv_buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -50,14 +50,6 @@ static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
 
-static struct fi_info *fi, *hints;
-
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_cq *rcq, *scq;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -370,7 +362,7 @@ static int init_av(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set 
+		/* Get local address blob. Find the addrlen first. We set
 		 * addrlen as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
@@ -386,7 +378,7 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -415,7 +407,7 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -51,14 +51,6 @@ static struct timespec start, end;
 static void *buf;
 static size_t buffer_size;
 
-static struct fi_info *fi, *hints;
-
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_cq *rcq, *scq;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -408,7 +400,7 @@ static int init_av(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen 
+		/* Get local address blob. Find the addrlen first. We set addrlen
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
@@ -424,7 +416,7 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -453,7 +445,7 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -59,16 +59,7 @@ static size_t prefix_len;
 static size_t max_msg_size = 0;
 static int timeout = 5;
 
-static struct fi_info *hints;
 static fi_addr_t remote_fi_addr;
-
-static struct fi_info *fi = NULL;
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_cq *rcq, *scq;
-static struct fid_mr *mr;
-static struct fid_av *av;
 
 static int poll_all_sends(void)
 {

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -66,16 +66,13 @@ enum CQ_INDEX {
 };
 
 static struct cs_opts 		opts;
-static struct fid_fabric	*fabric;
-static struct fid_eq		*eq;
-static struct fid_pep		*pep;
 static struct cma_node		*nodes;
 static int			conn_index;
 static int			connects_left;
 static int			disconnects_left;
 static int			connections = 1;
 
-static struct fi_info		*hints, *info;
+static struct fi_info		*info;
 
 
 static int post_recvs(struct cma_node *node)
@@ -564,13 +561,13 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-	
+
 	connects_left = connections;
 
 	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
 	if (ret)
 		return ret;
-	
+
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &info);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -47,16 +47,6 @@ static size_t buffer_size;
 static int rx_depth = 500;
 static size_t cq_data_size;
 
-static struct fi_info *hints;
-
-static struct fid_fabric *fab;
-static struct fid_pep *pep;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_eq *cmeq;
-static struct fid_cq *rcq, *scq;
-static struct fid_mr *mr;
-
 static void free_lres(void)
 {
 	fi_close(&cmeq->fid);
@@ -170,7 +160,7 @@ static int bind_ep_res(void)
 	ret = fi_enable(ep);
 	if (ret)
 		return ret;
-	
+
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
@@ -333,7 +323,7 @@ static int client_connect(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
-	
+
 	ret = alloc_ep_res(fi);
 	if (ret)
 		goto err4;
@@ -383,7 +373,7 @@ static int run_test()
 	size_t size = 1000;
 	uint64_t remote_cq_data;
 	struct fi_cq_data_entry comp;
-	
+
 	/* Set remote_cq_data based on the cq_data_size we got from fi_getinfo */
 	remote_cq_data = 0x0123456789abcdef & ((0x1ULL << (cq_data_size * 8)) - 1);
 
@@ -424,7 +414,7 @@ static int run_test()
 				remote_cq_data, comp.data);
 		}
 	}
-	
+
 	return 0;
 }
 
@@ -475,7 +465,7 @@ int main(int argc, char **argv)
 			return EXIT_FAILURE;
 		}
 	}
-	
+
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -50,13 +50,6 @@ static void *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
 
-static struct fi_info *fi, *hints;
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_av *av;
-static struct fid_cq *rcq, *scq;
-static struct fid_mr *mr;
 struct fi_context fi_ctx_send;
 struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_av;
@@ -160,7 +153,7 @@ static int bind_ep_res(void)
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
-	
+
 	/* Bind AV with the endpoint to map addresses */
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
@@ -181,18 +174,18 @@ static int init_fabric(void)
 	char *node, *service;
 	uint64_t flags = 0;
 	int ret;
-	
+
 	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
 	if (ret)
 		return ret;
-	
+
 	/* Get fabric info */
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		goto err0;
 	}
-	
+
 	/* Get remote address of the server */
 	if (opts.dst_addr) {
 		addrlen = fi->dest_addrlen;
@@ -213,7 +206,7 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
-	
+
 	ret = alloc_ep_res(fi);
 	if (ret)
 		goto err4;
@@ -221,10 +214,10 @@ static int init_fabric(void)
 	ret = bind_ep_res();
 	if (ret)
 		goto err5;
-	
+
 	if (opts.dst_addr) {
-		/* Insert address to the AV and get the fabric address back */ 	
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		/* Insert address to the AV and get the fabric address back */
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -255,8 +248,8 @@ static int send_recv()
 	if (opts.dst_addr) {
 		/* Client */
 		fprintf(stdout, "Posting a send...\n");
-		sprintf(buf, "Hello from Client!"); 
-		ret = fi_send(ep, buf, sizeof("Hello from Client!"), 
+		sprintf(buf, "Hello from Client!");
+		ret = fi_send(ep, buf, sizeof("Hello from Client!"),
 				fi_mr_desc(mr), remote_fi_addr, &fi_ctx_send);
 		if (ret) {
 			FT_PRINTERR("fi_send", ret);
@@ -276,7 +269,7 @@ static int send_recv()
 	} else {
 		/* Server */
 		fprintf(stdout, "Posting a recv...\n");
-		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, 
+		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0,
 				&fi_ctx_recv);
 		if (ret) {
 			FT_PRINTERR("fi_recv", ret);
@@ -303,7 +296,7 @@ int main(int argc, char **argv)
 {
 	int op, ret;
 	opts = INIT_OPTS;
-	
+
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;
@@ -323,7 +316,7 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-	
+
 	hints->ep_attr->type	= FI_EP_DGRAM;
 	hints->caps		= FI_MSG;
 	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -47,14 +47,6 @@ static size_t buffer_size = 1024;
 static int transfer_size = 1000;
 static int rx_depth = 512;
 
-static struct fi_info *fi, *hints;
-
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_cq *rcq, *scq;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static struct fid_wait *waitset;
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
@@ -116,7 +108,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
-	
+
 	/* Register memory */
 	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
@@ -232,7 +224,7 @@ static int init_fabric(void)
 	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
 	if (ret)
 		return ret;
-	
+
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
@@ -257,7 +249,7 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
-	
+
 	ret = alloc_ep_res(fi);
 	if (ret)
 		goto err3;
@@ -285,7 +277,7 @@ static int init_av(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen 
+		/* Get local address blob. Find the addrlen first. We set addrlen
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
@@ -301,7 +293,7 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -329,7 +321,7 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -375,7 +367,7 @@ static int send_recv()
 			FT_PRINTERR("fi_wait", ret);
 			return ret;
 		}
-		
+
 		/* Read the send completion entry */
 		ret = fi_cq_read(scq, &comp, 1);
 		if(ret > 0) {
@@ -387,10 +379,10 @@ static int send_recv()
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);
 			}
-			
+
 			return ret;
 		}
-		
+
 		/* Read the recv completion entry */
 		ret = fi_cq_read(rcq, &comp, 1);
 		if(ret > 0) {
@@ -434,7 +426,7 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-	
+
 	hints->ep_attr->type = FI_EP_DGRAM;
 	hints->caps = FI_MSG;
 	hints->mode = FI_CONTEXT | FI_LOCAL_MR;

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -42,15 +42,6 @@ static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;
 
-static struct fi_info *hints;
-static struct fid_fabric *fab;
-static struct fid_pep *pep;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_eq *cmeq;
-static struct fid_cq *rcq, *scq;
-static struct fid_mr *mr;
-
 static int alloc_cm_res(void)
 {
 	struct fi_eq_attr cm_attr = { 0 };
@@ -243,7 +234,7 @@ static int server_connect(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
-	
+
 	ret = alloc_ep_res(info);
 	if (ret)
 		 goto err1;
@@ -312,7 +303,7 @@ static int client_connect(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
-	
+
 	ret = alloc_cm_res();
 	if (ret)
 		goto err4;
@@ -371,7 +362,7 @@ static int send_recv()
 	if (opts.dst_addr) {
 		/* Client */
 		fprintf(stdout, "Posting a send...\n");
-		sprintf(buf, "Hello World!"); 
+		sprintf(buf, "Hello World!");
 		ret = fi_send(ep, buf, sizeof("Hello World!"), fi_mr_desc(mr), 0, buf);
 		if (ret) {
 			FT_PRINTERR("fi_send", ret);
@@ -423,7 +414,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "h" ADDR_OPTS INFO_OPTS)) != -1) {
-		switch (op) {					
+		switch (op) {
 		default:
 			ft_parse_addr_opts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints);
@@ -434,7 +425,7 @@ int main(int argc, char **argv)
 			return EXIT_FAILURE;
 		}
 	}
-		
+
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -47,15 +47,7 @@ static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;
 
-static struct fi_info *hints;
-static struct fid_fabric *fab;
-static struct fid_pep *pep;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_eq *cmeq;
-static struct fid_cq *rcq, *scq;
 static int epfd;
-static struct fid_mr *mr;
 
 static int alloc_cm_res(void)
 {

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -46,15 +46,6 @@ static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;
 
-static struct fi_info *hints;
-static struct fid_fabric *fab;
-static struct fid_pep *pep;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_eq *cmeq;
-static struct fid_cq *rcq, *scq;
-static struct fid_mr *mr;
-
 union sockaddr_any {
 	struct sockaddr		sa;
 	struct sockaddr_in	sin;

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -54,14 +54,6 @@ static size_t buffer_size = 1024;
 static int transfer_size = 1000;
 static int rx_depth = 512;
 
-static struct fi_info *fi, *hints;
-
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_cq *rcq, *scq;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static struct fid_poll *pollset;
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
@@ -120,7 +112,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		FT_PRINTERR("fi_poll_open", ret);
 		goto err2;
 	}
-	
+
 	/* Add send CQ to the polling set */
 	ret = fi_poll_add(pollset, &scq->fid, 0);
 	if (ret) {
@@ -263,7 +255,7 @@ static int init_fabric(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
-	
+
 	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
@@ -303,7 +295,7 @@ static int init_av(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen 
+		/* Get local address blob. Find the addrlen first. We set addrlen
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
@@ -319,7 +311,7 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -348,7 +340,7 @@ static int init_av(void)
 		remote_addr = malloc(addrlen);
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -440,7 +432,7 @@ int main(int argc, char **argv)
 {
 	int op, ret = 0;
 	opts = INIT_OPTS;
-	
+
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;
@@ -460,7 +452,7 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-	
+
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
 	hints->mode = FI_CONTEXT | FI_LOCAL_MR;

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -50,13 +50,6 @@ static void *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
 
-static struct fi_info *fi, *hints;
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_av *av;
-static struct fid_cq *rcq, *scq;
-static struct fid_mr *mr;
 struct fi_context fi_ctx_send;
 struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_av;
@@ -160,7 +153,7 @@ static int bind_ep_res(void)
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
-	
+
 	/* Bind AV with the endpoint to map addresses */
 	ret = fi_ep_bind(ep, &av->fid, 0);
 	if (ret) {
@@ -181,18 +174,18 @@ static int init_fabric(void)
 	char *node, *service;
 	uint64_t flags = 0;
 	int ret;
-	
+
 	ret = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
 	if (ret)
 		return ret;
-	
+
 	/* Get fabric info */
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
-	
+
 	/* Get remote address of the server */
 	if (opts.dst_addr) {
 		addrlen = fi->dest_addrlen;
@@ -213,7 +206,7 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
-	
+
 	ret = alloc_ep_res(fi);
 	if (ret)
 		goto err4;
@@ -221,10 +214,10 @@ static int init_fabric(void)
 	ret = bind_ep_res();
 	if (ret)
 		goto err5;
-	
+
 	if (opts.dst_addr) {
-		/* Insert address to the AV and get the fabric address back */ 	
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		/* Insert address to the AV and get the fabric address back */
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -252,8 +245,8 @@ static int send_recv()
 	if (opts.dst_addr) {
 		/* Client */
 		fprintf(stdout, "Posting a send...\n");
-		sprintf(buf, "Hello from Client!"); 
-		ret = fi_send(ep, buf, sizeof("Hello from Client!"), 
+		sprintf(buf, "Hello from Client!");
+		ret = fi_send(ep, buf, sizeof("Hello from Client!"),
 				fi_mr_desc(mr), remote_fi_addr, &fi_ctx_send);
 		if (ret) {
 			FT_PRINTERR("fi_send", ret);
@@ -273,7 +266,7 @@ static int send_recv()
 	} else {
 		/* Server */
 		fprintf(stdout, "Posting a recv...\n");
-		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, 
+		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0,
 				&fi_ctx_recv);
 		if (ret) {
 			FT_PRINTERR("fi_recv", ret);
@@ -306,7 +299,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "h" ADDR_OPTS INFO_OPTS)) != -1) {
-		switch (op) {			
+		switch (op) {
 		default:
 			ft_parse_addr_opts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints);
@@ -317,10 +310,10 @@ int main(int argc, char **argv)
 			return EXIT_FAILURE;
 		}
 	}
-	
+
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-	
+
 	hints->ep_attr->type	= FI_EP_RDM;
 	hints->caps		= FI_MSG;
 	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -47,14 +47,7 @@ static void *buf;
 static size_t buffer_size;
 struct fi_rma_iov local, remote;
 
-static struct fi_info *fi, *hints;
-
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
 static struct fid_cntr *rcntr, *scntr;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static void *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -70,9 +63,9 @@ static char * welcome_text = "Hello from Client!";
 static int rma_write(size_t size)
 {
 	int ret;
-	
+
 	/* Using specified base address and MR key for RMA write */
-	ret = fi_write(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 0, 
+	ret = fi_write(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 0,
 			user_defined_key, &fi_ctx_write);
 	if (ret){
 		FT_PRINTERR("fi_write", ret);
@@ -97,7 +90,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = MAX(sizeof(char *) * strlen(welcome_text), 
+	buffer_size = MAX(sizeof(char *) * strlen(welcome_text),
 			sizeof(uint64_t));
 	buf = malloc(buffer_size);
 	if (!buf) {
@@ -119,7 +112,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		FT_PRINTERR("fi_cntr_open", ret);
 		goto err2;
 	}
-	
+
 	ret = fi_mr_reg(dom, buf, buffer_size, FI_WRITE | FI_REMOTE_WRITE, 0,
 			user_defined_key, 0, &mr, NULL);
 	if (ret) {
@@ -226,7 +219,7 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
-	
+
 	ret = alloc_ep_res(fi);
 	if (ret)
 		goto err3;
@@ -234,9 +227,9 @@ static int init_fabric(void)
 	ret = bind_ep_res();
 	if (ret)
 		goto err4;
-	
+
 	if(opts.dst_addr) {
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -264,14 +257,14 @@ static int run_test(void)
 	if (ret)
 		return ret;
 
-	if (opts.dst_addr) {	
+	if (opts.dst_addr) {
 		/* Execute RMA write operation from Client */
 		fprintf(stdout, "RMA write to server\n");
 		sprintf(buf, "%s", welcome_text);
 		ret = rma_write(sizeof(char *) * strlen(buf));
 		if (ret)
 			return ret;
-	
+
 		ret = fi_cntr_wait(scntr, 1, -1);
 		if (ret < 0) {
 			FT_PRINTERR("fi_cntr_wait", ret);
@@ -279,7 +272,7 @@ static int run_test(void)
 		}
 
 		fprintf(stdout, "Received a completion event for RMA write\n");
-	} else {	
+	} else {
 		/* Server waits for message from Client */
 		ret = fi_cntr_wait(rcntr, 1, -1);
 		if (ret < 0) {
@@ -300,7 +293,7 @@ static int run_test(void)
 int main(int argc, char **argv)
 {
 	int op, ret;
-		
+
 	opts = INIT_OPTS;
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/rdm_rma_trigger.c
+++ b/simple/rdm_rma_trigger.c
@@ -47,13 +47,7 @@ static struct cs_opts opts;
 static void *buf;
 static size_t buffer_size;
 
-static struct fi_info *fi, *hints;
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
 static struct fid_cntr *rcntr, *scntr;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static void *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -63,7 +57,7 @@ static uint64_t user_defined_key = 45678;
 static char *welcome_text1 = "Hello1 from Client!";
 static char *welcome_text2 = "Hello2 from Client!";
 
-static int rma_write(void *src, size_t size, 
+static int rma_write(void *src, size_t size,
 		     void *context, uint64_t flags)
 {
 	int ret;
@@ -86,7 +80,7 @@ static int rma_write(void *src, size_t size,
 	msg.addr = remote_fi_addr;
 	msg.rma_iov = &rma_iov;
 	msg.context = context;
- 	
+
  	/* Using specified base address and MR key for RMA write */
 	ret = fi_writemsg(ep, &msg, flags);
  	if (ret){
@@ -144,7 +138,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		FT_PRINTERR("fi_cntr_open", ret);
 		goto err2;
 	}
-	
+
 	ret = fi_mr_reg(dom, buf, buffer_size, FI_WRITE | FI_REMOTE_WRITE, 0,
 			user_defined_key, 0, &mr, NULL);
 	if (ret) {
@@ -251,7 +245,7 @@ static int init_fabric(void)
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
-	
+
 	ret = alloc_ep_res(fi);
 	if (ret)
 		goto err3;
@@ -259,7 +253,7 @@ static int init_fabric(void)
 	ret = bind_ep_res();
 	if (ret)
 		goto err4;
-	
+
 	if(opts.dst_addr) {
 		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, NULL);
 		if (ret != 1) {
@@ -306,7 +300,7 @@ static int run_test(void)
 		ret = rma_write(ptr1, strlen(welcome_text1), NULL, 0);
 		if (ret)
 			goto out;
-	
+
 		ret = fi_cntr_wait(scntr, 2, -1);
 		if (ret < 0) {
 			FT_PRINTERR("fi_cntr_wait", ret);
@@ -314,7 +308,7 @@ static int run_test(void)
 		}
 
 		fprintf(stdout, "Received completion events for RMA write operations\n");
-	} else {	
+	} else {
 		/* Server waits for message from Client */
 		ret = fi_cntr_wait(rcntr, 2, -1);
 		if (ret < 0) {
@@ -343,7 +337,7 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
-		
+
 	opts = INIT_OPTS;
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -48,14 +48,6 @@ static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;
 
-static struct fi_info *fi, *hints;
-
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_cq *rcq, *scq;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -416,7 +408,7 @@ static int run(void)
 		fprintf(stdout, "Searching msg with tag [%" PRIu64 "]\n", tag_data);
 		tagged_peek(tag_data);
 
-		fprintf(stdout, "Posting buffer for msg with tag [%" PRIu64 "]\n", 
+		fprintf(stdout, "Posting buffer for msg with tag [%" PRIu64 "]\n",
 				tag_data + 1);
 		ret = post_recv(tag_data + 1);
 		if (ret)

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -54,17 +54,6 @@ struct fi_rma_iov remote;
 static uint64_t cq_data = 1;
 static enum fi_mr_mode mr_mode;
 
-static struct fi_info *hints;
-static struct fi_info *fi = NULL;
-
-static struct fid_fabric *fab;
-static struct fid_pep *pep;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_eq *cmeq;
-static struct fid_cq *rcq, *scq;
-static struct fid_mr *mr;
-
 static int send_xfer(int size)
 {
 	struct fi_cq_data_entry comp;
@@ -121,7 +110,7 @@ static int read_data(size_t size)
 {
 	int ret;
 
-	ret = fi_read(ep, buf, size, fi_mr_desc(mr), 
+	ret = fi_read(ep, buf, size, fi_mr_desc(mr),
 		      0, remote.addr, remote.key, ep);
 	if (ret) {
 		FT_PRINTERR("fi_read", ret);
@@ -148,7 +137,7 @@ static int write_data(size_t size)
 {
 	int ret;
 
-	ret = fi_write(ep, buf, size, fi_mr_desc(mr),  
+	ret = fi_write(ep, buf, size, fi_mr_desc(mr),
 		       0, remote.addr, remote.key, ep);
 	if (ret) {
 		FT_PRINTERR("fi_write", ret);
@@ -229,7 +218,7 @@ static int run_test(void)
 			ret = wait_remote_writedata_completion();
 			break;
 		case FT_RMA_READ:
-			ret = read_data(opts.transfer_size); 
+			ret = read_data(opts.transfer_size);
 			break;
 		}
 		if (ret)
@@ -241,10 +230,10 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	if (opts.machr)
-		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 
+		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end,
 				1, opts.argc, opts.argv);
 	else
-		show_perf(test_name, opts.transfer_size, opts.iterations, 
+		show_perf(test_name, opts.transfer_size, opts.iterations,
 				&start, &end, 1);
 
 	return 0;
@@ -307,7 +296,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
-	
+
 	switch (op_type) {
 	case FT_RMA_READ:
 		access_mode = FI_REMOTE_READ;
@@ -321,7 +310,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		ret = -FI_EINVAL;
 		goto err3;
 	}
-	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)), 
+	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)),
 			access_mode, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
@@ -374,7 +363,7 @@ static int bind_ep_res(void)
 		FT_PRINTERR("fi_enable", ret);
 		return ret;
 	}
-	
+
 	/* Post the first recv buffer */
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
 	if (ret)

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -53,14 +53,6 @@ static size_t buffer_size;
 struct fi_rma_iov remote;
 static uint64_t cq_data = 1;
 
-static struct fi_info *fi, *hints;
-
-static struct fid_fabric *fab;
-static struct fid_domain *dom;
-static struct fid_ep *ep;
-static struct fid_cq *rcq, *scq;
-static struct fid_av *av;
-static struct fid_mr *mr;
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -106,7 +98,7 @@ static int read_data(size_t size)
 {
 	int ret;
 
-	ret = fi_read(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 
+	ret = fi_read(ep, buf, size, fi_mr_desc(mr), remote_fi_addr,
 		      remote.addr, remote.key, &fi_ctx_read);
 	if (ret){
 		FT_PRINTERR("fi_read", ret);
@@ -134,7 +126,7 @@ static int write_data(size_t size)
 {
 	int ret;
 
-	ret = fi_write(ep, buf, size, fi_mr_desc(mr), remote_fi_addr, 
+	ret = fi_write(ep, buf, size, fi_mr_desc(mr), remote_fi_addr,
 		       remote.addr, remote.key, &fi_ctx_write);
 	if (ret){
 		FT_PRINTERR("fi_write", ret);
@@ -209,7 +201,7 @@ static int run_test(void)
 			ret = wait_remote_writedata_completion();
 			break;
 		case FT_RMA_READ:
-			ret = read_data(opts.transfer_size); 
+			ret = read_data(opts.transfer_size);
 			break;
 		}
 		if (ret)
@@ -221,10 +213,10 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	if (opts.machr)
-		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 
+		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end,
 				1, opts.argc, opts.argv);
 	else
-		show_perf(test_name, opts.transfer_size, opts.iterations, 
+		show_perf(test_name, opts.transfer_size, opts.iterations,
 				&start, &end, 1);
 
 	return 0;
@@ -270,7 +262,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
-	
+
 	switch (op_type) {
 	case FT_RMA_READ:
 		access_mode = FI_REMOTE_READ;
@@ -284,7 +276,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		FT_PRINTERR("invalid op_type", ret);
 		exit(1);
 	}
-	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)), 
+	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)),
 			access_mode, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
@@ -413,7 +405,7 @@ static int init_av(void)
 	int ret;
 
 	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen 
+		/* Get local address blob. Find the addrlen first. We set addrlen
 		 * as 0 and fi_getname will return the actual addrlen. */
 		addrlen = 0;
 		ret = fi_getname(&ep->fid, local_addr, &addrlen);
@@ -429,7 +421,7 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -459,7 +451,7 @@ static int init_av(void)
 		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
 
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, 
+		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
 				&fi_ctx_av);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
@@ -471,7 +463,7 @@ static int init_av(void)
 		if (ret)
 			return ret;
 	}
-	
+
 	/* Post the first recv buffer */
 	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
@@ -581,7 +573,7 @@ int main(int argc, char **argv)
 				ft_csusage(argv[0], "Ping pong client and server using rma.");
 				fprintf(stderr, "  -o <op>\trma op type: read|write (default: write)]\n");
 				return EXIT_FAILURE;
-			}	
+			}
 			break;
 		default:
 			ft_parseinfo(op, optarg, hints);
@@ -597,11 +589,11 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-	
+
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_RMA;
 	hints->mode = FI_CONTEXT | FI_LOCAL_MR | FI_RX_CQ_DATA;
-	
+
 	ret =run();
 
 	fi_freeinfo(hints);

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -55,7 +55,6 @@
 
 #define MAX_ADDR 256
 
-static struct fi_info *hints;
 static struct fi_eq_attr eq_attr;
 
 char *good_address;
@@ -64,11 +63,6 @@ char *bad_address;
 static char *src_addr_str = NULL;
 
 static enum fi_av_type av_type;
-
-static struct fi_info *fi;
-static struct fid_fabric *fabric;
-static struct fid_domain *domain;
-static struct fid_eq *eq;
 
 static char err_buf[512];
 
@@ -996,7 +990,7 @@ run_test_set()
 	if (bad_address != NULL) {
 		printf("Testing with bad_address = \"%s\"\n", bad_address);
 		failed += run_tests(test_array_bad, err_buf);
-	}	
+	}
 
 	bad_address = NULL;
 	printf("Testing with invalid address\n");
@@ -1043,17 +1037,17 @@ int main(int argc, char **argv)
 			printf("\t[-f provider_name]\n");
 			printf("\t[-s source_address]\n");
 			return EXIT_FAILURE;
-			
+
 		}
 	}
 
 	if (good_address == NULL ||  num_good_addr == 0) {
-		printf("Test requires -d  and -n\n");	
+		printf("Test requires -d  and -n\n");
 		return EXIT_FAILURE;
 	}
 
 	if (num_good_addr > MAX_ADDR - 1) {
-		printf("num_good_addr = %d is too big, dropped to %d\n", 
+		printf("num_good_addr = %d is too big, dropped to %d\n",
 				num_good_addr, MAX_ADDR);
 		num_good_addr = MAX_ADDR - 1;
 	}

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -55,11 +55,8 @@
 
 #define MAX_ADDR 256
 
-struct fi_info *hints = NULL;
 static struct fi_fabric_attr fabric_hints;
 
-static struct fi_info *fi = NULL;
-static struct fid_fabric *fabric = NULL;
 static struct fid_domain **domain_vec = NULL;
 
 /*

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -48,10 +48,6 @@
 #include "unit_common.h"
 #include "shared.h"
 
-struct fi_info *hints;
-
-static struct fid_fabric *fabric;
-static struct fid_eq *eq;
 
 static char err_buf[512];
 
@@ -148,7 +144,7 @@ eq_write_read_self()
 		event = ~0;
 		memset(&entry, 0, sizeof(entry));
 		ret = fi_eq_read(eq, &event, &entry, sizeof(entry),
-				(i & 1) ? 0 : FI_PEEK); 
+				(i & 1) ? 0 : FI_PEEK);
 		if (ret != sizeof(entry)) {
 			sprintf(err_buf, "fi_eq_read ret=%d, %s", ret, fi_strerror(-ret));
 			goto fail;

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -56,19 +56,12 @@
 
 int fabtests_debug = 0;
 
-static struct fi_info *fi, *hints;
 static struct fi_eq_attr eq_attr;
-
-static struct fid_fabric *fabric;
-static struct fid_domain *domain;
-static struct fid_eq *eq;
 
 static char err_buf[512];
 
 /* per-test fixture variables */
 static struct fid_cq *wcq = NULL;
-static struct fid_cq *rcq = NULL;
-static struct fid_av *av = NULL;
 
 /* returns 0 on success or a negative value that can be stringified with
  * fi_strerror on error.


### PR DESCRIPTION
Move global fabric variable declarations into a shared.c.  This
will make it easier for subsequent patches to merge
common code together.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>