### PR TITLE
ft_finalize: Pass local memory descriptor to fi_sendmsg

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -564,6 +564,7 @@ int ft_finalize(
 	size_t buf_size;
 	size_t prefix_size = 0;
 	char *buf;
+	void *desc = NULL;
 	int ret;
 
 	if (fi && fi->ep_attr)
@@ -579,10 +580,13 @@ int ft_finalize(
 
 	sprintf(buf + prefix_size, "%s", message);
 
+	if (mr)
+		desc = fi_mr_desc(mr);
+
 	iov.iov_base = buf;
 	iov.iov_len = buf_size;
 	msg.msg_iov = &iov;
-	msg.desc = NULL;
+	msg.desc = &desc;
 	msg.iov_count = 1;
 	msg.addr = addr;
 	msg.context = &tx_ctx;

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -478,6 +478,7 @@ int main(int argc, char **argv)
 				op_type = FT_RMA_READ;
 			} else if (!strcmp(optarg, "writedata")) {
 				op_type = FT_RMA_WRITEDATA;
+				cq_attr.format = FI_CQ_FORMAT_DATA;
 			} else if (!strcmp(optarg, "write")) {
 				op_type = FT_RMA_WRITE;
 			} else {

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -465,6 +465,7 @@ int main(int argc, char **argv)
 				op_type = FT_RMA_READ;
 			} else if (!strcmp(optarg, "writedata")) {
 				op_type = FT_RMA_WRITEDATA;
+				cq_attr.format = FI_CQ_FORMAT_DATA;
 			} else if (!strcmp(optarg, "write")) {
 				op_type = FT_RMA_WRITE;
 			} else {


### PR DESCRIPTION
Some providers would require local memory descriptor to be passed.
If there is a registered memory region, pass the local memory
descriptor to fi_sendmsg.

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>