### PR TITLE
Use separate buffers for send and receives

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -98,8 +98,8 @@ extern struct fid_mr *mr;
 extern struct fid_av *av;
 extern struct fid_eq *eq;
 
-extern void *buf;
-extern size_t buffer_size;
+extern void *buf, *tx_buf, *rx_buf;
+extern size_t buf_size, tx_size, rx_size;
 
 extern struct fi_eq_attr eq_attr;
 
@@ -155,6 +155,7 @@ int size_to_count(int size);
 		}				\
 	} while (0)
 
+int ft_alloc_bufs();
 int ft_open_fabric_res();
 int ft_start_server();
 int ft_init_ep(void *recv_ctx);

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -80,17 +80,9 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_cq_attr cq_attr;
 	int ret;
 
-	buffer_size = opts.user_options & FT_OPT_SIZE ?
-			opts.transfer_size : test_size[TEST_CNT - 1].size;
-
-	buf = malloc(buffer_size * 2);
-	if (!buf) {
-		perror("malloc");
-		return -1;
-	}
-
-	recv_buf = buf;
-	send_buf = (char *) buf + buffer_size;
+	ret = ft_alloc_bufs();
+	if (ret)
+		return ret;
 
 	memset(&cq_attr, 0, sizeof cq_attr);
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
@@ -108,7 +100,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		return ret;
 	}
 
-	ret = fi_mr_reg(domain, buf, buffer_size * 2, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;

--- a/pingpong/pingpong_shared.c
+++ b/pingpong/pingpong_shared.c
@@ -45,8 +45,6 @@ fi_addr_t remote_fi_addr;
 int max_credits = 128;
 int credits = 128;
 int verify_data;
-void *send_buf;
-void *recv_buf;
 int timeout;
 
 void ft_parsepongopts(int op)
@@ -115,9 +113,9 @@ int send_xfer(int size)
 	}
 
 	if (verify_data)
-		ft_fill_buf((char *) send_buf + fi->ep_attr->msg_prefix_size, size);
+		ft_fill_buf((char *) tx_buf + fi->ep_attr->msg_prefix_size, size);
 
-	ret = fi_send(ep, send_buf, (size_t) size + fi->ep_attr->msg_prefix_size,
+	ret = fi_send(ep, tx_buf, (size_t) size + fi->ep_attr->msg_prefix_size,
 			fi_mr_desc(mr), remote_fi_addr, NULL);
 	if (ret)
 		FT_PRINTERR("fi_send", ret);
@@ -130,7 +128,7 @@ int send_msg(int size)
 	int ret;
 
 	/* TODO: Prefix mode may differ for send/recv */
-	ret = fi_send(ep, send_buf, (size_t) size + fi->ep_attr->msg_prefix_size,
+	ret = fi_send(ep, tx_buf, (size_t) size + fi->ep_attr->msg_prefix_size,
 			fi_mr_desc(mr), remote_fi_addr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_send", ret);
@@ -156,13 +154,13 @@ int recv_xfer(int size, bool enable_timeout)
 
 	/* TODO: Prefix mode may differ for send/recv */
 	if (verify_data) {
-		ret = ft_check_buf((char *) recv_buf + fi->ep_attr->msg_prefix_size,
+		ret = ft_check_buf((char *) rx_buf + fi->ep_attr->msg_prefix_size,
 				   size);
 		if (ret)
 			return ret;
 	}
 
-	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), remote_fi_addr,
+	ret = fi_recv(ep, rx_buf, rx_size, fi_mr_desc(mr), remote_fi_addr,
 			NULL);
 	if (ret)
 		FT_PRINTERR("fi_recv", ret);
@@ -174,7 +172,7 @@ int recv_msg(int size, bool enable_timeout)
 {
 	int ret;
 
-	ret = fi_recv(ep, recv_buf, buffer_size, fi_mr_desc(mr), 0, NULL);
+	ret = fi_recv(ep, rx_buf, rx_size, fi_mr_desc(mr), 0, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
 		return ret;

--- a/pingpong/pingpong_shared.h
+++ b/pingpong/pingpong_shared.h
@@ -45,8 +45,6 @@ extern fi_addr_t remote_fi_addr;
 extern int max_credits;
 extern int credits;
 extern int verify_data;
-extern void *send_buf;
-extern void *recv_buf;
 extern int timeout;
 
 void ft_parsepongopts(int op);

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -50,12 +50,9 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_cq_attr cq_attr;
 	int ret;
 
-	buffer_size = test_size[TEST_CNT - 1].size;
-	buf = malloc(buffer_size);
-	if (!buf) {
-		perror("malloc");
-		return -1;
-	}
+	ret = ft_alloc_bufs();
+	if (ret)
+		return ret;
 
 	memset(&cq_attr, 0, sizeof cq_attr);
 	cq_attr.format = FI_CQ_FORMAT_DATA;
@@ -74,7 +71,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		return ret;
 	}
 
-	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
@@ -287,6 +284,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.user_options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -59,11 +59,9 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buf = calloc(1, buffer_size);
-	if (!buf) {
-		perror("malloc");
-		return -1;
-	}
+	ret = ft_alloc_bufs();
+	if (ret)
+		return ret;
 
 	memset(&cq_attr, 0, sizeof cq_attr);
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
@@ -85,7 +83,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV| FI_SEND, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
@@ -198,7 +196,7 @@ static int send_recv()
 	} else {
 		/* Server */
 		fprintf(stdout, "Posting a recv...\n");
-		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0,
+		ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0,
 				&fi_ctx_recv);
 		if (ret) {
 			FT_PRINTERR("fi_recv", ret);
@@ -224,7 +222,9 @@ static int send_recv()
 int main(int argc, char **argv)
 {
 	int op, ret;
+
 	opts = INIT_OPTS;
+	opts.user_options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -59,11 +59,9 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_wait_attr wait_attr;
 	int ret;
 
-	buf = malloc(buffer_size);
-	if (!buf) {
-		perror("malloc");
-		return -1;
-	}
+	ret = ft_alloc_bufs();
+	if (ret)
+		return ret;
 
 	/* Open a wait set */
 	memset(&wait_attr, 0, sizeof wait_attr);
@@ -96,7 +94,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
@@ -145,7 +143,7 @@ static int recv_msg(void)
 {
 	int ret;
 
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
+	ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
 		return ret;
@@ -335,6 +333,8 @@ int main(int argc, char **argv)
 	int op, ret = 0;
 
 	opts = INIT_OPTS;
+	opts.user_options |= FT_OPT_SIZE;
+
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -46,11 +46,9 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_cq_attr cq_attr = { 0 };
 	int ret;
 
-	buf = malloc(buffer_size);
-	if (!buf) {
-		perror("malloc");
-		return -1;
-	}
+	ret = ft_alloc_bufs();
+	if (ret)
+		return ret;
 
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_NONE;
@@ -71,7 +69,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
@@ -235,7 +233,7 @@ static int send_recv()
 	} else {
 		/* Server */
 		fprintf(stdout, "Posting a recv...\n");
-		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
+		ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0, buf);
 		if (ret) {
 			FT_PRINTERR("fi_recv", ret);
 			return ret;
@@ -262,6 +260,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.user_options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -54,11 +54,9 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct epoll_event event;
 	int ret, fd;
 
-	buf = malloc(buffer_size);
-	if (!buf) {
-		perror("malloc");
-		return -1;
-	}
+	ret = ft_alloc_bufs();
+	if (ret)
+		return ret;
 
 	memset(&cq_attr, 0, sizeof cq_attr);
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
@@ -124,7 +122,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
@@ -303,7 +301,7 @@ static int send_recv()
 	} else {
 		/* Server */
 		fprintf(stdout, "Posting a recv...\n");
-		ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, buf);
+		ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0, buf);
 		if (ret) {
 			FT_PRINTERR("fi_recv", ret);
 			return ret;
@@ -341,6 +339,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.user_options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -67,11 +67,9 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_poll_attr poll_attr;
 	int ret;
 
-	buf = malloc(buffer_size);
-	if (!buf) {
-		perror("malloc");
-		return -1;
-	}
+	ret = ft_alloc_bufs();
+	if (ret)
+		return ret;
 
 	memset(&cq_attr, 0, sizeof cq_attr);
 	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
@@ -115,7 +113,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	}
 
 	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buffer_size, 0, 0, 0, 0, &mr, NULL);
+	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
@@ -163,7 +161,7 @@ static int recv_msg(void)
 {
 	int ret;
 
-	ret = fi_recv(ep, buf, buffer_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
+	ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
 		return ret;
@@ -359,7 +357,9 @@ static int send_recv()
 int main(int argc, char **argv)
 {
 	int op, ret = 0;
+
 	opts = INIT_OPTS;
+	opts.user_options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -77,9 +77,9 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = MAX(sizeof(char *) * strlen(welcome_text),
+	buf_size = MAX(sizeof(char *) * strlen(welcome_text),
 			sizeof(uint64_t));
-	buf = malloc(buffer_size);
+	buf = malloc(buf_size);
 	if (!buf) {
 		perror("malloc");
 		return -1;
@@ -100,7 +100,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		return ret;
 	}
 
-	ret = fi_mr_reg(domain, buf, buffer_size, FI_WRITE | FI_REMOTE_WRITE, 0,
+	ret = fi_mr_reg(domain, buf, buf_size, FI_WRITE | FI_REMOTE_WRITE, 0,
 			user_defined_key, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
@@ -223,6 +223,8 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.user_options |= FT_OPT_SIZE;
+
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;

--- a/simple/rdm_rma_trigger.c
+++ b/simple/rdm_rma_trigger.c
@@ -102,8 +102,8 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct fi_av_attr av_attr;
 	int ret;
 
-	buffer_size = strlen(welcome_text1) + strlen(welcome_text2);
-	buf = malloc(buffer_size);
+	buf_size = strlen(welcome_text1) + strlen(welcome_text2);
+	buf = malloc(buf_size);
 	if (!buf) {
 		perror("malloc");
 		return -1;
@@ -124,7 +124,7 @@ static int alloc_ep_res(struct fi_info *fi)
 		return ret;
 	}
 
-	ret = fi_mr_reg(domain, buf, buffer_size, FI_WRITE | FI_REMOTE_WRITE, 0,
+	ret = fi_mr_reg(domain, buf, buf_size, FI_WRITE | FI_REMOTE_WRITE, 0,
 			user_defined_key, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
@@ -265,6 +265,8 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.user_options |= FT_OPT_SIZE;
+
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -512,7 +512,9 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+
 	opts = INIT_OPTS;
+	opts.user_options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)


### PR DESCRIPTION
This change gives us separate memory buffers for the send and receive side, which is necessary for data verification.  This is a re-post of just the first patch in my previous pull request.