### PR TITLE
msg_pingpong: Fix memory registration call

### DIFF
--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -223,7 +223,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		goto err2;
 	}
 
-	ret = fi_mr_reg(domain, buf, buffer_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buffer_size * 2, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		goto err3;


### PR DESCRIPTION
Commit e121c2616aabdf57a620b523e534c9120760fc2c replaced 2 memory
regions with one.  However, it did not adjust the size of the
memory region.  Ensure that the entire buffer has been registered.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>