### PR TITLE
More updates to migrate fabtests to use common code

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -47,6 +47,9 @@ struct fid_mr *mr;
 struct fid_av *av;
 struct fid_eq *eq;
 
+struct cs_opts opts;
+
+
 struct test_size_param test_size[] = {
 	{ 1 <<  1, 1 }, { (1 <<  1) + (1 <<  0), 2},
 	{ 1 <<  2, 2 }, { (1 <<  2) + (1 <<  1), 2},

--- a/common/shared.c
+++ b/common/shared.c
@@ -42,6 +42,7 @@ struct fid_domain *domain;
 struct fid_pep *pep;
 struct fid_ep *ep;
 struct fid_cq *txcq, *rxcq;
+struct fid_cntr *txcntr, *rxcntr;
 struct fid_mr *mr;
 struct fid_av *av;
 struct fid_eq *eq;

--- a/common/shared.c
+++ b/common/shared.c
@@ -47,7 +47,7 @@ struct fid_mr *mr;
 struct fid_av *av;
 struct fid_eq *eq;
 
-struct cs_opts opts;
+struct ft_opts opts;
 
 
 struct test_size_param test_size[] = {
@@ -141,7 +141,7 @@ int ft_getdestaddr(char *node, char *service, struct fi_info *hints)
 }
 
 int ft_read_addr_opts(char **node, char **service, struct fi_info *hints,
-		uint64_t *flags, struct cs_opts *opts)
+		uint64_t *flags, struct ft_opts *opts)
 {
 	int ret;
 
@@ -218,7 +218,7 @@ int size_to_count(int size)
 		return 100000;
 }
 
-void init_test(struct cs_opts *opts, char *test_name, size_t test_name_len)
+void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len)
 {
 	char sstr[FT_STR_LEN];
 
@@ -497,7 +497,7 @@ void ft_parseinfo(int op, char *optarg, struct fi_info *hints)
 	}
 }
 
-void ft_parse_addr_opts(int op, char *optarg, struct cs_opts *opts)
+void ft_parse_addr_opts(int op, char *optarg, struct ft_opts *opts)
 {
 	switch (op) {
 	case 's':
@@ -515,7 +515,7 @@ void ft_parse_addr_opts(int op, char *optarg, struct cs_opts *opts)
 	}
 }
 
-void ft_parsecsopts(int op, char *optarg, struct cs_opts *opts)
+void ft_parsecsopts(int op, char *optarg, struct ft_opts *opts)
 {
 	ft_parse_addr_opts(op, optarg, opts);
 

--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -53,7 +53,6 @@ extern int listen_sock, sock;
 
 //extern struct fid_wait	 *waitset;
 //extern struct fid_poll	 *pollset;
-//extern struct fid_cntr	 *txcntr, *rxcntr;
 //extern struct fid_stx	 *stx;
 //extern struct fid_sep	 *sep;
 

--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -58,7 +58,6 @@ extern int listen_sock, sock;
 
 extern struct ft_info test_info;
 extern struct fi_info *fabric_info;
-extern struct cs_opts opts;
 
 extern size_t sm_size_array[];
 extern size_t med_size_array[];

--- a/complex/ft_comp.c
+++ b/complex/ft_comp.c
@@ -32,8 +32,6 @@
 #include "fabtest.h"
 
 
-//struct fid_cntr *txcntr, *rxcntr;
-
 static size_t comp_entry_cnt[] = {
 	[FI_CQ_FORMAT_UNSPEC] = 0,
 	[FI_CQ_FORMAT_CONTEXT] = FT_COMP_BUF_SIZE / sizeof(struct fi_cq_entry),

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -55,7 +55,6 @@ struct ft_info test_info;
 struct fi_info *fabric_info;
 struct ft_xcontrol ft_rx, ft_tx;
 struct ft_control ft;
-struct cs_opts opts;
 
 size_t recv_size, send_size;
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -65,9 +65,7 @@ enum precision {
 	MILLI = 1000000,
 };
 
-/* client-server common options and option parsing */
-
-struct cs_opts {
+struct ft_opts {
 	int iterations;
 	int transfer_size;
 	char *src_port;
@@ -98,12 +96,12 @@ extern struct fid_mr *mr;
 extern struct fid_av *av;
 extern struct fid_eq *eq;
 
-extern struct cs_opts opts;
+extern struct ft_opts opts;
 
 
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
-void ft_parse_addr_opts(int op, char *optarg, struct cs_opts *opts);
-void ft_parsecsopts(int op, char *optarg, struct cs_opts *opts);
+void ft_parse_addr_opts(int op, char *optarg, struct ft_opts *opts);
+void ft_parsecsopts(int op, char *optarg, struct ft_opts *opts);
 void ft_usage(char *name, char *desc);
 void ft_csusage(char *name, char *desc);
 void ft_fill_buf(void *buf, int size);
@@ -112,7 +110,7 @@ int ft_check_buf(void *buf, int size);
 #define INFO_OPTS "n:f:"
 #define CS_OPTS ADDR_OPTS "I:S:m"
 
-#define INIT_OPTS (struct cs_opts) { .iterations = 1000, \
+#define INIT_OPTS (struct ft_opts) { .iterations = 1000, \
 				     .transfer_size = 1024, \
 				     .src_port = "9228", \
 				     .dst_port = "9228", \
@@ -126,12 +124,12 @@ const unsigned int test_cnt;
 int ft_getsrcaddr(char *node, char *service, struct fi_info *hints);
 int ft_getdestaddr(char *node, char *service, struct fi_info *hints);
 int ft_read_addr_opts(char **node, char **service, struct fi_info *hints,
-		uint64_t *flags, struct cs_opts *opts);
+		uint64_t *flags, struct ft_opts *opts);
 char *size_str(char str[FT_STR_LEN], long long size);
 char *cnt_str(char str[FT_STR_LEN], long long cnt);
 int size_to_count(int size);
 
-void init_test(struct cs_opts *opts, char *test_name, size_t test_name_len);
+void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len);
 int ft_finalize(struct fi_info *fi, struct fid_ep *tx_ep, struct fid_cq *txcq,
 		struct fid_cq *rxcq, fi_addr_t addr);
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -93,6 +93,7 @@ extern struct fid_domain *domain;
 extern struct fid_pep *pep;
 extern struct fid_ep *ep;
 extern struct fid_cq *txcq, *rxcq;
+extern struct fid_cntr *txcntr, *rxcntr;
 extern struct fid_mr *mr;
 extern struct fid_av *av;
 extern struct fid_eq *eq;

--- a/include/shared.h
+++ b/include/shared.h
@@ -98,6 +98,8 @@ extern struct fid_mr *mr;
 extern struct fid_av *av;
 extern struct fid_eq *eq;
 
+extern struct cs_opts opts;
+
 
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
 void ft_parse_addr_opts(int op, char *optarg, struct cs_opts *opts);

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -41,7 +41,7 @@
 
 #include "shared.h"
 
-static struct cs_opts opts;
+
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -46,12 +46,10 @@ static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";
 static struct timespec start, end;
+static void *buf;
 static void *recv_buf;
 static void *send_buf;
 static size_t buffer_size;
-
-static struct fid_mr *recv_mr;
-static struct fid_mr *send_mr;
 
 static int verify_data = 0;
 
@@ -79,7 +77,7 @@ post:
 	if (verify_data)
 		ft_fill_buf(send_buf, size);
 
-	ret = fi_send(ep, send_buf, (size_t) size, fi_mr_desc(send_mr), 0, NULL);
+	ret = fi_send(ep, send_buf, (size_t) size, fi_mr_desc(mr), 0, NULL);
 	if (ret)
 		FT_PRINTERR("fi_send", ret);
 
@@ -109,7 +107,7 @@ static int recv_xfer(int size)
 			return ret;
 	}
 
-	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(recv_mr), 0, recv_buf);
+	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), 0, recv_buf);
 	if (ret)
 		FT_PRINTERR("fi_recv", ret);
 
@@ -186,12 +184,10 @@ static int alloc_cm_res(void)
 static void free_ep_res(void)
 {
 	fi_close(&ep->fid);
-	fi_close(&recv_mr->fid);
-	fi_close(&send_mr->fid);
+	fi_close(&mr->fid);
 	fi_close(&rxcq->fid);
 	fi_close(&txcq->fid);
-	free(recv_buf);
-	free(send_buf);
+	free(buf);
 }
 
 static int alloc_ep_res(struct fi_info *fi)
@@ -202,17 +198,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	buffer_size = opts.user_options & FT_OPT_SIZE ?
 			opts.transfer_size : test_size[TEST_CNT - 1].size;
 
-	recv_buf = malloc(buffer_size);
-	if (!recv_buf) {
+	buf = malloc(buffer_size * 2);
+	if (!buf) {
 		perror("malloc");
 		return -1;
 	}
 
-	send_buf = malloc(buffer_size);
-	if (!send_buf) {
-		perror("malloc");
-		return -1;
-	}
+	recv_buf = buf;
+	send_buf = (char *) buf + buffer_size;
 
 	memset(&cq_attr, 0, sizeof cq_attr);
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
@@ -230,13 +223,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		goto err2;
 	}
 
-	ret = fi_mr_reg(domain, recv_buf, buffer_size, FI_RECV, 0, 0, 0, &recv_mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		goto err3;
-	}
-
-	ret = fi_mr_reg(domain, send_buf, buffer_size, FI_SEND, 0, 1, 0, &send_mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;
@@ -257,15 +244,13 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 
 err4:
-	fi_close(&recv_mr->fid);
-	fi_close(&send_mr->fid);
+	fi_close(&mr->fid);
 err3:
 	fi_close(&rxcq->fid);
 err2:
 	fi_close(&txcq->fid);
 err1:
-	free(recv_buf);
-	free(send_buf);
+	free(buf);
 	return ret;
 }
 
@@ -298,7 +283,7 @@ static int bind_ep_res(void)
 	}
 
 	/* Post the first recv buffer */
-	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(recv_mr), 0, recv_buf);
+	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), 0, recv_buf);
 	if (ret)
 		FT_PRINTERR("fi_recv", ret);
 

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -41,7 +41,7 @@
 #include <rdma/fi_cm.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static int max_credits = 128;
 static int credits = 128;
 static int send_count = 0;

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -42,7 +42,7 @@
 
 #include "shared.h"
 
-static struct cs_opts opts;
+
 static int max_inject_size;
 static int max_credits = 128;
 static char test_name[10] = "custom";

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -42,7 +42,7 @@
 
 #include "shared.h"
 
-static struct cs_opts opts;
+
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -341,7 +341,6 @@ static int bind_ep_res(void)
 
 static int init_fabric(void)
 {
-	struct fi_info *fi;
 	uint64_t flags = 0;
 	char *node, *service;
 	int ret;

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -43,7 +43,7 @@
 
 #include "shared.h"
 
-static struct cs_opts opts;
+
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -47,7 +47,7 @@
 
 #include "shared.h"
 
-static struct cs_opts opts;
+
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -423,8 +423,6 @@ static void usage(char *argv0)
 
 int main(int argc, char *argv[])
 {
-	struct 		fi_info				*info;
-	struct 		fi_info 			*hints;
 	uint64_t 	flags 				= 0;
 	char 		*service 			= NULL;
 	char 		*node 				= NULL;
@@ -513,14 +511,14 @@ int main(int argc, char *argv[])
 	if (rc)
 		return 1;
 	
-	rc = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &info);
+	rc = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (rc) {
 		FT_PRINTERR("fi_getinfo", rc);
 		return -rc;
 	}
 	fi_freeinfo(hints);
 
-	ctx = pp_init_ctx(info, size, rx_depth, use_event);
+	ctx = pp_init_ctx(fi, size, rx_depth, use_event);
 	if (!ctx)
 		return 1;
 

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -65,7 +65,6 @@
 	} while (0)
 
 static int page_size;
-static struct cs_opts opts;
 
 enum {
 	PINGPONG_RECV_WCID = 1,

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -65,7 +65,6 @@ enum CQ_INDEX {
 	RECV_CQ_INDEX
 };
 
-static struct cs_opts 		opts;
 static struct cma_node		*nodes;
 static int			conn_index;
 static int			connects_left;

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -71,8 +71,6 @@ static int			connects_left;
 static int			disconnects_left;
 static int			connections = 1;
 
-static struct fi_info		*info;
-
 
 static int post_recvs(struct cma_node *node)
 {
@@ -105,7 +103,7 @@ static int create_messages(struct cma_node *node)
 		return -1;
 	}
 
-	if (info->mode & FI_LOCAL_MR) {
+	if (fi->mode & FI_LOCAL_MR) {
 		ret = fi_mr_reg(node->domain, node->mem, hints->ep_attr->max_msg_size,
 				FI_SEND | FI_RECV, 0, 0, 0, &node->mr, NULL);
 		if (ret) {
@@ -240,7 +238,7 @@ static int alloc_nodes(void)
 	for (i = 0; i < connections; i++) {
 		nodes[i].id = i;
 		if (opts.dst_addr) {
-			ret = init_node(nodes + i, info);
+			ret = init_node(nodes + i, fi);
 			if (ret)
 				goto err;
 		}
@@ -394,7 +392,7 @@ static int run_server(void)
 	int i, ret;
 
 	printf("cmatose: starting server\n");
-	ret = fi_passive_ep(fabric, info, &pep, NULL);
+	ret = fi_passive_ep(fabric, fi, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
 		return ret;
@@ -462,7 +460,7 @@ static int run_client(void)
 
 	printf("cmatose: connecting\n");
 	for (i = 0; i < connections; i++) {
-		ret = fi_connect(nodes[i].ep, info->dest_addr, NULL, 0);
+		ret = fi_connect(nodes[i].ep, fi->dest_addr, NULL, 0);
 		if (ret) {
 			FT_PRINTERR("fi_connect", ret);
 			connects_left--;
@@ -567,14 +565,14 @@ int main(int argc, char **argv)
 	if (ret)
 		return ret;
 
-	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &info);
+	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		goto exit0;
 	}
 
-	printf("using provider: %s\n", info->fabric_attr->prov_name);
-	ret = fi_fabric(info->fabric_attr, &fabric, NULL);
+	printf("using provider: %s\n", fi->fabric_attr->prov_name);
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		goto exit1;
@@ -602,7 +600,7 @@ exit3:
 exit2:
 	fi_close(&fabric->fid);
 exit1:
-	fi_freeinfo(info);
+	fi_freeinfo(fi);
 exit0:
 	fi_freeinfo(hints);
 	return -ret;

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -172,7 +172,6 @@ static int bind_ep_res(void)
 
 static int server_listen(void)
 {
-	struct fi_info *fi;
 	int ret;
 
 	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.src_port, FI_SOURCE, hints,
@@ -296,7 +295,6 @@ static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *fi;
 	ssize_t rd;
 	int ret;
 

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -41,7 +41,7 @@
 #include <rdma/fi_cm.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size;
 static int rx_depth = 500;

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -41,7 +41,7 @@
 #include <rdma/fi_cm.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -41,7 +41,7 @@
 #include <rdma/fi_cm.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static int transfer_size = 1000;

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -151,7 +151,6 @@ static int bind_ep_res(void)
 
 static int server_listen(void)
 {
-	struct fi_info *fi;
 	int ret;
 
 	/* Get fabric info */
@@ -279,7 +278,6 @@ static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *fi;
 	ssize_t rd;
 	int ret;
 

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -37,7 +37,7 @@
 
 #include "shared.h"
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -208,7 +208,6 @@ static int bind_ep_res(void)
 
 static int server_listen(void)
 {
-	struct fi_info *fi;
 	int ret;
 
 	/* Get fabric info */
@@ -337,7 +336,6 @@ static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *fi;
 	ssize_t rd;
 	int ret;
 

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -42,7 +42,7 @@
 #include <rdma/fi_cm.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -354,7 +354,6 @@ static int client_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *fi;
 	ssize_t rd;
 	int ret;
 
@@ -493,7 +492,6 @@ static int setup_handle(void)
 {
 	static char buf[BUFSIZ];
 	struct addrinfo *ai, aihints;
-	struct fi_info *fi;
 	int ret;
 
 	memset(&aihints, 0, sizeof aihints);

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -41,7 +41,7 @@
 
 #include "shared.h"
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -48,7 +48,7 @@ enum comp_type {
 	CQ_RECV = 2
 };
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static int transfer_size = 1000;

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -41,7 +41,7 @@
 #include <rdma/fi_cm.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -42,7 +42,7 @@
 #include <rdma/fi_errno.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size;
 struct fi_rma_iov local, remote;

--- a/simple/rdm_rma_trigger.c
+++ b/simple/rdm_rma_trigger.c
@@ -43,7 +43,7 @@
 #include <rdma/fi_trigger.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size;
 

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -49,7 +49,7 @@
 		}				\
 	} while (0)
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static size_t transfer_size = 1000;

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -43,7 +43,7 @@
 #include <rdma/fi_tagged.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static int rx_depth = 512;

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -51,7 +51,7 @@
 		}				\
 	} while (0)
 
-static struct cs_opts opts;
+
 static void *buf;
 static size_t buffer_size = 1024;
 static size_t transfer_size = 1000;

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -43,7 +43,6 @@
 #include <shared.h>
 
 static enum ft_rma_opcodes op_type = FT_RMA_WRITE;
-static struct cs_opts opts;
 static int max_credits = 128;
 static int credits = 128;
 static char test_name[10] = "custom";

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -54,7 +54,7 @@
 
 #include "shared.h"
 
-static struct cs_opts opts;
+
 static enum fi_op op_type = FI_MIN;
 static char test_name[10] = "custom";
 static struct timespec start, end;

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -50,7 +50,7 @@
 #define DEFAULT_MULTI_BUF_SIZE 1024*1024
 #define SYNC_DATA_SIZE 16
 
-static struct cs_opts opts;
+
 static int max_credits = 128;
 static char test_name[10] = "custom";
 static struct timespec start, end;

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -43,7 +43,7 @@
 #include <rdma/fi_errno.h>
 #include <shared.h>
 
-static struct cs_opts opts;
+
 static uint64_t op_type = FT_RMA_WRITE;
 static int max_credits = 128;
 static char test_name[10] = "custom";

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -410,7 +410,6 @@ struct test_entry test_array[] = {
 int main(int argc, char **argv)
 {
 	int op, ret;
-	struct fi_info *fi;
 	int failed;
 
 	hints = fi_allocinfo();

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -241,12 +241,9 @@ rx_size_left_err(void)
 	int ret;
 	int testret;
 	struct fid_ep *ep;
-	struct fi_info *myfi;
 
 	testret = FAIL;
 	ep = NULL;
-
-	myfi = fi_dupinfo(fi);
 
 	/* datapath operation, not expected to be caught by libfabric */
 #if 0
@@ -256,7 +253,7 @@ rx_size_left_err(void)
 	}
 #endif
 
-	ret = fi_endpoint(domain, myfi, &ep, NULL);
+	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret != 0) {
 		printf("fi_endpoint %s\n", fi_strerror(-ret));
 		goto fail;
@@ -272,9 +269,6 @@ fail:
 		if (ret != 0)
 			printf("fi_close %s\n", fi_strerror(-ret));
 		ep = NULL;
-	}
-	if (myfi != NULL) {
-		fi_freeinfo(myfi);
 	}
 	return testret;
 }


### PR DESCRIPTION
These patches help to migrate fabtests to where more of the code can be shared between the different tests.

1. msg_pingpong uses 2 MRs.  Whereas all other tests only use 1.  Move to using 1 MR.
2. Move fid_cntr variables into shared code.
3. Move cs_opts variable into shared code.
4. Rename cs_opts structure to ft_opts
5. Eliminate a few stragglers to use the global fi_info definitions
6. Cleanup size_left_test to use global fi_info, rather than duplicate it.