### PR TITLE
common/shared.c: Negate ret before passing to fi_strerror.

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -208,7 +208,7 @@ static int getaddr(char *node, char *service,
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
 	if (ret) {
-		FT_ERR("fi_getinfo error %s\n", fi_strerror(ret));
+		FT_ERR("fi_getinfo error %s\n", fi_strerror(-ret));
 		return ret;
 	}
 	hints->addr_format = fi->addr_format;


### PR DESCRIPTION
Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>