### PR TITLE
Correct error strings on EAI_SYSTEM

### DIFF
--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -104,9 +104,8 @@ sockaddrstr(const union sockaddr_any *addr, socklen_t len, char *buf, size_t buf
 		if (errcode != EAI_SYSTEM) {
 			fprintf(stderr, "getnameinfo: %s\n", gai_strerror(errcode));
 		} else {
-			fprintf(stderr, "getnameinfo: %s\n", strerror(errcode));
+			fprintf(stderr, "getnameinfo: %s\n", strerror(errno));
 		}
-		errno = errcode;
 		return NULL;
 	}
 
@@ -498,7 +497,8 @@ static int setup_handle(void)
 	aihints.ai_flags = AI_PASSIVE;
 	ret = getaddrinfo(opts.src_addr, opts.src_port, &aihints, &ai);
 	if (ret == EAI_SYSTEM) {
-		FT_PRINTERR("getaddrinfo", -ret);
+		fprintf("getaddrinfo for %s:%s: %s\n",
+				opts.src_addr, opts.src_port, strerror(errno));
 		return -ret;
 	} else if (ret) {
 		FT_ERR("getaddrinfo: %s\n", gai_strerror(ret));


### PR DESCRIPTION
The error return EAI_SYSTEM for getaddrinfo() and getnameinfo()
indicates that the user should check errno for the cause of the error.
This test previously did the wrong thing everywhere that EAI_SYSTEM could
be returned, and this commit fixes the code to print the correct error
string using strerror(errno).

This commit fixes Coverity CID 131051.

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>