### PR TITLE
Move active EP allocation to common code

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -65,6 +65,15 @@ enum precision {
 	MILLI = 1000000,
 };
 
+enum {
+	FT_OPT_ITER		= 1 << 0,
+	FT_OPT_SIZE		= 1 << 1,
+	FT_OPT_RX_CQ		= 1 << 2,
+	FT_OPT_TX_CQ		= 1 << 3,
+	FT_OPT_RX_CNTR		= 1 << 4,
+	FT_OPT_TX_CNTR		= 1 << 5,
+};
+
 struct ft_opts {
 	int iterations;
 	int transfer_size;
@@ -73,17 +82,11 @@ struct ft_opts {
 	char *src_addr;
 	char *dst_addr;
 	int size_option;
-	int user_options;
+	int options;
 	int machr;
 	int argc;
 	char **argv;
 };
-
-enum {
-	FT_OPT_ITER = 1 << 0,
-	FT_OPT_SIZE = 1 << 1
-};
-
 
 extern struct fi_info *fi, *hints;
 extern struct fid_fabric *fabric;
@@ -101,7 +104,11 @@ extern struct fid_eq *eq;
 extern void *buf, *tx_buf, *rx_buf;
 extern size_t buf_size, tx_size, rx_size;
 
+extern size_t tx_credits;
+extern struct fi_av_attr av_attr;
 extern struct fi_eq_attr eq_attr;
+extern struct fi_cq_attr cq_attr;
+extern struct fi_cntr_attr cntr_attr;
 
 extern struct ft_opts opts;
 
@@ -117,11 +124,14 @@ int ft_check_buf(void *buf, int size);
 #define INFO_OPTS "n:f:"
 #define CS_OPTS ADDR_OPTS "I:S:m"
 
-#define INIT_OPTS (struct ft_opts) { .iterations = 1000, \
-				     .transfer_size = 1024, \
-				     .src_port = "9228", \
-				     .dst_port = "9228", \
-				     .argc = argc, .argv = argv }
+#define INIT_OPTS (struct ft_opts) \
+	{	.options = FT_OPT_RX_CQ | FT_OPT_TX_CQ, \
+		.iterations = 1000, \
+		.transfer_size = 1024, \
+		.src_port = "9228", \
+		.dst_port = "9228", \
+		.argc = argc, .argv = argv \
+	}
 
 extern struct test_size_param test_size[];
 const unsigned int test_cnt;
@@ -158,6 +168,7 @@ int size_to_count(int size);
 int ft_alloc_bufs();
 int ft_open_fabric_res();
 int ft_start_server();
+int ft_alloc_active_res(struct fi_info *fi);
 int ft_init_ep(void *recv_ctx);
 void ft_free_res();
 void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len);

--- a/pingpong/pingpong_shared.h
+++ b/pingpong/pingpong_shared.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -42,8 +43,6 @@ extern "C" {
 #define PONG_OPTS "vP"
 
 extern fi_addr_t remote_fi_addr;
-extern int max_credits;
-extern int credits;
 extern int verify_data;
 extern int timeout;
 

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license
  * below:
@@ -42,8 +42,6 @@
 #include <shared.h>
 
 
-static int max_credits = 128;
-static int credits = 128;
 static int send_count = 0;
 static int recv_outs = 0;	/* Outstanding recvs */
 static char test_name[10] = "custom";
@@ -66,7 +64,7 @@ static int get_send_completions()
 		return ret;
 	}
 
-	credits = max_credits;
+	tx_credits = fi->tx_attr->size;
 
 	return ret;
 }
@@ -75,7 +73,7 @@ static int send_xfer(int size)
 {
 	int ret;
 
-	if (!credits) {
+	if (!tx_credits) {
 		ret = fi_cntr_wait(txcntr, send_count, -1);
 		if (ret < 0) {
 			FT_PRINTERR("fi_cntr_wait", ret);
@@ -83,9 +81,9 @@ static int send_xfer(int size)
 		}
 	}
 
-	credits--;
+	tx_credits--;
 	ret = fi_send(ep, tx_buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-			&fi_ctx_send);
+		      &fi_ctx_send);
 	if (ret) {
 		FT_PRINTERR("fi_send", ret);
 		return ret;
@@ -204,52 +202,15 @@ out:
 
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cntr_attr cntr_attr;
-	struct fi_av_attr av_attr;
 	int ret;
 
 	ret = ft_alloc_bufs();
 	if (ret)
 		return ret;
 
-	memset(&cntr_attr, 0, sizeof cntr_attr);
-	cntr_attr.events = FI_CNTR_EVENTS_COMP;
-
-	ret = fi_cntr_open(domain, &cntr_attr, &txcntr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cntr_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	ret = fi_cntr_open(domain, &cntr_attr, &rxcntr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cntr_open", ret);
-		return ret;
-	}
-
-	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		return ret;
-	}
-
-	memset(&av_attr, 0, sizeof av_attr);
-	av_attr.type = fi->domain_attr->av_type ?
-			fi->domain_attr->av_type : FI_AV_MAP;
-	av_attr.count = 1;
-	av_attr.name = NULL;
-
-	ret = fi_av_open(domain, &av_attr, &av, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_av_open", ret);
-		return ret;
-	}
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -383,7 +344,7 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!(opts.user_options & FT_OPT_SIZE)) {
+	if (!(opts.options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
@@ -409,7 +370,9 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+
 	opts = INIT_OPTS;
+	opts.options = FT_OPT_RX_CNTR | FT_OPT_TX_CNTR;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -396,7 +396,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
-	hints->mode = FI_CONTEXT | FI_LOCAL_MR;
+	hints->mode = FI_LOCAL_MR;
 
 	ret = run();
 

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license
  * below:
@@ -44,7 +44,6 @@
 
 
 static int max_inject_size;
-static int max_credits = 128;
 static char test_name[10] = "custom";
 static struct timespec start, end;
 
@@ -160,56 +159,21 @@ out:
 
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr;
-	struct fi_av_attr av_attr;
 	int ret;
 
 	ret = ft_alloc_bufs();
 	if (ret)
 		return ret;
 
-	memset(&cq_attr, 0, sizeof cq_attr);
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	cq_attr.wait_obj = FI_WAIT_NONE;
-	cq_attr.size = max_credits << 1;
+	/* TODO:
+	 * Memory registration not required for send_buf since we use fi_inject.
+	 * fi_inject copies the buffer of data that needs to be sent.
+	 * Fix-up when separating send/receive buffer registration.
+	 */
 
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	/* Memory registration not required for send_buf since we use fi_inject.
-	 * fi_inject copies the buffer of data that needs to be sent. */
-	ret = fi_mr_reg(domain, rx_buf, rx_size, FI_RECV, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	memset(&av_attr, 0, sizeof av_attr);
-	av_attr.type = fi->domain_attr->av_type ?
-			fi->domain_attr->av_type : FI_AV_MAP;
-	av_attr.count = 1;
-	av_attr.name = NULL;
-
-	ret = fi_av_open(domain, &av_attr, &av, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_av_open", ret);
-		return ret;
-	}
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -232,7 +196,7 @@ static int init_fabric(void)
 
 	/* check max msg size */
 	max_inject_size = fi->tx_attr->inject_size;
-	if ((opts.user_options & FT_OPT_SIZE) &&
+	if ((opts.options & FT_OPT_SIZE) &&
 	    (opts.transfer_size > max_inject_size)) {
 		fprintf(stderr, "Msg size greater than max inject size\n");
 		return -FI_EINVAL;
@@ -350,7 +314,7 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!(opts.user_options & FT_OPT_SIZE)) {
+	if (!(opts.options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
@@ -376,6 +340,7 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+
 	opts = INIT_OPTS;
 	opts.transfer_size = 64;
 

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license
  * below:
@@ -84,53 +84,15 @@ out:
 
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr;
-	struct fi_av_attr av_attr;
 	int ret;
 
 	ret = ft_alloc_bufs();
 	if (ret)
 		return ret;
 
-	memset(&cq_attr, 0, sizeof cq_attr);
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	cq_attr.wait_obj = FI_WAIT_NONE;
-	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		return ret;
-	}
-
-	memset(&av_attr, 0, sizeof av_attr);
-	av_attr.type = fi->domain_attr->av_type ?
-			fi->domain_attr->av_type : FI_AV_MAP;
-	av_attr.count = 1;
-	av_attr.name = NULL;
-
-	ret = fi_av_open(domain, &av_attr, &av, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_av_open", ret);
-		return ret;
-	}
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -263,7 +225,7 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!(opts.user_options & FT_OPT_SIZE)) {
+	if (!(opts.options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
@@ -280,7 +242,7 @@ static int run(void)
 			goto out;
 	}
 
-	wait_for_completion(txcq, max_credits - credits);
+	wait_for_completion(txcq, fi->tx_attr->size - tx_credits);
 	/* Finalize before closing ep */
 	ft_finalize(fi, ep, txcq, rxcq, remote_fi_addr);
 out:
@@ -290,6 +252,7 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+
 	opts = INIT_OPTS;
 
 	hints = fi_allocinfo();

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -413,7 +413,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_TAGGED;
-	hints->mode = FI_CONTEXT | FI_LOCAL_MR;
+	hints->mode = FI_LOCAL_MR;
 
 	ret = run();
 

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license
  * below:
@@ -44,8 +44,6 @@
 #include "shared.h"
 
 
-static int max_credits = 128;
-static int credits = 128;
 static char test_name[10] = "custom";
 static struct timespec start, end;
 
@@ -79,10 +77,10 @@ int wait_for_completion_tagged(struct fid_cq *cq, int num_completions)
 
 static int send_xfer(int size)
 {
-	struct fi_cq_entry comp;
+	struct fi_cq_tagged_entry comp;
 	int ret;
 
-	while (!credits) {
+	while (!tx_credits) {
 		ret = fi_cq_read(txcq, &comp, 1);
 		if (ret > 0) {
 			goto post;
@@ -96,7 +94,7 @@ static int send_xfer(int size)
 		}
 	}
 
-	credits--;
+	tx_credits--;
 post:
 	ret = fi_tsend(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
 			tag_data, &fi_ctx_tsend);
@@ -168,11 +166,11 @@ static int sync_test(void)
 {
 	int ret;
 
-	ret = wait_for_completion_tagged(txcq, max_credits - credits);
+	ret = wait_for_completion_tagged(txcq, fi->tx_attr->size - tx_credits);
 	if (ret) {
 		return ret;
 	}
-	credits = max_credits;
+	tx_credits = fi->tx_attr->size;
 
 	ret = opts.dst_addr ? send_xfer(16) : recv_xfer(16);
 	if (ret)
@@ -222,53 +220,15 @@ out:
 
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr;
-	struct fi_av_attr av_attr;
 	int ret;
 
 	ret = ft_alloc_bufs();
 	if (ret)
 		return ret;
 
-	memset(&cq_attr, 0, sizeof cq_attr);
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	cq_attr.wait_obj = FI_WAIT_NONE;
-	cq_attr.size = max_credits << 1;
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		return ret;
-	}
-
-	memset(&av_attr, 0, sizeof av_attr);
-	av_attr.type = fi->domain_attr->av_type ?
-			fi->domain_attr->av_type : FI_AV_MAP;
-	av_attr.count = 1;
-	av_attr.name = NULL;
-
-	ret = fi_av_open(domain, &av_attr, &av, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_av_open", ret);
-		return ret;
-	}
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -401,7 +361,7 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!(opts.user_options & FT_OPT_SIZE)) {
+	if (!(opts.options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
@@ -418,7 +378,7 @@ static int run(void)
 			goto out;
 	}
 
-	wait_for_completion_tagged(txcq, max_credits - credits);
+	wait_for_completion_tagged(txcq, fi->tx_attr->size - tx_credits);
 	/* Finalize before closing ep */
 	ft_finalize(fi, ep, txcq, rxcq, remote_fi_addr);
 out:
@@ -428,6 +388,7 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+
 	opts = INIT_OPTS;
 
 	hints = fi_allocinfo();

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license below:
  *
@@ -42,46 +42,19 @@
 #include <shared.h>
 
 
-static int rx_depth = 500;
-
-
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr;
 	int ret;
 
 	ret = ft_alloc_bufs();
 	if (ret)
 		return ret;
 
-	memset(&cq_attr, 0, sizeof cq_attr);
 	cq_attr.format = FI_CQ_FORMAT_DATA;
-	cq_attr.wait_obj = FI_WAIT_UNSPEC;
-	cq_attr.size = rx_depth;
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
 
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		return ret;
-	}
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -284,7 +257,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.user_options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license
  * below:
@@ -42,8 +42,6 @@
 #include <shared.h>
 
 
-static int rx_depth = 512;
-
 static void *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -55,58 +53,15 @@ struct fi_context fi_ctx_av;
 
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr;
-	struct fi_av_attr av_attr;
 	int ret;
 
 	ret = ft_alloc_bufs();
 	if (ret)
 		return ret;
 
-	memset(&cq_attr, 0, sizeof cq_attr);
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	cq_attr.wait_obj = FI_WAIT_NONE;
-	cq_attr.size = rx_depth;
-
-	/* Open completion queue for send completions */
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	/* Open completion queue for recv completions */
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV| FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		return ret;
-	}
-
-	memset(&av_attr, 0, sizeof av_attr);
-	av_attr.type = fi->domain_attr->av_type ?
-			fi->domain_attr->av_type : FI_AV_MAP;
-	av_attr.count = 1;
-	av_attr.name = NULL;
-
-	/* Open address vector (AV) for mapping address */
-	ret = fi_av_open(domain, &av_attr, &av, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_av_open", ret);
-		return ret;
-	 }
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -224,7 +179,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.user_options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under the BSD license below:
@@ -42,9 +42,6 @@
 #include <shared.h>
 
 
-static int transfer_size = 1000;
-static int rx_depth = 512;
-
 static void *local_addr, *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -52,10 +49,9 @@ struct fi_context fi_ctx_send;
 struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_av;
 
+
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr;
-	struct fi_av_attr av_attr;
 	struct fi_wait_attr wait_attr;
 	int ret;
 
@@ -63,7 +59,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	if (ret)
 		return ret;
 
-	/* Open a wait set */
 	memset(&wait_attr, 0, sizeof wait_attr);
 	wait_attr.wait_obj = FI_WAIT_UNSPEC;
 	ret = fi_wait_open(fabric, &wait_attr, &waitset);
@@ -72,52 +67,13 @@ static int alloc_ep_res(struct fi_info *fi)
 		return ret;
 	}
 
-	memset(&cq_attr, 0, sizeof cq_attr);
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 	cq_attr.wait_obj = FI_WAIT_SET;
 	cq_attr.wait_cond = FI_CQ_COND_NONE;
 	cq_attr.wait_set = waitset;
-	cq_attr.size = rx_depth;
 
-	/* Open completion queue for send completions */
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	/* Open completion queue for recv completions */
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		return ret;
-	}
-
-	memset(&av_attr, 0, sizeof av_attr);
-	av_attr.type = fi->domain_attr->av_type ?
-			fi->domain_attr->av_type : FI_AV_MAP;
-	av_attr.count = 1;
-	av_attr.name = NULL;
-
-	/* Open Address Vector */
-	ret = fi_av_open(domain, &av_attr, &av, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_av_open", ret);
-		return ret;
-	}
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -269,7 +225,7 @@ static int send_recv()
 	int ret, send_pending = 0, recv_pending = 0;
 
 	fprintf(stdout, "Posting a recv...\n");
-	ret = fi_recv(ep, buf, transfer_size, fi_mr_desc(mr),
+	ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr),
 			remote_fi_addr, &fi_ctx_recv);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
@@ -278,7 +234,7 @@ static int send_recv()
 	recv_pending++;
 
 	fprintf(stdout, "Posting a send...\n");
-	ret = fi_send(ep, buf, transfer_size, fi_mr_desc(mr),
+	ret = fi_send(ep, buf, tx_size, fi_mr_desc(mr),
 			remote_fi_addr, &fi_ctx_send);
 	if (ret) {
 		FT_PRINTERR("fi_send", ret);
@@ -333,7 +289,7 @@ int main(int argc, char **argv)
 	int op, ret = 0;
 
 	opts = INIT_OPTS;
-	opts.user_options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license
  * below:
@@ -38,48 +38,17 @@
 #include "shared.h"
 
 
-static int rx_depth = 512;
-
-
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr = { 0 };
 	int ret;
 
 	ret = ft_alloc_bufs();
 	if (ret)
 		return ret;
 
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	cq_attr.wait_obj = FI_WAIT_NONE;
-	cq_attr.size = rx_depth;
-
-	/* Open completion queue for send completions */
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	/* Open completion queue for recv completions */
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		return ret;
-	}
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -260,7 +229,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.user_options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license
  * below:
@@ -41,8 +41,6 @@
 
 #include "shared.h"
 
-
-static int rx_depth = 512;
 
 union sockaddr_any {
 	struct sockaddr		sa;
@@ -138,43 +136,15 @@ static int check_address(struct fid *fid, const char *message)
 
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr = { 0 };
 	int ret;
 
 	ret = ft_alloc_bufs();
 	if (ret)
 		return ret;
 
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	cq_attr.wait_obj = FI_WAIT_NONE;
-	cq_attr.size = rx_depth;
-
-	/* Open completion queue for send completions */
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	/* Open completion queue for recv completions */
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		return ret;
-	}
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -482,7 +452,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.user_options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license
  * below:
@@ -42,8 +42,6 @@
 #include <shared.h>
 
 
-static int rx_depth = 512;
-
 static void *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t remote_fi_addr;
@@ -55,58 +53,15 @@ struct fi_context fi_ctx_av;
 
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr;
-	struct fi_av_attr av_attr;
 	int ret;
 
 	ret = ft_alloc_bufs();
 	if (ret)
 		return ret;
 
-	memset(&cq_attr, 0, sizeof cq_attr);
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	cq_attr.wait_obj = FI_WAIT_NONE;
-	cq_attr.size = rx_depth;
-
-	/* Open completion queue for send completions */
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	/* Open completion queue for recv completions */
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	/* Register memory */
-	ret = fi_mr_reg(domain, buf, buf_size, FI_RECV | FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_mr_reg", ret);
-		return ret;
-	}
-
-	memset(&av_attr, 0, sizeof av_attr);
-	av_attr.type = fi->domain_attr->av_type ?
-			fi->domain_attr->av_type : FI_AV_MAP;
-	av_attr.count = 1;
-	av_attr.name = NULL;
-
-	/* Open address vector (AV) for mapping address */
-	ret = fi_av_open(domain, &av_attr, &av, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_av_open", ret);
-		return ret;
-	 }
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -224,7 +179,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.user_options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license below:
  *
@@ -359,8 +359,6 @@ static uint64_t get_mr_key()
 
 static int alloc_ep_res(struct fi_info *fi)
 {
-	struct fi_cq_attr cq_attr;
-	struct fi_av_attr av_attr;
 	int ret;
 
 	ret = ft_alloc_bufs();
@@ -377,22 +375,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	if (!compare) {
 		perror("malloc");
 		return -1;
-	}
-
-	memset(&cq_attr, 0, sizeof cq_attr);
-	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
-	cq_attr.wait_obj = FI_WAIT_NONE;
-	cq_attr.size = 128;
-	ret = fi_cq_open(domain, &cq_attr, &txcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
-	}
-
-	ret = fi_cq_open(domain, &cq_attr, &rxcq, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_cq_open", ret);
-		return ret;
 	}
 
 	// registers local data buffer buff that specifies
@@ -424,23 +406,9 @@ static int alloc_ep_res(struct fi_info *fi)
 		return ret;
 	}
 
-	memset(&av_attr, 0, sizeof av_attr);
-	av_attr.type = fi->domain_attr->av_type ?
-			fi->domain_attr->av_type : FI_AV_MAP;
-	av_attr.count = 1;
-	av_attr.name = NULL;
-
-	ret = fi_av_open(domain, &av_attr, &av, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_av_open", ret);
+	ret = ft_alloc_active_res(fi);
+	if (ret)
 		return ret;
-	}
-
-	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_endpoint", ret);
-		return ret;
-	}
 
 	return 0;
 }
@@ -606,7 +574,7 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	if (!(opts.user_options & FT_OPT_SIZE)) {
+	if (!(opts.options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (test_size[i].option > opts.size_option)
 				continue;
@@ -631,6 +599,7 @@ out:
 int main(int argc, char **argv)
 {
 	int op, ret;
+
 	opts = INIT_OPTS;
 
 	hints = fi_allocinfo();

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two


### PR DESCRIPTION
Replace individual implementations of alloc_ep_res() with
a shared implementation for allocating an active EP and
associated resources.

This patch also fixes incorrect usage of determining the
'max_credits' of requests that can be posted to the transmit
queue of the EP.

Private usages of 'transfer_size' are also replaced with
the common transfer size option.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>