### PR TITLE
Use common variable names for all fabtests

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -37,7 +37,7 @@
 #include <shared.h>
 
 struct fi_info *fi, *hints;
-struct fid_fabric *fab, *fabric; /* dups */
+struct fid_fabric *fabric;
 struct fid_domain *dom, *domain; /* dups */
 struct fid_pep *pep;
 struct fid_ep *ep;

--- a/common/shared.c
+++ b/common/shared.c
@@ -44,7 +44,7 @@ struct fid_ep *ep;
 struct fid_cq *rcq, *scq, *txcq, *rxcq; /* dups */
 struct fid_mr *mr;
 struct fid_av *av;
-struct fid_eq *cmeq, *eq; /* dups */
+struct fid_eq *eq;
 
 struct test_size_param test_size[] = {
 	{ 1 <<  1, 1 }, { (1 <<  1) + (1 <<  0), 2},

--- a/common/shared.c
+++ b/common/shared.c
@@ -41,7 +41,7 @@ struct fid_fabric *fabric;
 struct fid_domain *domain;
 struct fid_pep *pep;
 struct fid_ep *ep;
-struct fid_cq *rcq, *scq, *txcq, *rxcq; /* dups */
+struct fid_cq *txcq, *rxcq;
 struct fid_mr *mr;
 struct fid_av *av;
 struct fid_eq *eq;
@@ -305,8 +305,8 @@ void eq_readerr(struct fid_eq *eq, char *eq_str)
 int ft_finalize(
 	struct fi_info *fi,
 	struct fid_ep *tx_ep,
-	struct fid_cq *scq,
-	struct fid_cq *rcq,
+	struct fid_cq *txcq,
+	struct fid_cq *rxcq,
 	fi_addr_t addr)
 {
 	struct fi_msg msg;
@@ -346,8 +346,8 @@ int ft_finalize(
 		goto err;
 	}
 
-	wait_for_data_completion(scq, 1);
-	wait_for_data_completion(rcq, 1);
+	wait_for_data_completion(txcq, 1);
+	wait_for_data_completion(rxcq, 1);
 
 err:
 	free(buf);

--- a/common/shared.c
+++ b/common/shared.c
@@ -38,7 +38,7 @@
 
 struct fi_info *fi, *hints;
 struct fid_fabric *fabric;
-struct fid_domain *dom, *domain; /* dups */
+struct fid_domain *domain;
 struct fid_pep *pep;
 struct fid_ep *ep;
 struct fid_cq *rcq, *scq, *txcq, *rxcq; /* dups */

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -32,9 +32,7 @@
 #include "fabtest.h"
 
 
-struct fid_fabric *fabric;
 struct fid_domain *domain;
-struct fid_eq *eq;
 
 
 static int ft_open_fabric(void)

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -32,9 +32,6 @@
 #include "fabtest.h"
 
 
-struct fid_domain *domain;
-
-
 static int ft_open_fabric(void)
 {
 	int ret;

--- a/include/shared.h
+++ b/include/shared.h
@@ -88,7 +88,7 @@ enum {
 
 
 extern struct fi_info *fi, *hints;
-extern struct fid_fabric *fab, *fabric; /* dups */
+extern struct fid_fabric *fabric;
 extern struct fid_domain *dom, *domain; /* dups */
 extern struct fid_pep *pep;
 extern struct fid_ep *ep;

--- a/include/shared.h
+++ b/include/shared.h
@@ -95,7 +95,7 @@ extern struct fid_ep *ep;
 extern struct fid_cq *rcq, *scq, *txcq, *rxcq; /* dups */
 extern struct fid_mr *mr;
 extern struct fid_av *av;
-extern struct fid_eq *cmeq, *eq; /* dups */
+extern struct fid_eq *eq;
 
 
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints);

--- a/include/shared.h
+++ b/include/shared.h
@@ -89,7 +89,7 @@ enum {
 
 extern struct fi_info *fi, *hints;
 extern struct fid_fabric *fabric;
-extern struct fid_domain *dom, *domain; /* dups */
+extern struct fid_domain *domain;
 extern struct fid_pep *pep;
 extern struct fid_ep *ep;
 extern struct fid_cq *rcq, *scq, *txcq, *rxcq; /* dups */

--- a/include/shared.h
+++ b/include/shared.h
@@ -92,7 +92,7 @@ extern struct fid_fabric *fabric;
 extern struct fid_domain *domain;
 extern struct fid_pep *pep;
 extern struct fid_ep *ep;
-extern struct fid_cq *rcq, *scq, *txcq, *rxcq; /* dups */
+extern struct fid_cq *txcq, *rxcq;
 extern struct fid_mr *mr;
 extern struct fid_av *av;
 extern struct fid_eq *eq;
@@ -129,8 +129,8 @@ char *cnt_str(char str[FT_STR_LEN], long long cnt);
 int size_to_count(int size);
 
 void init_test(struct cs_opts *opts, char *test_name, size_t test_name_len);
-int ft_finalize(struct fi_info *fi, struct fid_ep *tx_ep, struct fid_cq *scq,
-		struct fid_cq *rcq, fi_addr_t addr);
+int ft_finalize(struct fi_info *fi, struct fid_ep *tx_ep, struct fid_cq *txcq,
+		struct fid_cq *rxcq, fi_addr_t addr);
 
 
 int wait_for_data_completion(struct fid_cq *cq, int num_completions);

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -176,7 +176,7 @@ static int alloc_cm_res(void)
 
 	memset(&cm_attr, 0, sizeof cm_attr);
 	cm_attr.wait_obj = FI_WAIT_FD;
-	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -316,13 +316,13 @@ static int server_listen(void)
 		return ret;
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_passive_ep(fab, fi, &pep, NULL);
+	ret = fi_passive_ep(fabric, fi, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
 		goto err1;
@@ -351,7 +351,7 @@ err3:
 err2:
 	fi_close(&pep->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	fi_freeinfo(fi);
 	return ret;
@@ -378,7 +378,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fab, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -442,13 +442,13 @@ static int client_connect(void)
 		goto err0;
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -490,7 +490,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err2:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err1:
 	fi_freeinfo(fi);
 err0:
@@ -538,7 +538,7 @@ out:
 	if (!opts.dst_addr)
 		free_lres();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -61,12 +61,12 @@ static int send_xfer(int size)
 	int ret;
 
 	while (!credits) {
-		ret = fi_cq_read(scq, &comp, 1);
+		ret = fi_cq_read(txcq, &comp, 1);
 		if (ret > 0) {
 			goto post;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
-				cq_readerr(scq, "scq");
+				cq_readerr(txcq, "txcq");
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);
 			}
@@ -92,10 +92,10 @@ static int recv_xfer(int size)
 	int ret;
 
 	do {
-		ret = fi_cq_read(rcq, &comp, 1);
+		ret = fi_cq_read(rxcq, &comp, 1);
 		if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
-				cq_readerr(rcq, "rcq");
+				cq_readerr(rxcq, "rxcq");
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);
 			}
@@ -120,7 +120,7 @@ static int sync_test(void)
 {
 	int ret;
 
-	ret = wait_for_completion(scq, max_credits - credits);
+	ret = wait_for_completion(txcq, max_credits - credits);
 	if (ret) {
 		return ret;
 	}
@@ -188,8 +188,8 @@ static void free_ep_res(void)
 	fi_close(&ep->fid);
 	fi_close(&recv_mr->fid);
 	fi_close(&send_mr->fid);
-	fi_close(&rcq->fid);
-	fi_close(&scq->fid);
+	fi_close(&rxcq->fid);
+	fi_close(&txcq->fid);
 	free(recv_buf);
 	free(send_buf);
 }
@@ -218,13 +218,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -260,9 +260,9 @@ err4:
 	fi_close(&recv_mr->fid);
 	fi_close(&send_mr->fid);
 err3:
-	fi_close(&rcq->fid);
+	fi_close(&rxcq->fid);
 err2:
-	fi_close(&scq->fid);
+	fi_close(&txcq->fid);
 err1:
 	free(recv_buf);
 	free(send_buf);
@@ -279,13 +279,13 @@ static int bind_ep_res(void)
 		return ret;
 	}
 
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
-	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -529,9 +529,9 @@ static int run(void)
 			goto out;
 	}
 
-	ret = wait_for_completion(scq, max_credits - credits);
+	ret = wait_for_completion(txcq, max_credits - credits);
 	/* Finalize before closing ep */
-	ft_finalize(fi, ep, scq, rcq, FI_ADDR_UNSPEC);
+	ft_finalize(fi, ep, txcq, rxcq, FI_ADDR_UNSPEC);
 out:
 	fi_shutdown(ep, 0);
 	free_ep_res();

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -218,25 +218,25 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
-	ret = fi_mr_reg(dom, recv_buf, buffer_size, FI_RECV, 0, 0, 0, &recv_mr, NULL);
+	ret = fi_mr_reg(domain, recv_buf, buffer_size, FI_RECV, 0, 0, 0, &recv_mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
-	ret = fi_mr_reg(dom, send_buf, buffer_size, FI_SEND, 0, 1, 0, &send_mr, NULL);
+	ret = fi_mr_reg(domain, send_buf, buffer_size, FI_SEND, 0, 1, 0, &send_mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -248,7 +248,7 @@ static int alloc_ep_res(struct fi_info *fi)
 			goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err4;
@@ -378,7 +378,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fabric, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -448,7 +448,7 @@ static int client_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -488,7 +488,7 @@ static int client_connect(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err2:
 	fi_close(&fabric->fid);
 err1:
@@ -537,7 +537,7 @@ out:
 	free_ep_res();
 	if (!opts.dst_addr)
 		free_lres();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -166,7 +166,7 @@ static int run_test()
 
 static void free_lres(void)
 {
-	fi_close(&cmeq->fid);
+	fi_close(&eq->fid);
 }
 
 static int alloc_cm_res(void)
@@ -176,7 +176,7 @@ static int alloc_cm_res(void)
 
 	memset(&cm_attr, 0, sizeof cm_attr);
 	cm_attr.wait_obj = FI_WAIT_FD;
-	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &eq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -242,7 +242,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		goto err3;
 	}
 
-	if (!cmeq) {
+	if (!eq) {
 		ret = alloc_cm_res();
 		if (ret)
 			goto err4;
@@ -273,7 +273,7 @@ static int bind_ep_res(void)
 {
 	int ret;
 
-	ret = fi_ep_bind(ep, &cmeq->fid, 0);
+	ret = fi_ep_bind(ep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -332,7 +332,7 @@ static int server_listen(void)
 	if (ret)
 		goto err2;
 
-	ret = fi_pep_bind(pep, &cmeq->fid, 0);
+	ret = fi_pep_bind(pep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_pep_bind", ret);
 		goto err3;
@@ -365,9 +365,9 @@ static int server_connect(void)
 	ssize_t rd;
 	int ret;
 
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "listen");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "listen");
 		return (int) rd;
 	}
 
@@ -398,9 +398,9 @@ static int server_connect(void)
 		goto err3;
 	}
 
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "accept");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "accept");
 		ret = (int) rd;
 		goto err3;
 	}
@@ -468,9 +468,9 @@ static int client_connect(void)
 		goto err4;
 	}
 
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "connect");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "connect");
 		ret = (int) rd;
 		goto err4;
 	}

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -337,13 +337,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -364,7 +364,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -476,7 +476,7 @@ static int run(void)
 out:
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -232,19 +232,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&cntr_attr, 0, sizeof cntr_attr);
 	cntr_attr.events = FI_CNTR_EVENTS_COMP;
 
-	ret = fi_cntr_open(dom, &cntr_attr, &scntr, NULL);
+	ret = fi_cntr_open(domain, &cntr_attr, &scntr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cntr_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cntr_open(dom, &cntr_attr, &rcntr, NULL);
+	ret = fi_cntr_open(domain, &cntr_attr, &rcntr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cntr_open", ret);
 		goto err2;
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -256,13 +256,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -343,7 +343,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -362,7 +362,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -475,7 +475,7 @@ static int run(void)
 	/* TODO: need support for finalize operation to sync test */
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -199,13 +199,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -213,7 +213,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	/* Memory registration not required for send_buf since we use fi_inject.
 	 * fi_inject copies the buffer of data that needs to be sent. */
-	ret = fi_mr_reg(dom, recv_buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, recv_buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err3;
@@ -225,13 +225,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -322,7 +322,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -341,7 +341,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -453,7 +453,7 @@ static int run(void)
 	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -316,13 +316,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -343,7 +343,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -454,7 +454,7 @@ static int run(void)
 out:
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -74,10 +74,10 @@ static int recv_xfer(int size)
 	int ret;
 
 	do {
-		ret = fi_cq_read(rcq, &comp, 1);
+		ret = fi_cq_read(rxcq, &comp, 1);
 		if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
-				cq_readerr(rcq, "rcq");
+				cq_readerr(rxcq, "rxcq");
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);
 			}
@@ -116,7 +116,7 @@ static int recv_msg(void)
 		return ret;
 	}
 
-	ret = wait_for_completion(rcq, 1);
+	ret = wait_for_completion(rxcq, 1);
 
 	return ret;
 }
@@ -173,8 +173,8 @@ static void free_ep_res(void)
 	fi_close(&ep->fid);
 	fi_close(&av->fid);
 	fi_close(&mr->fid);
-	fi_close(&rcq->fid);
-	fi_close(&scq->fid);
+	fi_close(&rxcq->fid);
+	fi_close(&txcq->fid);
 	free(send_buf);
 	free(recv_buf);
 }
@@ -199,13 +199,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
 
-	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -244,9 +244,9 @@ err5:
 err4:
 	fi_close(&mr->fid);
 err3:
-	fi_close(&scq->fid);
+	fi_close(&txcq->fid);
 err2:
-	fi_close(&rcq->fid);
+	fi_close(&rxcq->fid);
 err1:
 	free(send_buf);
 	free(recv_buf);
@@ -257,13 +257,13 @@ static int bind_ep_res(void)
 {
 	int ret;
 
-	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -450,7 +450,7 @@ static int run(void)
 	}
 
 	/* Finalize before closing ep */
-	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, txcq, rxcq, remote_fi_addr);
 out:
 	free_ep_res();
 	fi_close(&domain->fid);

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -325,13 +325,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -352,7 +352,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -464,7 +464,7 @@ static int run(void)
 out:
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -220,19 +220,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -244,13 +244,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -331,7 +331,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -350,7 +350,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -463,7 +463,7 @@ static int run(void)
 	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -250,19 +250,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -274,13 +274,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -369,7 +369,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -388,7 +388,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -501,7 +501,7 @@ static int run(void)
 	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -363,13 +363,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -390,7 +390,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -502,7 +502,7 @@ static int run(void)
 out:
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -85,12 +85,12 @@ static int send_xfer(int size)
 	int ret;
 
 	while (!credits) {
-		ret = fi_cq_read(scq, &comp, 1);
+		ret = fi_cq_read(txcq, &comp, 1);
 		if (ret > 0) {
 			goto post;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
-				cq_readerr(scq, "scq");
+				cq_readerr(txcq, "txcq");
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);
 			}
@@ -114,10 +114,10 @@ static int recv_xfer(int size)
 	int ret;
 
 	do {
-		ret = fi_cq_read(rcq, &comp, 1);
+		ret = fi_cq_read(rxcq, &comp, 1);
 		if (ret < 0 && ret != -FI_EAGAIN) {
 			if (ret == -FI_EAVAIL) {
-				cq_readerr(rcq, "rcq");
+				cq_readerr(rxcq, "rxcq");
 			} else {
 				FT_PRINTERR("fi_cq_read", ret);
 			}
@@ -145,7 +145,7 @@ static int send_msg(int size)
 		return ret;
 	}
 
-	ret = wait_for_completion_tagged(scq, 1);
+	ret = wait_for_completion_tagged(txcq, 1);
 
 	return ret;
 }
@@ -161,7 +161,7 @@ static int recv_msg(void)
 		return ret;
 	}
 
-	ret = wait_for_completion_tagged(rcq, 1);
+	ret = wait_for_completion_tagged(rxcq, 1);
 
 	return ret;
 }
@@ -170,7 +170,7 @@ static int sync_test(void)
 {
 	int ret;
 
-	ret = wait_for_completion_tagged(scq, max_credits - credits);
+	ret = wait_for_completion_tagged(txcq, max_credits - credits);
 	if (ret) {
 		return ret;
 	}
@@ -227,8 +227,8 @@ static void free_ep_res(void)
 	fi_close(&ep->fid);
 	fi_close(&av->fid);
 	fi_close(&mr->fid);
-	fi_close(&rcq->fid);
-	fi_close(&scq->fid);
+	fi_close(&rxcq->fid);
+	fi_close(&txcq->fid);
 	free(buf);
 }
 
@@ -250,13 +250,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -293,9 +293,9 @@ err5:
 err4:
 	fi_close(&mr->fid);
 err3:
-	fi_close(&rcq->fid);
+	fi_close(&rxcq->fid);
 err2:
-	fi_close(&scq->fid);
+	fi_close(&txcq->fid);
 err1:
 	free(buf);
 	return ret;
@@ -305,13 +305,13 @@ static int bind_ep_res(void)
 {
 	int ret;
 
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
-	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -496,9 +496,9 @@ static int run(void)
 			goto out;
 	}
 
-	wait_for_completion_tagged(scq, max_credits - credits);
+	wait_for_completion_tagged(txcq, max_credits - credits);
 	/* Finalize before closing ep */
-	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, txcq, rxcq, remote_fi_addr);
 out:
 	free_ep_res();
 	fi_close(&domain->fid);

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -341,7 +341,7 @@ static int common_setup(void)
 		max_msg_size = fi->ep_attr->max_msg_size;
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
@@ -350,7 +350,7 @@ static int common_setup(void)
 		prefix_len = fi->ep_attr->msg_prefix_size;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -373,7 +373,7 @@ err5:
 err4:
 	fi_close(&dom->fid);
 err2:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err1:
 
 	return ret;
@@ -417,7 +417,7 @@ err:
 	free_ep_res();
 	fi_close(&av->fid);
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 
 	return ret;
 }
@@ -479,8 +479,8 @@ err:
 	if (dom)
 		fi_close(&dom->fid);
 
-	if (fab)
-		fi_close(&fab->fid);
+	if (fabric)
+		fi_close(&fabric->fid);
 
 	return ret;
 }
@@ -528,7 +528,7 @@ out:
 	if (ret2 != 0) {
 		FT_PRINTERR("fi_close", ret2);
 	}
-	ret2 = fi_close(&fab->fid);
+	ret2 = fi_close(&fabric->fid);
 	if (ret2 != 0) {
 		FT_PRINTERR("fi_close", ret2);
 	}

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -67,7 +67,7 @@ static int poll_all_sends(void)
 	int ret;
 
 	do {
-		ret = fi_cq_read(scq, &comp, 1);
+		ret = fi_cq_read(txcq, &comp, 1);
 		if (ret > 0) {
 			credits++;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {
@@ -84,7 +84,7 @@ static int send_xfer(int size)
 	int ret;
 
 	while (!credits) {
-		ret = fi_cq_read(scq, &comp, 1);
+		ret = fi_cq_read(txcq, &comp, 1);
 		if (ret > 0) {
 			goto post;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {
@@ -111,7 +111,7 @@ static int recv_xfer(int size)
 
 	clock_gettime(CLOCK_MONOTONIC, &a);
 	do {
-		ret = fi_cq_read(rcq, &comp, sizeof comp);
+		ret = fi_cq_read(rxcq, &comp, sizeof comp);
 		if (ret < 0) {
 			if (ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
@@ -193,14 +193,14 @@ static void free_ep_res(void)
 			FT_PRINTERR("fi_close", ret);
 		}
 	}
-	if (rcq) {
-		ret = fi_close(&rcq->fid);
+	if (rxcq) {
+		ret = fi_close(&rxcq->fid);
 		if (ret != 0) {
 			FT_PRINTERR("fi_close", ret);
 		}
 	}
-	if (scq) {
-		ret = fi_close(&scq->fid);
+	if (txcq) {
+		ret = fi_close(&txcq->fid);
 		if (ret != 0) {
 			FT_PRINTERR("fi_close", ret);
 		}
@@ -234,13 +234,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -276,9 +276,9 @@ err5:
 err4:
 	fi_close(&mr->fid);
 err3:
-	fi_close(&rcq->fid);
+	fi_close(&rxcq->fid);
 err2:
-	fi_close(&scq->fid);
+	fi_close(&txcq->fid);
 err1:
 	free(buf);
 	return ret;
@@ -288,13 +288,13 @@ static int bind_ep_res(void)
 {
 	int ret;
 
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
-	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -434,7 +434,7 @@ static int server_connect(void)
 
 	clock_gettime(CLOCK_MONOTONIC, &a);
 	do {
-		ret = fi_cq_read(rcq, &comp, 1);
+		ret = fi_cq_read(rxcq, &comp, 1);
 		if (ret < 0) {
 			if (ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
@@ -517,7 +517,7 @@ static int run(void)
 	while (credits < max_credits)
 		poll_all_sends();
 
-	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, txcq, rxcq, remote_fi_addr);
 out:
 	free_ep_res();
 	ret2 = fi_close(&av->fid);

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -234,19 +234,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -257,13 +257,13 @@ static int alloc_ep_res(struct fi_info *fi)
 			fi->domain_attr->av_type : FI_AV_MAP;
 	av_attr.name = NULL;
 	av_attr.flags = 0;
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -350,7 +350,7 @@ static int common_setup(void)
 		prefix_len = fi->ep_attr->msg_prefix_size;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -371,7 +371,7 @@ static int common_setup(void)
 err5:
 	free_ep_res();
 err4:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err2:
 	fi_close(&fabric->fid);
 err1:
@@ -416,7 +416,7 @@ static int client_connect(void)
 err:
 	free_ep_res();
 	fi_close(&av->fid);
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 
 	return ret;
@@ -476,8 +476,8 @@ static int server_connect(void)
 
 err:
 	free_ep_res();
-	if (dom)
-		fi_close(&dom->fid);
+	if (domain)
+		fi_close(&domain->fid);
 
 	if (fabric)
 		fi_close(&fabric->fid);
@@ -524,7 +524,7 @@ out:
 	if (ret2 != 0) {
 		FT_PRINTERR("fi_close", ret2);
 	}
-	ret2 = fi_close(&dom->fid);
+	ret2 = fi_close(&domain->fid);
 	if (ret2 != 0) {
 		FT_PRINTERR("fi_close", ret2);
 	}

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -59,7 +59,7 @@ static int alloc_cm_res(void)
 
 	memset(&cm_attr, 0, sizeof cm_attr);
 	cm_attr.wait_obj = FI_WAIT_FD;
-	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -184,13 +184,13 @@ static int server_listen(void)
 
 	cq_data_size = fi->domain_attr->cq_data_size;
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_passive_ep(fab, fi, &pep, NULL);
+	ret = fi_passive_ep(fabric, fi, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
 		goto err1;
@@ -219,7 +219,7 @@ err3:
 err2:
 	fi_close(&pep->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	fi_freeinfo(fi);
 	return ret;
@@ -246,7 +246,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fab, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -312,13 +312,13 @@ static int client_connect(void)
 
 	cq_data_size = fi->domain_attr->cq_data_size;
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -360,7 +360,7 @@ err5:
 err4:
 	fi_close(&dom->fid);
 err2:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err1:
 	fi_freeinfo(fi);
 err0:
@@ -440,7 +440,7 @@ static int run(void)
 	if (!opts.dst_addr)
 		free_lres();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -49,7 +49,7 @@ static size_t cq_data_size;
 
 static void free_lres(void)
 {
-	fi_close(&cmeq->fid);
+	fi_close(&eq->fid);
 }
 
 static int alloc_cm_res(void)
@@ -59,7 +59,7 @@ static int alloc_cm_res(void)
 
 	memset(&cm_attr, 0, sizeof cm_attr);
 	cm_attr.wait_obj = FI_WAIT_FD;
-	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &eq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -110,7 +110,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		goto err3;
 	}
 
-	if (!cmeq) {
+	if (!eq) {
 		ret = alloc_cm_res();
 		if (ret)
 			goto err4;
@@ -139,7 +139,7 @@ static int bind_ep_res(void)
 {
 	int ret;
 
-	ret = fi_ep_bind(ep, &cmeq->fid, 0);
+	ret = fi_ep_bind(ep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -200,7 +200,7 @@ static int server_listen(void)
 	if (ret)
 		goto err2;
 
-	ret = fi_pep_bind(pep, &cmeq->fid, 0);
+	ret = fi_pep_bind(pep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_pep_bind", ret);
 		goto err3;
@@ -233,9 +233,9 @@ static int server_connect(void)
 	ssize_t rd;
 	int ret;
 
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "listen");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "listen");
 		return (int) rd;
 	}
 
@@ -267,9 +267,9 @@ static int server_connect(void)
 		goto err3;
 	}
 
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "accept");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "accept");
 		ret = (int) rd;
 		goto err3;
 	}
@@ -338,9 +338,9 @@ static int client_connect(void)
 		goto err5;
 	}
 
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "connect");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "connect");
 		ret = (int) rd;
 		goto err5;
 	}

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -91,20 +91,20 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = FI_WAIT_UNSPEC;
 	cq_attr.size = rx_depth;
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -116,7 +116,7 @@ static int alloc_ep_res(struct fi_info *fi)
 			goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err4;
@@ -246,7 +246,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fabric, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -318,7 +318,7 @@ static int client_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -358,7 +358,7 @@ static int client_connect(void)
 err5:
 	free_ep_res();
 err4:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err2:
 	fi_close(&fabric->fid);
 err1:
@@ -439,7 +439,7 @@ static int run(void)
 	free_ep_res();
 	if (!opts.dst_addr)
 		free_lres();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -194,14 +194,14 @@ static int init_fabric(void)
 	}
 
 	/* Open fabric */
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	/* Open domain */
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -233,7 +233,7 @@ err5:
 err4:
 	fi_close(&dom->fid);
 err2:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err1:
 	fi_freeinfo(fi);
 err0:
@@ -331,7 +331,7 @@ int main(int argc, char **argv)
 
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	fi_freeinfo(hints);
 
 	return ret;

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -82,21 +82,21 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -109,13 +109,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.name = NULL;
 
 	/* Open address vector (AV) for mapping address */
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		 goto err4;
 	 }
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -201,7 +201,7 @@ static int init_fabric(void)
 	}
 
 	/* Open domain */
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -231,7 +231,7 @@ static int init_fabric(void)
 err5:
 	free_ep_res();
 err4:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err2:
 	fi_close(&fabric->fid);
 err1:
@@ -330,7 +330,7 @@ int main(int argc, char **argv)
 	ret = send_recv();
 
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	fi_freeinfo(hints);
 

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -59,8 +59,8 @@ static void free_ep_res(void)
 	fi_close(&ep->fid);
 	fi_close(&av->fid);
 	fi_close(&mr->fid);
-	fi_close(&rcq->fid);
-	fi_close(&scq->fid);
+	fi_close(&rxcq->fid);
+	fi_close(&txcq->fid);
 	free(buf);
 }
 
@@ -82,14 +82,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -128,9 +128,9 @@ err5:
 err4:
 	fi_close(&mr->fid);
 err3:
-	fi_close(&rcq->fid);
+	fi_close(&rxcq->fid);
 err2:
-	fi_close(&scq->fid);
+	fi_close(&txcq->fid);
 err1:
 	free(buf);
 	return ret;
@@ -141,14 +141,14 @@ static int bind_ep_res(void)
 	int ret;
 
 	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	/* Bind Recv CQ with endpoint to collect recv completions */
-	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -258,7 +258,7 @@ static int send_recv()
 
 		/* Read send queue */
 		do {
-			ret = fi_cq_read(scq, &comp, 1);
+			ret = fi_cq_read(txcq, &comp, 1);
 			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
@@ -279,7 +279,7 @@ static int send_recv()
 		/* Read recv queue */
 		fprintf(stdout, "Waiting for client...\n");
 		do {
-			ret = fi_cq_read(rcq, &comp, 1);
+			ret = fi_cq_read(rxcq, &comp, 1);
 			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -82,7 +82,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	/* Open a wait set */
 	memset(&wait_attr, 0, sizeof wait_attr);
 	wait_attr.wait_obj = FI_WAIT_UNSPEC;
-	ret = fi_wait_open(fab, &wait_attr, &waitset);
+	ret = fi_wait_open(fabric, &wait_attr, &waitset);
 	if (ret) {
 		FT_PRINTERR("fi_wait_open", ret);
 		goto err1;
@@ -238,13 +238,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -265,7 +265,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	fi_freeinfo(fi);
 
@@ -444,7 +444,7 @@ int main(int argc, char **argv)
 
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	fi_freeinfo(hints);
 	fi_freeinfo(fi);
 

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -96,21 +96,21 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err4;
@@ -123,13 +123,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.name = NULL;
 
 	/* Open Address Vector */
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err5;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err6;
@@ -244,7 +244,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -263,7 +263,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -443,7 +443,7 @@ int main(int argc, char **argv)
 	ret = send_recv();
 
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	fi_freeinfo(hints);
 	fi_freeinfo(fi);

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -82,27 +82,27 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err4;
@@ -229,7 +229,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fabric, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -298,7 +298,7 @@ static int client_connect(void)
 	}
 
 	/* Open domain */
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -345,7 +345,7 @@ err6:
 err5:
 	fi_close(&cmeq->fid);
 err4:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err2:
 	fi_close(&fabric->fid);
 err1:
@@ -452,7 +452,7 @@ int main(int argc, char **argv)
 	fi_shutdown(ep, 0);
 	free_ep_res();
 	fi_close(&cmeq->fid);
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 
 	return ret;

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -50,7 +50,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 
 	/* Open EQ to receive CM events */
-	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -162,14 +162,14 @@ static int server_listen(void)
 	}
 
 	/* Open the fabric */
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	/* Open a passive endpoint */
-	ret = fi_passive_ep(fab, fi, &pep, NULL);
+	ret = fi_passive_ep(fabric, fi, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
 		goto err1;
@@ -201,7 +201,7 @@ err3:
 err2:
 	fi_close(&pep->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	fi_freeinfo(fi);
 	return ret;
@@ -229,7 +229,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fab, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -291,14 +291,14 @@ static int client_connect(void)
 	}
 
 	/* Open fabric */
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	/* Open domain */
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -347,7 +347,7 @@ err5:
 err4:
 	fi_close(&dom->fid);
 err2:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err1:
 	fi_freeinfo(fi);
 err0:
@@ -453,7 +453,7 @@ int main(int argc, char **argv)
 	free_ep_res();
 	fi_close(&cmeq->fid);
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 
 	return ret;
 }

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -58,7 +58,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 
 	/* Open EQ to receive CM events */
-	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -219,14 +219,14 @@ static int server_listen(void)
 	}
 
 	/* Open the fabric */
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
 	/* Open a passive endpoint */
-	ret = fi_passive_ep(fab, fi, &pep, NULL);
+	ret = fi_passive_ep(fabric, fi, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
 		goto err1;
@@ -258,7 +258,7 @@ err3:
 err2:
 	fi_close(&pep->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	fi_freeinfo(fi);
 	return ret;
@@ -286,7 +286,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fab, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -349,14 +349,14 @@ static int client_connect(void)
 	}
 
 	/* Open fabric */
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	/* Open domain */
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -406,7 +406,7 @@ err5:
 err4:
 	fi_close(&dom->fid);
 err2:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err1:
 	fi_freeinfo(fi);
 err0:
@@ -536,7 +536,7 @@ int main(int argc, char **argv)
 	free_ep_res();
 	fi_close(&cmeq->fid);
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 
 	return ret;
 }

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -58,7 +58,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 
 	/* Open EQ to receive CM events */
-	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &eq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -183,7 +183,7 @@ static int bind_ep_res(void)
 	int ret;
 
 	/* Bind EQ with endpoint */
-	ret = fi_ep_bind(ep, &cmeq->fid, 0);
+	ret = fi_ep_bind(ep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -238,7 +238,7 @@ static int server_listen(void)
 		goto err2;
 
 	/* Bind EQ to passive endpoint */
-	ret = fi_pep_bind(pep, &cmeq->fid, 0);
+	ret = fi_pep_bind(pep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_pep_bind", ret);
 		goto err3;
@@ -254,7 +254,7 @@ static int server_listen(void)
 	fi_freeinfo(fi);
 	return 0;
 err3:
-	fi_close(&cmeq->fid);
+	fi_close(&eq->fid);
 err2:
 	fi_close(&pep->fid);
 err1:
@@ -273,9 +273,9 @@ static int server_connect(void)
 	int ret;
 
 	/* Wait for connection request from client */
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "listen");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "listen");
 		return (int) rd;
 	}
 
@@ -308,9 +308,9 @@ static int server_connect(void)
 	}
 
 	/* Wait for the connection to be established */
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "accept");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "accept");
 		ret = (int) rd;
 		goto err3;
 	}
@@ -382,9 +382,9 @@ static int client_connect(void)
 	}
 
 	/* Wait for the connection to be established */
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "connect");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "connect");
 		ret = (int) rd;
 		goto err6;
 	}
@@ -402,7 +402,7 @@ static int client_connect(void)
 err6:
 	free_ep_res();
 err5:
-	fi_close(&cmeq->fid);
+	fi_close(&eq->fid);
 err4:
 	fi_close(&domain->fid);
 err2:
@@ -534,7 +534,7 @@ int main(int argc, char **argv)
 
 	fi_shutdown(ep, 0);
 	free_ep_res();
-	fi_close(&cmeq->fid);
+	fi_close(&eq->fid);
 	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -93,14 +93,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -151,13 +151,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -286,7 +286,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fabric, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -356,7 +356,7 @@ static int client_connect(void)
 	}
 
 	/* Open domain */
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -404,7 +404,7 @@ err6:
 err5:
 	fi_close(&cmeq->fid);
 err4:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err2:
 	fi_close(&fabric->fid);
 err1:
@@ -535,7 +535,7 @@ int main(int argc, char **argv)
 	fi_shutdown(ep, 0);
 	free_ep_res();
 	fi_close(&cmeq->fid);
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 
 	return ret;

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -147,7 +147,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 
 	/* Open EQ to receive CM events */
-	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &eq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -223,7 +223,7 @@ static int bind_ep_res(void)
 	int ret;
 
 	/* Bind EQ with endpoint */
-	ret = fi_ep_bind(ep, &cmeq->fid, 0);
+	ret = fi_ep_bind(ep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -256,7 +256,7 @@ static int server_listen(void)
 		goto err2;
 
 	/* Bind EQ to passive endpoint */
-	ret = fi_pep_bind(pep, &cmeq->fid, 0);
+	ret = fi_pep_bind(pep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_pep_bind", ret);
 		goto err3;
@@ -271,7 +271,7 @@ static int server_listen(void)
 
 	return 0;
 err3:
-	fi_close(&cmeq->fid);
+	fi_close(&eq->fid);
 err2:
 	fi_close(&pep->fid);
 	fi_close(&fabric->fid);
@@ -287,7 +287,7 @@ static int server_connect(void)
 	int ret;
 
 	/* Wait for connection request from client */
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
 		FT_PRINTERR("fi_eq_sread", rd);
 		return (int) rd;
@@ -322,7 +322,7 @@ static int server_connect(void)
 	}
 
 	/* Wait for the connection to be established */
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
 		FT_PRINTERR("fi_eq_sread", rd);
 		goto err3;
@@ -407,7 +407,7 @@ static int client_connect(void)
 	}
 
 	/* Wait for the connection to be established */
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
 		FT_PRINTERR("fi_eq_sread", rd);
 		return (int) rd;
@@ -430,7 +430,7 @@ static int client_connect(void)
 err6:
 	free_ep_res();
 err5:
-	fi_close(&cmeq->fid);
+	fi_close(&eq->fid);
 err4:
 	fi_close(&domain->fid);
 err2:
@@ -648,7 +648,7 @@ int main(int argc, char **argv)
 
 	fi_shutdown(ep, 0);
 	free_ep_res();
-	fi_close(&cmeq->fid);
+	fi_close(&eq->fid);
 	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -179,27 +179,27 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err4;
@@ -300,7 +300,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fabric, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -366,7 +366,7 @@ static int client_connect(void)
 	}
 
 	/* Open domain */
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -432,7 +432,7 @@ err6:
 err5:
 	fi_close(&cmeq->fid);
 err4:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err2:
 	fi_freeinfo(fi);
 err0:
@@ -649,7 +649,7 @@ int main(int argc, char **argv)
 	fi_shutdown(ep, 0);
 	free_ep_res();
 	fi_close(&cmeq->fid);
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 
 	return ret;

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -147,7 +147,7 @@ static int alloc_cm_res(void)
 	cm_attr.wait_obj = FI_WAIT_FD;
 
 	/* Open EQ to receive CM events */
-	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -274,7 +274,7 @@ err3:
 	fi_close(&cmeq->fid);
 err2:
 	fi_close(&pep->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 
@@ -300,7 +300,7 @@ static int server_connect(void)
 		goto err1;
 	}
 
-	ret = fi_domain(fab, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -366,7 +366,7 @@ static int client_connect(void)
 	}
 
 	/* Open domain */
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -527,14 +527,14 @@ static int setup_handle(void)
 	fi->src_addrlen = 0;
 
 	/* Open the fabric */
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto free_fi;
 	}
 
 	/* Open a passive endpoint */
-	ret = fi_passive_ep(fab, fi, &pep, NULL);
+	ret = fi_passive_ep(fabric, fi, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
 		goto free_fabric;
@@ -579,7 +579,7 @@ static int setup_handle(void)
 free_pep:
 	fi_close(&pep->fid);
 free_fabric:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 
 free_fi:
 	fi_freeinfo(fi);
@@ -650,7 +650,7 @@ int main(int argc, char **argv)
 	free_ep_res();
 	fi_close(&cmeq->fid);
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 
 	return ret;
 }

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -158,8 +158,8 @@ static void free_ep_res(void)
 {
 	fi_close(&ep->fid);
 	fi_close(&mr->fid);
-	fi_close(&rcq->fid);
-	fi_close(&scq->fid);
+	fi_close(&rxcq->fid);
+	fi_close(&txcq->fid);
 	free(buf);
 }
 
@@ -179,14 +179,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -210,9 +210,9 @@ static int alloc_ep_res(struct fi_info *fi)
 err4:
 	fi_close(&mr->fid);
 err3:
-	fi_close(&rcq->fid);
+	fi_close(&rxcq->fid);
 err2:
-	fi_close(&scq->fid);
+	fi_close(&txcq->fid);
 err1:
 	free(buf);
 	return ret;
@@ -230,14 +230,14 @@ static int bind_ep_res(void)
 	}
 
 	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	/* Bind Recv CQ with endpoint to collect recv completions */
-	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -456,7 +456,7 @@ static int send_recv()
 
 		/* Read send queue */
 		do {
-			ret = fi_cq_read(scq, &comp, 1);
+			ret = fi_cq_read(txcq, &comp, 1);
 			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
@@ -476,7 +476,7 @@ static int send_recv()
 		/* Read recv queue */
 		fprintf(stdout, "Waiting for client...\n");
 		do {
-			ret = fi_cq_read(rcq, &comp, 1);
+			ret = fi_cq_read(rxcq, &comp, 1);
 			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -256,13 +256,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -283,7 +283,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	fi_freeinfo(fi);
 
@@ -470,7 +470,7 @@ int main(int argc, char **argv)
 
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	fi_freeinfo(hints);
 	fi_freeinfo(fi);
 

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -92,14 +92,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(dom, &cq_attr, &scq, (void *)CQ_SEND);
+	ret = fi_cq_open(domain, &cq_attr, &scq, (void *)CQ_SEND);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(dom, &cq_attr, &rcq, (void *)CQ_RECV);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, (void *)CQ_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -107,7 +107,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	/* Open a polling set */
 	memset(&poll_attr, 0, sizeof poll_attr);
-	ret = fi_poll_open(dom, &poll_attr, &pollset);
+	ret = fi_poll_open(domain, &poll_attr, &pollset);
 	if (ret) {
 		FT_PRINTERR("fi_poll_open", ret);
 		goto err2;
@@ -128,7 +128,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err4;
@@ -141,13 +141,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.name = NULL;
 
 	/* Open Address Vector */
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err5;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err6;
@@ -262,7 +262,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -281,7 +281,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -469,7 +469,7 @@ int main(int argc, char **argv)
 	ret = send_recv();
 
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	fi_freeinfo(hints);
 	fi_freeinfo(fi);

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -59,8 +59,8 @@ static void free_ep_res(void)
 	fi_close(&ep->fid);
 	fi_close(&av->fid);
 	fi_close(&mr->fid);
-	fi_close(&rcq->fid);
-	fi_close(&scq->fid);
+	fi_close(&rxcq->fid);
+	fi_close(&txcq->fid);
 	free(buf);
 }
 
@@ -82,14 +82,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -128,9 +128,9 @@ err5:
 err4:
 	fi_close(&mr->fid);
 err3:
-	fi_close(&rcq->fid);
+	fi_close(&rxcq->fid);
 err2:
-	fi_close(&scq->fid);
+	fi_close(&txcq->fid);
 err1:
 	free(buf);
 	return ret;
@@ -141,14 +141,14 @@ static int bind_ep_res(void)
 	int ret;
 
 	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
 	/* Bind Recv CQ with endpoint to collect recv completions */
-	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -255,7 +255,7 @@ static int send_recv()
 
 		/* Read send queue */
 		do {
-			ret = fi_cq_read(scq, &comp, 1);
+			ret = fi_cq_read(txcq, &comp, 1);
 			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;
@@ -276,7 +276,7 @@ static int send_recv()
 		/* Read recv queue */
 		fprintf(stdout, "Waiting for client...\n");
 		do {
-			ret = fi_cq_read(rcq, &comp, 1);
+			ret = fi_cq_read(rxcq, &comp, 1);
 			if (ret < 0 && ret != -FI_EAGAIN) {
 				FT_PRINTERR("fi_cq_read", ret);
 				return ret;

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -82,21 +82,21 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.size = rx_depth;
 
 	/* Open completion queue for send completions */
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
 	/* Open completion queue for recv completions */
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -109,13 +109,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.name = NULL;
 
 	/* Open address vector (AV) for mapping address */
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		 goto err4;
 	 }
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -201,7 +201,7 @@ static int init_fabric(void)
 	}
 
 	/* Open domain */
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -230,7 +230,7 @@ static int init_fabric(void)
 err5:
 	free_ep_res();
 err4:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err2:
 	fi_close(&fabric->fid);
 err1:
@@ -327,7 +327,7 @@ int main(int argc, char **argv)
 	ret = send_recv();
 
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	fi_freeinfo(hints);
 	fi_freeinfo(fi);

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -194,14 +194,14 @@ static int init_fabric(void)
 	}
 
 	/* Open fabric */
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	/* Open domain */
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -232,7 +232,7 @@ err5:
 err4:
 	fi_close(&dom->fid);
 err2:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err1:
 	return ret;
 }
@@ -328,7 +328,7 @@ int main(int argc, char **argv)
 
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	fi_freeinfo(hints);
 	fi_freeinfo(fi);
 	return ret;

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -101,19 +101,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&cntr_attr, 0, sizeof cntr_attr);
 	cntr_attr.events = FI_CNTR_EVENTS_COMP;
 
-	ret = fi_cntr_open(dom, &cntr_attr, &scntr, NULL);
+	ret = fi_cntr_open(domain, &cntr_attr, &scntr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cntr_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cntr_open(dom, &cntr_attr, &rcntr, NULL);
+	ret = fi_cntr_open(domain, &cntr_attr, &rcntr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cntr_open", ret);
 		goto err2;
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, FI_WRITE | FI_REMOTE_WRITE, 0,
+	ret = fi_mr_reg(domain, buf, buffer_size, FI_WRITE | FI_REMOTE_WRITE, 0,
 			user_defined_key, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
@@ -126,13 +126,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -214,7 +214,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -242,7 +242,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -285,7 +285,7 @@ static int run_test(void)
 
 	/* TODO: need support for finalize operation to sync test */
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return 0;
 }

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -208,13 +208,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -244,7 +244,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -286,7 +286,7 @@ static int run_test(void)
 	/* TODO: need support for finalize operation to sync test */
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return 0;
 }
 

--- a/simple/rdm_rma_trigger.c
+++ b/simple/rdm_rma_trigger.c
@@ -127,19 +127,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&cntr_attr, 0, sizeof cntr_attr);
 	cntr_attr.events = FI_CNTR_EVENTS_COMP;
 
-	ret = fi_cntr_open(dom, &cntr_attr, &scntr, NULL);
+	ret = fi_cntr_open(domain, &cntr_attr, &scntr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cntr_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cntr_open(dom, &cntr_attr, &rcntr, NULL);
+	ret = fi_cntr_open(domain, &cntr_attr, &rcntr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cntr_open", ret);
 		goto err2;
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, FI_WRITE | FI_REMOTE_WRITE, 0,
+	ret = fi_mr_reg(domain, buf, buffer_size, FI_WRITE | FI_REMOTE_WRITE, 0,
 			user_defined_key, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
@@ -152,13 +152,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -240,7 +240,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -267,7 +267,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -329,7 +329,7 @@ static int run_test(void)
 
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/simple/rdm_rma_trigger.c
+++ b/simple/rdm_rma_trigger.c
@@ -234,13 +234,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -269,7 +269,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -330,7 +330,7 @@ static int run_test(void)
 out:
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -338,13 +338,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -368,7 +368,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -487,7 +487,7 @@ static int run(void)
 out:
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -135,31 +135,31 @@ static int alloc_ep_res(struct fi_info *fi)
 	memset(&tx_attr, 0, sizeof tx_attr);
 	memset(&rx_attr, 0, sizeof rx_attr);
 
-	ret = fi_stx_context(dom, &tx_attr, &stx_ctx, NULL);
+	ret = fi_stx_context(domain, &tx_attr, &stx_ctx, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_stx_context", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
-	ret = fi_srx_context(dom, &rx_attr, &srx_ctx, NULL);
+	ret = fi_srx_context(domain, &rx_attr, &srx_ctx, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_srx_context", ret);
 		goto err3;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err4;
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err5;
@@ -170,7 +170,7 @@ static int alloc_ep_res(struct fi_info *fi)
 			fi->domain_attr->av_type : FI_AV_MAP;
 	av_attr.count = ep_cnt;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err6;
@@ -182,7 +182,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		goto err7;
 	}
 	for (i = 0; i < ep_cnt; i++) {
-		ret = fi_endpoint(dom, fi, &ep_array[i], NULL);
+		ret = fi_endpoint(domain, fi, &ep_array[i], NULL);
 		if (ret) {
 			FT_PRINTERR("fi_endpoint", ret);
 			goto err8;
@@ -344,7 +344,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -366,7 +366,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -486,7 +486,7 @@ static int run(void)
 	//ft_finalize(fi, ep_array[0], scq, rcq, remote_fi_addr[0]);
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -267,13 +267,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -294,7 +294,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -460,7 +460,7 @@ static int run(void)
 out:
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -155,19 +155,19 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = rx_depth;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -179,13 +179,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err5;
@@ -273,7 +273,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -292,7 +292,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -459,7 +459,7 @@ static int run(void)
 	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -332,13 +332,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -371,7 +371,7 @@ err3:
 err2:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -463,7 +463,7 @@ out:
 	free_ep_res();
 	fi_close(&sep->fid);
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -152,7 +152,7 @@ static int alloc_ep_res(struct fid_ep *sep)
 			goto err1;
 		}
 
-		ret = fi_cq_open(dom, &cq_attr, &scq_array[i], NULL);
+		ret = fi_cq_open(domain, &cq_attr, &scq_array[i], NULL);
 		if (ret) {
 			FT_PRINTERR("fi_cq_open", ret);
 			goto err2;
@@ -167,14 +167,14 @@ static int alloc_ep_res(struct fid_ep *sep)
 			goto err3;
 		}
 
-		ret = fi_cq_open(dom, &cq_attr, &rcq_array[i], NULL);
+		ret = fi_cq_open(domain, &cq_attr, &rcq_array[i], NULL);
 		if (ret) {
 			FT_PRINTERR("fi_cq_open", ret);
 			goto err4;
 		}
 	}
 
-	ret = fi_mr_reg(dom, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err5;
@@ -191,7 +191,7 @@ static int alloc_ep_res(struct fid_ep *sep)
 	av_attr.rx_ctx_bits = rx_ctx_bits;
 
 	/* Open Address Vector */
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err6;
@@ -338,7 +338,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -348,7 +348,7 @@ static int init_fabric(void)
 	fi->ep_attr->tx_ctx_cnt = ctx_cnt;
 	fi->ep_attr->rx_ctx_cnt = ctx_cnt;
 
-	ret = fi_scalable_ep(dom, fi, &sep, NULL);
+	ret = fi_scalable_ep(domain, fi, &sep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_scalable_ep", ret);
 		goto err2;
@@ -369,7 +369,7 @@ err4:
 err3:
 	fi_close(&sep->fid);
 err2:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -462,7 +462,7 @@ static int run(void)
 out:
 	free_ep_res();
 	fi_close(&sep->fid);
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -251,7 +251,7 @@ static int alloc_cm_res(void)
 
 	memset(&cm_attr, 0, sizeof cm_attr);
 	cm_attr.wait_obj = FI_WAIT_FD;
-	ret = fi_eq_open(fab, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -383,13 +383,13 @@ static int server_listen(void)
 		return ret;
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_passive_ep(fab, fi, &pep, NULL);
+	ret = fi_passive_ep(fabric, fi, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
 		goto err1;
@@ -418,7 +418,7 @@ err3:
 err2:
 	fi_close(&pep->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	fi_freeinfo(fi);
 	return ret;
@@ -446,7 +446,7 @@ static int server_connect(void)
 	}
 
 	mr_mode = info->domain_attr->mr_mode;
-	ret = fi_domain(fab, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -515,14 +515,14 @@ static int client_connect(void)
 		goto err0;
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err1;
 	}
 
 	mr_mode = fi->domain_attr->mr_mode;
- 	ret = fi_domain(fab, fi, &dom, NULL);
+ 	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
@@ -570,7 +570,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err2:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err1:
 	fi_freeinfo(fi);
 err0:
@@ -647,7 +647,7 @@ out:
 	if (!opts.dst_addr)
 		free_lres();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -241,7 +241,7 @@ static int run_test(void)
 
 static void free_lres(void)
 {
-	fi_close(&cmeq->fid);
+	fi_close(&eq->fid);
 }
 
 static int alloc_cm_res(void)
@@ -251,7 +251,7 @@ static int alloc_cm_res(void)
 
 	memset(&cm_attr, 0, sizeof cm_attr);
 	cm_attr.wait_obj = FI_WAIT_FD;
-	ret = fi_eq_open(fabric, &cm_attr, &cmeq, NULL);
+	ret = fi_eq_open(fabric, &cm_attr, &eq, NULL);
 	if (ret)
 		FT_PRINTERR("fi_eq_open", ret);
 
@@ -317,7 +317,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		goto err3;
 	}
 
-	if (!cmeq) {
+	if (!eq) {
 		ret = alloc_cm_res();
 		if (ret)
 			goto err4;
@@ -340,7 +340,7 @@ static int bind_ep_res(void)
 {
 	int ret;
 
-	ret = fi_ep_bind(ep, &cmeq->fid, 0);
+	ret = fi_ep_bind(ep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -399,7 +399,7 @@ static int server_listen(void)
 	if (ret)
 		goto err2;
 
-	ret = fi_pep_bind(pep, &cmeq->fid, 0);
+	ret = fi_pep_bind(pep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_pep_bind", ret);
 		goto err3;
@@ -432,9 +432,9 @@ static int server_connect(void)
 	ssize_t rd;
 	int ret;
 
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "listen");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "listen");
 		return (int) rd;
 	}
 
@@ -473,9 +473,9 @@ static int server_connect(void)
 		goto err3;
 	}
 
-	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "accept");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "accept");
 		ret = (int) rd;
 		goto err3;
 	}
@@ -548,9 +548,9 @@ static int client_connect(void)
 		goto err4;
 	}
 
- 	rd = fi_eq_sread(cmeq, &event, &entry, sizeof entry, -1, 0);
+ 	rd = fi_eq_sread(eq, &event, &entry, sizeof entry, -1, 0);
 	if (rd != sizeof entry) {
-		FT_PROCESS_EQ_ERR(rd, cmeq, "fi_eq_sread", "connect");
+		FT_PROCESS_EQ_ERR(rd, eq, "fi_eq_sread", "connect");
 		ret = (int) rd;
 		goto err4;
 	}

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -285,13 +285,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -310,7 +310,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		ret = -FI_EINVAL;
 		goto err3;
 	}
-	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)),
+	ret = fi_mr_reg(domain, buf, MAX(buffer_size, sizeof(uint64_t)),
 			access_mode, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
@@ -446,14 +446,14 @@ static int server_connect(void)
 	}
 
 	mr_mode = info->domain_attr->mr_mode;
-	ret = fi_domain(fabric, info, &dom, NULL);
+	ret = fi_domain(fabric, info, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
 
-	ret = fi_endpoint(dom, info, &ep, NULL);
+	ret = fi_endpoint(domain, info, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", -ret);
 		goto err1;
@@ -522,13 +522,13 @@ static int client_connect(void)
 	}
 
 	mr_mode = fi->domain_attr->mr_mode;
- 	ret = fi_domain(fabric, fi, &dom, NULL);
+ 	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err2;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err3;
@@ -568,7 +568,7 @@ static int client_connect(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err2:
 	fi_close(&fabric->fid);
 err1:
@@ -646,7 +646,7 @@ out:
 	free_ep_res();
 	if (!opts.dst_addr)
 		free_lres();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -531,13 +531,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -558,7 +558,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -701,7 +701,7 @@ static int run(void)
 out:
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 
 	return ret;
 }

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -389,13 +389,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = 128;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -403,7 +403,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	// registers local data buffer buff that specifies
 	// the first operand of the atomic operation
-	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)),
+	ret = fi_mr_reg(domain, buf, MAX(buffer_size, sizeof(uint64_t)),
 		FI_REMOTE_READ | FI_REMOTE_WRITE, 0,
 		get_mr_key(), 0, &mr, NULL);
 	if (ret) {
@@ -413,7 +413,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	// registers local data buffer that stores initial value of
 	// the remote buffer
-	ret = fi_mr_reg(dom, result, MAX(buffer_size, sizeof(uint64_t)),
+	ret = fi_mr_reg(domain, result, MAX(buffer_size, sizeof(uint64_t)),
 		FI_REMOTE_READ | FI_REMOTE_WRITE, 0,
 		get_mr_key(), 0, &mr_result, NULL);
 	if (ret) {
@@ -422,7 +422,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	}
 
 	// registers local data buffer that contains comparison data
-	ret = fi_mr_reg(dom, compare, MAX(buffer_size, sizeof(uint64_t)),
+	ret = fi_mr_reg(domain, compare, MAX(buffer_size, sizeof(uint64_t)),
 		FI_REMOTE_READ | FI_REMOTE_WRITE, 0,
 		get_mr_key(), 0, &mr_compare, NULL);
 	if (ret) {
@@ -436,13 +436,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err6;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err7;
@@ -537,7 +537,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -556,7 +556,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -700,7 +700,7 @@ static int run(void)
 	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 
 	return ret;

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -82,7 +82,7 @@ int wait_for_send_completion(int num_completions)
 
 	while (num_completions > 0) {
 	 	memset(&comp, 0, sizeof(comp));
-		ret = fi_cq_read(scq, &comp, 1);
+		ret = fi_cq_read(txcq, &comp, 1);
 		if (ret > 0) {
 			num_completions--;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {
@@ -103,7 +103,7 @@ int wait_for_recv_completion(void **recv_data, enum data_type type,
 
 	while (num_completions > 0) {
 	 	memset(&comp, 0, sizeof(comp));
-		ret = fi_cq_read(rcq, &comp, 1);
+		ret = fi_cq_read(rxcq, &comp, 1);
 		if (ret > 0) {
  			header = (struct fi_ctx_multi_recv *)comp.op_context;
 			buf_index = header->index;
@@ -262,10 +262,10 @@ static void free_ep_res(void)
 		fi_close(&mr->fid);
 	if (mr_multi_recv)
 		fi_close(&mr_multi_recv->fid);
-	if (rcq)
-		fi_close(&rcq->fid);
-	if (scq)
-		fi_close(&scq->fid);
+	if (rxcq)
+		fi_close(&rxcq->fid);
+	if (txcq)
+		fi_close(&txcq->fid);
 
 	free(ctx_send);
 	free(ctx_multi_recv);
@@ -324,13 +324,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
 
-	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err4;
@@ -359,9 +359,9 @@ static int alloc_ep_res(struct fi_info *fi)
 err6:
 	fi_close(&av->fid);
 err5:
-	fi_close(&rcq->fid);
+	fi_close(&rxcq->fid);
 err4:
-	fi_close(&scq->fid);
+	fi_close(&txcq->fid);
 err3:
 	fi_close(&mr_multi_recv->fid);
 err2:
@@ -389,13 +389,13 @@ static int bind_ep_res(void)
 {
 	int ret;
 
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
 	}
 
-	ret = fi_ep_bind(ep, &rcq->fid, FI_RECV);
+	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;
@@ -566,7 +566,7 @@ static int run(void)
 
 	ret = run_test();
 	/* Finalize before closing ep */
-	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
+	ft_finalize(fi, ep, txcq, rxcq, remote_fi_addr);
 out:
 	free_ep_res();
 

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -297,7 +297,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		return -1;
 	}
 
-	ret = fi_mr_reg(dom, send_buf, max_send_buf_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, send_buf, max_send_buf_size, 0, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err1;
@@ -313,7 +313,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		goto err1;
 	}
 
-	ret = fi_mr_reg(dom, multi_recv_buf, multi_buf_size, 0, 0, 1, 0,
+	ret = fi_mr_reg(domain, multi_recv_buf, multi_buf_size, 0, 0, 1, 0,
 			&mr_multi_recv, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
@@ -324,13 +324,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err3;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err4;
@@ -342,13 +342,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err5;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err6;
@@ -448,7 +448,7 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -477,7 +477,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err3:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -570,8 +570,8 @@ static int run(void)
 out:
 	free_ep_res();
 
-	if (dom)
-		fi_close(&dom->fid);
+	if (domain)
+		fi_close(&domain->fid);
 	if (fabric)
 		fi_close(&fabric->fid);
 

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -442,13 +442,13 @@ static int init_fabric(void)
 	// set FI_MULTI_RECV flag for all recv operations
 	fi->rx_attr->op_flags = FI_MULTI_RECV;
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -479,7 +479,7 @@ err4:
 err3:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -572,8 +572,8 @@ out:
 
 	if (dom)
 		fi_close(&dom->fid);
-	if (fab)
-		fi_close(&fab->fid);
+	if (fabric)
+		fi_close(&fabric->fid);
 
 	return ret;
 }

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -362,13 +362,13 @@ static int init_fabric(void)
 		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto err0;
 	}
 
-	ret = fi_domain(fab, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &dom, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
@@ -395,7 +395,7 @@ err4:
 err2:
 	fi_close(&dom->fid);
 err1:
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 err0:
 	return ret;
 }
@@ -547,7 +547,7 @@ static int run(void)
 out:
 	free_ep_res();
 	fi_close(&dom->fid);
-	fi_close(&fab->fid);
+	fi_close(&fabric->fid);
 	return ret;
 }
 

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -251,13 +251,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(dom, &cq_attr, &scq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &scq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err1;
 	}
 
-	ret = fi_cq_open(dom, &cq_attr, &rcq, NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rcq, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_cq_open", ret);
 		goto err2;
@@ -276,7 +276,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		FT_PRINTERR("invalid op_type", ret);
 		exit(1);
 	}
-	ret = fi_mr_reg(dom, buf, MAX(buffer_size, sizeof(uint64_t)),
+	ret = fi_mr_reg(domain, buf, MAX(buffer_size, sizeof(uint64_t)),
 			access_mode, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
@@ -289,7 +289,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	av_attr.count = 1;
 	av_attr.name = NULL;
 
-	ret = fi_av_open(dom, &av_attr, &av, NULL);
+	ret = fi_av_open(domain, &av_attr, &av, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_av_open", ret);
 		goto err4;
@@ -368,13 +368,13 @@ static int init_fabric(void)
 		goto err0;
 	}
 
-	ret = fi_domain(fabric, fi, &dom, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err1;
 	}
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_endpoint", ret);
 		goto err2;
@@ -393,7 +393,7 @@ static int init_fabric(void)
 err4:
 	free_ep_res();
 err2:
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 err1:
 	fi_close(&fabric->fid);
 err0:
@@ -546,7 +546,7 @@ static int run(void)
 	ft_finalize(fi, ep, scq, rcq, remote_fi_addr);
 out:
 	free_ep_res();
-	fi_close(&dom->fid);
+	fi_close(&domain->fid);
 	fi_close(&fabric->fid);
 	return ret;
 }

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -88,10 +88,10 @@ static int teardown_ep_fixture(struct fid_ep *ep)
 			teardown_ret = ret;
 		}
 	}
-	if (rcq != NULL) {
-		ret = fi_close(&rcq->fid);
+	if (rxcq != NULL) {
+		ret = fi_close(&rxcq->fid);
 		if (ret != 0) {
-			printf("fi_close(rcq) %s\n", fi_strerror(-ret));
+			printf("fi_close(rxcq) %s\n", fi_strerror(-ret));
 			teardown_ret = ret;
 		}
 	}
@@ -146,7 +146,7 @@ static int setup_ep_fixture(struct fid_ep **ep_o)
 	cq_attr.wait_obj = FI_WAIT_NONE;
 	cq_attr.size = RX_CQ_DEPTH;
 
-	ret = fi_cq_open(domain, &cq_attr, &rcq, /*context=*/NULL);
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, /*context=*/NULL);
 	if (ret != 0) {
 		printf("fi_cq_open %s\n", fi_strerror(-ret));
 		goto fail;
@@ -170,9 +170,9 @@ static int setup_ep_fixture(struct fid_ep **ep_o)
 		goto fail;
 	}
 
-	ret = fi_ep_bind(*ep_o, &rcq->fid, FI_RECV);
+	ret = fi_ep_bind(*ep_o, &rxcq->fid, FI_RECV);
 	if (ret != 0) {
-		printf("fi_ep_bind(rcq) %s\n", fi_strerror(-ret));
+		printf("fi_ep_bind(rxcq) %s\n", fi_strerror(-ret));
 		goto fail;
 	}
 


### PR DESCRIPTION
This will make it easier to identify and remove duplicate code.