### PR TITLE
Used shared call to bind resources to an EP

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -153,6 +153,7 @@ int size_to_count(int size);
 		}				\
 	} while (0)
 
+int ft_init_ep(void *recv_ctx);
 void ft_free_res();
 void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len);
 int ft_finalize(struct fi_info *fi, struct fid_ep *tx_ep, struct fid_cq *txcq,

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -258,37 +258,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcntr->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcntr->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -328,7 +297,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -228,37 +228,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -306,7 +275,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -247,37 +247,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -317,7 +286,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -277,44 +277,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	/* Post the first recv buffer */
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -354,7 +316,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(&fi_ctx_recv);
 	if (ret)
 		return ret;
 

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -239,44 +239,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	/* Post the first recv buffer */
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-	}
-
-	return ret;
-}
-
-
 static int common_setup(void)
 {
 	int ret;
@@ -316,7 +278,7 @@ static int common_setup(void)
 		return ret;
 	}
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(buf);
 	if (ret) {
 		return ret;
 	}

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -110,41 +110,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &eq->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret)
-		return ret;
-
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int server_listen(void)
 {
 	int ret;
@@ -220,7 +185,7 @@ static int server_connect(void)
 	if (ret)
 		 goto err;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(buf);
 	if (ret)
 		goto err;
 
@@ -288,7 +253,7 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(buf);
 	if (ret)
 		return ret;
 

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -113,39 +113,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind Recv CQ with endpoint to collect recv completions */
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind AV with the endpoint to map addresses */
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	 }
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	char *node, *service;
@@ -188,7 +155,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -124,37 +124,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	/* Bind AV and CQs with endpoint */
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	return ret;
-}
 
 static int send_msg(int size)
 {
@@ -226,7 +195,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -100,34 +100,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	/* Bind EQ with endpoint */
-	ret = fi_ep_bind(ep, &eq->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind Recv CQ with endpoint to collect recv completions */
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int server_listen(void)
 {
 	int ret;
@@ -207,7 +179,7 @@ static int server_connect(void)
 	if (ret)
 		 goto err;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		goto err;
 
@@ -277,7 +249,7 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -154,34 +154,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	/* Bind EQ with endpoint */
-	ret = fi_ep_bind(ep, &eq->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind Recv CQ with endpoint to collect recv completions */
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int server_listen(void)
 {
 	int ret;
@@ -261,7 +233,7 @@ static int server_connect(void)
 	if (ret)
 		 goto err;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		goto err;
 
@@ -332,7 +304,7 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -196,34 +196,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	/* Bind EQ with endpoint */
-	ret = fi_ep_bind(ep, &eq->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind Recv CQ with endpoint to collect recv completions */
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int server_listen(void)
 {
 	int ret;
@@ -282,7 +254,7 @@ static int server_connect(void)
 	if (ret)
 		 goto err;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		goto err;
 
@@ -362,7 +334,7 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -143,38 +143,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	/* Bind AV and CQs with endpoint */
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int send_msg(int size)
 {
 	int ret;
@@ -245,7 +213,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -113,39 +113,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind Recv CQ with endpoint to collect recv completions */
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Bind AV with the endpoint to map addresses */
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	 }
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	char *node, *service;
@@ -188,7 +155,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -128,39 +128,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcntr->fid, FI_WRITE);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Use FI_REMOTE_WRITE flag so that remote side can get completion event
-	 *  for RMA write operation */
-	ret = fi_ep_bind(ep, &rxcntr->fid, FI_REMOTE_WRITE);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	char *node, *service;
@@ -199,7 +166,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/simple/rdm_rma_trigger.c
+++ b/simple/rdm_rma_trigger.c
@@ -152,39 +152,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcntr->fid, FI_WRITE);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	/* Use FI_REMOTE_WRITE flag so that remote side can get completion event
-	 *  for RMA write operation */
-	ret = fi_ep_bind(ep, &rxcntr->fid, FI_REMOTE_WRITE);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	char *node, *service;
@@ -223,7 +190,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -182,44 +182,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	/* Post a recv buffer for synchronization */
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -259,7 +221,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(&fi_ctx_recv);
 	if (ret)
 		return ret;
 

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -308,42 +308,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &eq->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	/* Post the first recv buffer */
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
-	if (ret)
-		FT_PRINTERR("fi_recv", ret);
-
-	return ret;
-}
-
 static int server_listen(void)
 {
 	int ret;
@@ -425,7 +389,7 @@ static int server_connect(void)
 	if (ret)
 		 goto err;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(buf);
 	if (ret)
 		goto err;
 
@@ -498,7 +462,7 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(buf);
 	if (ret)
 		return ret;
 

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -449,44 +449,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND | FI_READ | FI_WRITE);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", -ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", -ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if(ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	/* Post the first recv buffer */
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -526,7 +488,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(&fi_ctx_recv);
 	if (ret)
 		return ret;
 

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -368,37 +368,6 @@ static int set_min_multi_recv()
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -441,7 +410,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -286,37 +286,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-static int bind_ep_res(void)
-{
-	int ret;
-
-	ret = fi_ep_bind(ep, &txcq->fid, FI_SEND);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_ep_bind(ep, &av->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
-	}
-
-	ret = fi_enable(ep);
-	if (ret) {
-		FT_PRINTERR("fi_enable", ret);
-		return ret;
-	}
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -362,7 +331,7 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = bind_ep_res();
+	ret = ft_init_ep(NULL);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
Create a shared version of bind_ep_res(), which is duplicated
by most apps to some degree.  There are a couple of instances
where a shared call cannot easily be used, such as the scalable
endpoint test.  Those are left unchanged.

About half the apps post an initial receive buffer in
bind_ep_res().  Use a parameter to indicate if a receive
should be posted.  Subsequent work will examine if all apps
can be made consistent in this area.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>