### PR TITLE
Fixes to fabtests to allow psm provider to pass tests

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -184,7 +184,8 @@ int ft_init_ep(void *recv_ctx)
 {
 	int flags, ret;
 
-	FT_EP_BIND(ep, eq, 0);
+	if (fi->ep_attr->type == FI_EP_MSG)
+		FT_EP_BIND(ep, eq, 0);
 	FT_EP_BIND(ep, av, 0);
 	FT_EP_BIND(ep, txcq, FI_TRANSMIT);
 	FT_EP_BIND(ep, rxcq, FI_RECV);


### PR DESCRIPTION
Work-around for psm provider not supporting binding EP to EQ.
Update of Ben's patch, which no longer applies after my previous merge.