### PR TITLE
Extract some pingpong functionality into common space

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -122,11 +122,13 @@ streaming_fi_rdm_rma_SOURCES = \
 streaming_fi_rdm_rma_LDADD = libfabtests.la
 
 pingpong_fi_msg_pingpong_SOURCES = \
-	pingpong/msg_pingpong.c
+	pingpong/msg_pingpong.c \
+	pingpong/pingpong_shared.c
 pingpong_fi_msg_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_ud_pingpong_SOURCES = \
-	pingpong/ud_pingpong.c
+	pingpong/ud_pingpong.c \
+	pingpong/pingpong_shared.c
 pingpong_fi_ud_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_rdm_cntr_pingpong_SOURCES = \
@@ -134,7 +136,8 @@ pingpong_fi_rdm_cntr_pingpong_SOURCES = \
 pingpong_fi_rdm_cntr_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_rdm_pingpong_SOURCES = \
-	pingpong/rdm_pingpong.c
+	pingpong/rdm_pingpong.c \
+	pingpong/pingpong_shared.c
 pingpong_fi_rdm_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_rdm_tagged_pingpong_SOURCES = \

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -49,18 +49,18 @@ static int run_test()
 {
 	int ret, i;
 
-	ret = sync_test();
+	ret = sync_test(false);
 	if (ret)
 		return ret;
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	for (i = 0; i < opts.iterations; i++) {
 		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
-				 recv_xfer(opts.transfer_size);
+				 recv_xfer(opts.transfer_size, false);
 		if (ret)
 			return ret;
 
-		ret = opts.dst_addr ? recv_xfer(opts.transfer_size) :
+		ret = opts.dst_addr ? recv_xfer(opts.transfer_size, false) :
 				 send_xfer(opts.transfer_size);
 		if (ret)
 			return ret;

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -160,6 +160,9 @@ static int server_listen(void)
 		return ret;
 	}
 
+	if (fi->mode & FI_MSG_PREFIX)
+		prefix_len = fi->ep_attr->msg_prefix_size;
+
 	ret = fi_passive_ep(fabric, fi, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
@@ -272,6 +275,9 @@ static int client_connect(void)
 		return ret;
 	}
 
+	if (fi->mode & FI_MSG_PREFIX)
+		prefix_len = fi->ep_attr->msg_prefix_size;
+
 	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
@@ -358,19 +364,18 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "vh" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS PONG_OPTS)) !=
+			-1) {
 		switch (op) {
-		case 'v':
-			verify_data = 1;
-			break;
 		default:
+			ft_parsepongopts(op);
 			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
 			break;
 		case '?':
 		case 'h':
 			ft_csusage(argv[0], "Ping pong client and server using message endpoints.");
-			FT_PRINT_OPTS_USAGE("-v", "enables data_integrity checks");
+			ft_pongusage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/pingpong/pingpong_shared.c
+++ b/pingpong/pingpong_shared.c
@@ -71,6 +71,22 @@ int send_xfer(int size)
 	return ret;
 }
 
+int send_msg(int size)
+{
+	int ret;
+
+	ret = fi_send(ep, send_buf, (size_t) size, fi_mr_desc(mr),
+			remote_fi_addr, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_send", ret);
+		return ret;
+	}
+
+	ret = wait_for_completion(txcq, 1);
+
+	return ret;
+}
+
 int recv_xfer(int size)
 {
 	int ret;
@@ -89,6 +105,21 @@ int recv_xfer(int size)
 			NULL);
 	if (ret)
 		FT_PRINTERR("fi_recv", ret);
+
+	return ret;
+}
+
+int recv_msg(void)
+{
+	int ret;
+
+	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), 0, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_recv", ret);
+		return ret;
+	}
+
+	ret = wait_for_completion(rxcq, 1);
 
 	return ret;
 }

--- a/pingpong/pingpong_shared.c
+++ b/pingpong/pingpong_shared.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+
+#include "shared.h"
+#include "pingpong_shared.h"
+
+fi_addr_t remote_fi_addr;
+int max_credits = 128;
+size_t prefix_len;
+int credits = 128;
+int verify_data;
+void *send_buf;
+void *recv_buf;
+
+int send_xfer(int size)
+{
+	int ret;
+
+	if (!credits) {
+		ret = wait_for_completion(txcq, 1);
+		if (ret)
+			return ret;
+	} else {
+		credits--;
+	}
+
+	if (verify_data)
+		ft_fill_buf(send_buf, size);
+
+	ret = fi_send(ep, send_buf, (size_t) size + prefix_len, fi_mr_desc(mr),
+			remote_fi_addr, NULL);
+	if (ret)
+		FT_PRINTERR("fi_send", ret);
+
+	return ret;
+}
+
+int recv_xfer(int size)
+{
+	int ret;
+
+	ret = wait_for_completion(rxcq, 1);
+	if (ret)
+		return ret;
+
+	if (verify_data) {
+		ret = ft_check_buf(recv_buf, size);
+		if (ret)
+			return ret;
+	}
+
+	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
+			NULL);
+	if (ret)
+		FT_PRINTERR("fi_recv", ret);
+
+	return ret;
+}
+
+int sync_test(void)
+{
+	int ret;
+
+	ret = wait_for_completion(txcq, max_credits - credits);
+	if (ret)
+		return ret;
+	credits = max_credits;
+
+	ret = opts.dst_addr ? send_xfer(16) : recv_xfer(16);
+	if (ret)
+		return ret;
+
+	return opts.dst_addr ? recv_xfer(16) : send_xfer(16);
+}

--- a/pingpong/pingpong_shared.h
+++ b/pingpong/pingpong_shared.h
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+#define PONG_OPTS "vP"
+
 extern fi_addr_t remote_fi_addr;
 extern int max_credits;
 extern int credits;
@@ -44,6 +46,9 @@ extern size_t prefix_len;
 extern int verify_data;
 extern void *send_buf;
 extern void *recv_buf;
+
+void ft_parsepongopts(int op);
+void ft_pongusage(void);
 
 int send_xfer(int size);
 int send_msg(int size);

--- a/pingpong/pingpong_shared.h
+++ b/pingpong/pingpong_shared.h
@@ -46,7 +46,9 @@ extern void *send_buf;
 extern void *recv_buf;
 
 int send_xfer(int size);
+int send_msg(int size);
 int recv_xfer(int size);
+int recv_msg(void);
 int sync_test(void);
 
 #ifdef __cplusplus

--- a/pingpong/pingpong_shared.h
+++ b/pingpong/pingpong_shared.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _PINGPONG_SHARED_H_
+#define _PINGPONG_SHARED_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern fi_addr_t remote_fi_addr;
+extern int max_credits;
+extern int credits;
+extern size_t prefix_len;
+extern int verify_data;
+extern void *send_buf;
+extern void *recv_buf;
+
+int send_xfer(int size);
+int recv_xfer(int size);
+int sync_test(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PINGPONG_SHARED_H_ */

--- a/pingpong/pingpong_shared.h
+++ b/pingpong/pingpong_shared.h
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
+
 #define PONG_OPTS "vP"
 
 extern fi_addr_t remote_fi_addr;
@@ -46,15 +48,18 @@ extern size_t prefix_len;
 extern int verify_data;
 extern void *send_buf;
 extern void *recv_buf;
+extern int timeout;
 
 void ft_parsepongopts(int op);
 void ft_pongusage(void);
 
+int wait_for_completion_timeout(struct fid_cq *cq, int num_completions);
+
 int send_xfer(int size);
 int send_msg(int size);
-int recv_xfer(int size);
-int recv_msg(void);
-int sync_test(void);
+int recv_xfer(int size, bool enable_timeout);
+int recv_msg(int size, bool enable_timeout);
+int sync_test(bool enable_timeout);
 
 #ifdef __cplusplus
 }

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -53,18 +53,18 @@ static int run_test(void)
 {
 	int ret, i;
 
-	ret = sync_test();
+	ret = sync_test(false);
 	if (ret)
 		goto out;
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	for (i = 0; i < opts.iterations; i++) {
 		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
-				 recv_xfer(opts.transfer_size);
+				 recv_xfer(opts.transfer_size, false);
 		if (ret)
 			goto out;
 
-		ret = opts.dst_addr ? recv_xfer(opts.transfer_size) :
+		ret = opts.dst_addr ? recv_xfer(opts.transfer_size, false) :
 				 send_xfer(opts.transfer_size);
 		if (ret)
 			goto out;
@@ -227,13 +227,13 @@ static int init_av(void)
 			return ret;
 
 		/* Receive ACK from server */
-		ret = recv_msg();
+		ret = recv_msg(16, false);
 		if (ret)
 			return ret;
 
 	} else {
 		/* Post a recv to get the remote address */
-		ret = recv_msg();
+		ret = recv_msg(buffer_size, false);
 		if (ret)
 			return ret;
 

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -171,6 +171,9 @@ static int init_fabric(void)
 		return ret;
 	}
 
+	if (fi->mode & FI_MSG_PREFIX)
+		prefix_len = fi->ep_attr->msg_prefix_size;
+
 	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
@@ -305,15 +308,18 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS PONG_OPTS)) !=
+			-1) {
 		switch (op) {
 		default:
+			ft_parsepongopts(op);
 			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
 			break;
 		case '?':
 		case 'h':
 			ft_csusage(argv[0], "Ping pong client and server using RDM.");
+			ft_pongusage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -49,37 +49,6 @@ static struct timespec start, end;
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
 
-static int send_msg(int size)
-{
-	int ret;
-
-	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-			NULL);
-	if (ret) {
-		FT_PRINTERR("fi_send", ret);
-		return ret;
-	}
-
-	ret = wait_for_completion(txcq, 1);
-
-	return ret;
-}
-
-static int recv_msg(void)
-{
-	int ret;
-
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-
-	ret = wait_for_completion(rxcq, 1);
-
-	return ret;
-}
-
 static int run_test(void)
 {
 	int ret, i;

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -52,24 +52,23 @@ static char test_name[10] = "custom";
 static struct timespec start, end;
 static void *payload;
 static size_t max_msg_size = 0;
-static int timeout = 5;
 
 static int run_test(void)
 {
 	int ret, i;
 
-	ret = sync_test();
+	ret = sync_test(true);
 	if (ret)
 		return ret;
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	for (i = 0; i < opts.iterations; i++) {
 		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
-				 recv_xfer(opts.transfer_size);
+				 recv_xfer(opts.transfer_size, true);
 		if (ret)
 			return ret;
 
-		ret = opts.dst_addr ? recv_xfer(opts.transfer_size) :
+		ret = opts.dst_addr ? recv_xfer(opts.transfer_size, true) :
 				 send_xfer(opts.transfer_size);
 		if (ret)
 			return ret;
@@ -225,7 +224,7 @@ static int client_connect(void)
 		return ret;
 
 	// wait for reply to know server is ready
-	ret = recv_msg();
+	ret = recv_msg(4, true);
 	if (ret != 0)
 		return ret;
 
@@ -326,6 +325,8 @@ int main(int argc, char **argv)
 {
 	int ret, op;
 	opts = INIT_OPTS;
+
+	timeout = 5;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -174,9 +174,9 @@ static int common_setup(void)
 		FT_PRINTERR("fi_fabric", ret);
 		return ret;
 	}
-	if (fi->mode & FI_MSG_PREFIX) {
+
+	if (fi->mode & FI_MSG_PREFIX)
 		prefix_len = fi->ep_attr->msg_prefix_size;
-	}
 
 	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
@@ -331,24 +331,23 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "ht:P" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "ht:" CS_OPTS INFO_OPTS PONG_OPTS)) !=
+			-1) {
 		switch (op) {
-		case 'P':
-			hints->mode |= FI_MSG_PREFIX;
-			break;
 		case 't':
 			timeout = atoi(optarg);
 			break;
 		default:
+			ft_parsepongopts(op);
 			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
 			break;
 		case '?':
 		case 'h':
 			ft_csusage(argv[0], "Ping pong client and server using UD.");
+			ft_pongusage();
 			FT_PRINT_OPTS_USAGE("-t <timeout>",
 					"seconds before timeout on receive");
-			FT_PRINT_OPTS_USAGE("-P", "enable prefix mode");
 			return EXIT_FAILURE;
 		}
 	}

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -220,12 +220,12 @@ static int client_connect(void)
 		return ret;
 	}
 
-	ret = send_xfer(addrlen);
+	ret = send_msg(addrlen);
 	if (ret != 0)
 		return ret;
 
 	// wait for reply to know server is ready
-	ret = recv_xfer(4);
+	ret = recv_msg();
 	if (ret != 0)
 		return ret;
 
@@ -278,11 +278,9 @@ static int server_connect(void)
 		return ret;
 	}
 
-	ret = send_xfer(4);
-	if (ret != 0)
-		return ret;
+	ret = send_msg(4);
 
-	return 0;
+	return ret;
 }
 
 static int run(void)

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -60,7 +60,8 @@ short_tests=(
 )
 
 standard_tests=(
-	"msg_pingpong"
+	"msg_pingpong -v"
+	"msg_pingpong -P -v"
 	"msg_rma -o write"
 	"msg_rma -o read"
 	"msg_rma -o writedata"
@@ -68,13 +69,14 @@ standard_tests=(
 	"rdm_cntr_pingpong"
 	"rdm_inject_pingpong"
 	"rdm_multi_recv"
-	"rdm_pingpong"
+	"rdm_pingpong -v"
+	"rdm_pingpong -P -v"
 	"rdm_rma -o write"
 	"rdm_rma -o read"
 	"rdm_rma -o writedata"
 	"rdm_tagged_pingpong"
-	"ud_pingpong"
-	"ud_pingpong -P"
+	"ud_pingpong -v"
+	"ud_pingpong -P -v"
 	"rc_pingpong"
 )
 


### PR DESCRIPTION
This is an initial attempt at reducing some of the duplication inside of msg_pingpong, rdm_pingpong, and ud_pingpong. The extracted functionality was only really found in the pingpong tests so I made a new file 
inside of the pingpong subdirectory.

This came out of an attempt to add data verification to the three main pingpong tests.

@shefty I'm not sure what your plans were for refactoring this, but here's a start. rdm_pingpong, msg_pingpong, and ud_pingpong now support verification and prefix mode. I'd eventually like to add completion length checking as well (and associated flag), but that probably won't get added until a future PR. That's the reason recv_msg now takes a size.

Thoughts?

@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>