### PR TITLE
Added missing returns in the error path

### DIFF
--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -250,7 +250,7 @@ static int run(void)
 		return ret;
 	}
 
-	run_test();
+	ret = run_test();
 
 	fi_shutdown(ep, 0);
 	return ret;

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -397,7 +397,7 @@ static int run(void)
 	if (ret)
 		goto out;
 
-	run_test();
+	ret = run_test();
 	/* TODO: Add a local finalize applicable to shared ctx */
 	//ft_finalize(fi, ep_array[0], txcq, rxcq, remote_fi_addr[0]);
 out:


### PR DESCRIPTION
In case there is error during running <code>run_test</code>, return the error value.

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>