### PR TITLE
Fix stack corruption in CQ data test

### DIFF
--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -205,7 +205,7 @@ static int run_test()
 			return ret;
 		}
 
-		wait_for_completion(txcq, 1);
+		wait_for_data_completion(txcq, 1);
 		fprintf(stdout, "Done\n");
 	} else {
 		fprintf(stdout, "Waiting for immediate data from client\n");


### PR DESCRIPTION
wait_for_completion uses fi_cq_entry, where as the completion entry is of type fi_cq_data_entry, resulting in stack corruption.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>