### PR TITLE
Makefile.am: Add pingpong_shared.h to distribution tarball.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,11 +123,13 @@ streaming_fi_rdm_rma_LDADD = libfabtests.la
 
 pingpong_fi_msg_pingpong_SOURCES = \
 	pingpong/msg_pingpong.c \
+	pingpong/pingpong_shared.h \
 	pingpong/pingpong_shared.c
 pingpong_fi_msg_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_ud_pingpong_SOURCES = \
 	pingpong/ud_pingpong.c \
+	pingpong/pingpong_shared.h \
 	pingpong/pingpong_shared.c
 pingpong_fi_ud_pingpong_LDADD = libfabtests.la
 
@@ -137,6 +139,7 @@ pingpong_fi_rdm_cntr_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_rdm_pingpong_SOURCES = \
 	pingpong/rdm_pingpong.c \
+	pingpong/pingpong_shared.h \
 	pingpong/pingpong_shared.c
 pingpong_fi_rdm_pingpong_LDADD = libfabtests.la
 


### PR DESCRIPTION
List pingpong_shared.h in the relevant pingpong test _SOURCES variables
to ensure that it is installed.

@goodell @jsquyres @shantonu 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>