### PR TITLE
Move init_av calls into common code

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -101,8 +101,11 @@ extern struct fid_mr *mr;
 extern struct fid_av *av;
 extern struct fid_eq *eq;
 
+extern fi_addr_t remote_fi_addr;
 extern void *buf, *tx_buf, *rx_buf;
 extern size_t buf_size, tx_size, rx_size;
+
+extern struct fi_context tx_ctx, rx_ctx;
 
 extern size_t tx_credits;
 extern struct fi_av_attr av_attr;
@@ -137,6 +140,8 @@ extern struct test_size_param test_size[];
 const unsigned int test_cnt;
 #define TEST_CNT test_cnt
 #define FT_STR_LEN 32
+#define FT_MAX_CTRL_MSG 64
+#define FT_MR_KEY 0xC0DE
 
 int ft_getsrcaddr(char *node, char *service, struct fi_info *hints);
 int ft_getdestaddr(char *node, char *service, struct fi_info *hints);
@@ -169,12 +174,18 @@ int ft_alloc_bufs();
 int ft_open_fabric_res();
 int ft_start_server();
 int ft_alloc_active_res(struct fi_info *fi);
-int ft_init_ep(void *recv_ctx);
+int ft_init_ep();
+int ft_init_av();
 void ft_free_res();
 void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len);
 int ft_finalize(struct fi_info *fi, struct fid_ep *tx_ep, struct fid_cq *txcq,
 		struct fid_cq *rxcq, fi_addr_t addr);
 
+size_t ft_rx_prefix_size();
+size_t ft_tx_prefix_size();
+
+int ft_get_rx_comp(int count);
+int ft_get_tx_comp(int count);
 
 int ft_wait_for_comp(struct fid_cq *cq, int num_completions);
 void cq_readerr(struct fid_cq *cq, const char *cq_str);

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -75,21 +75,6 @@ static int run_test()
 	return 0;
 }
 
-static int alloc_ep_res(struct fi_info *fi)
-{
-	int ret;
-
-	ret = ft_alloc_bufs();
-	if (ret)
-		return ret;
-
-	ret = ft_alloc_active_res(fi);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
 static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
@@ -117,11 +102,11 @@ static int server_connect(void)
 		goto err;
 	}
 
-	ret = alloc_ep_res(info);
+	ret = ft_alloc_active_res(info);
 	if (ret)
 		 goto err;
 
-	ret = ft_init_ep(buf);
+	ret = ft_init_ep();
 	if (ret)
 		goto err;
 
@@ -181,11 +166,11 @@ static int client_connect(void)
 		return ret;
 	}
 
-	ret = alloc_ep_res(fi);
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(buf);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
 

--- a/pingpong/pingpong_shared.h
+++ b/pingpong/pingpong_shared.h
@@ -42,7 +42,6 @@ extern "C" {
 
 #define PONG_OPTS "vP"
 
-extern fi_addr_t remote_fi_addr;
 extern int verify_data;
 extern int timeout;
 
@@ -51,10 +50,8 @@ void ft_pongusage(void);
 
 int wait_for_completion_timeout(struct fid_cq *cq, int num_completions);
 
-int send_xfer(int size);
-int send_msg(int size);
-int recv_xfer(int size, bool enable_timeout);
-int recv_msg(int size, bool enable_timeout);
+int send_xfer(size_t size);
+int recv_xfer(size_t size, bool enable_timeout);
 int sync_test(bool enable_timeout);
 
 #ifdef __cplusplus

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -47,12 +47,6 @@ static int recv_outs = 0;	/* Outstanding recvs */
 static char test_name[10] = "custom";
 static struct timespec start, end;
 
-static void *local_addr, *remote_addr;
-static size_t addrlen = 0;
-static fi_addr_t remote_fi_addr;
-struct fi_context fi_ctx_send;
-struct fi_context fi_ctx_recv;
-struct fi_context fi_ctx_av;
 
 static int get_send_completions()
 {
@@ -83,7 +77,7 @@ static int send_xfer(int size)
 
 	tx_credits--;
 	ret = fi_send(ep, tx_buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-		      &fi_ctx_send);
+		      &tx_ctx);
 	if (ret) {
 		FT_PRINTERR("fi_send", ret);
 		return ret;
@@ -104,50 +98,10 @@ static int recv_xfer(int size)
 	}
 
 	ret = fi_recv(ep, rx_buf, rx_size, fi_mr_desc(mr), remote_fi_addr,
-			&fi_ctx_recv);
+			&rx_ctx);
 	if (ret)
 		FT_PRINTERR("fi_recv", ret);
 	recv_outs++;
-
-	return ret;
-}
-
-static int send_msg(int size)
-{
-	int ret;
-
-	ret = fi_send(ep, tx_buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-			&fi_ctx_send);
-	if (ret) {
-		FT_PRINTERR("fi_send", ret);
-		return ret;
-	}
-	send_count++;
-
-	ret = fi_cntr_wait(txcntr, send_count, -1);
-	if (ret < 0) {
-		FT_PRINTERR("fi_cntr_wait", ret);
-	}
-
-	return ret;
-}
-
-static int recv_msg(void)
-{
-	int ret;
-
-	ret = fi_recv(ep, rx_buf, rx_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-	recv_outs++;
-
-	ret = fi_cntr_wait(rxcntr, recv_outs, -1);
-	if (ret < 0) {
-		FT_PRINTERR("fi_cntr_wait", ret);
-		return ret;
-	}
 
 	return ret;
 }
@@ -200,21 +154,6 @@ out:
 	return ret;
 }
 
-static int alloc_ep_res(struct fi_info *fi)
-{
-	int ret;
-
-	ret = ft_alloc_bufs();
-	if (ret)
-		return ret;
-
-	ret = ft_alloc_active_res(fi);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -231,13 +170,6 @@ static int init_fabric(void)
 		return ret;
 	}
 
-	/* Get remote address */
-	if (opts.dst_addr) {
-		addrlen = fi->dest_addrlen;
-		remote_addr = malloc(addrlen);
-		memcpy(remote_addr, fi->dest_addr, addrlen);
-	}
-
 	ret = ft_open_fabric_res();
 	if (ret)
 		return ret;
@@ -248,88 +180,15 @@ static int init_fabric(void)
 		return ret;
 	}
 
-	ret = alloc_ep_res(fi);
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(NULL);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
 
 	return 0;
-}
-
-static int init_av(void)
-{
-	int ret;
-
-	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen
-		 * as 0 and fi_getname will return the actual addrlen. */
-		addrlen = 0;
-		ret = fi_getname(&ep->fid, local_addr, &addrlen);
-		if (ret != -FI_ETOOSMALL) {
-			FT_PRINTERR("fi_getname", ret);
-			return ret;
-		}
-
-		local_addr = malloc(addrlen);
-		ret = fi_getname(&ep->fid, local_addr, &addrlen);
-		if (ret) {
-			FT_PRINTERR("fi_getname", ret);
-			return ret;
-		}
-
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
-				&fi_ctx_av);
-		if (ret != 1) {
-			FT_PRINTERR("fi_av_insert", ret);
-			return ret;
-		}
-
-		/* Send local addr size and local addr */
-		memcpy(tx_buf, &addrlen, sizeof(size_t));
-		memcpy(tx_buf + sizeof(size_t), local_addr, addrlen);
-		ret = send_msg(sizeof(size_t) + addrlen);
-		if (ret)
-			return ret;
-
-		/* Receive ACK from server */
-		ret = recv_msg();
-		if (ret)
-			return ret;
-
-	} else {
-		/* Post a recv to get the remote address */
-		ret = recv_msg();
-		if (ret)
-			return ret;
-
-		memcpy(&addrlen, rx_buf, sizeof(size_t));
-		remote_addr = malloc(addrlen);
-		memcpy(remote_addr, rx_buf + sizeof(size_t), addrlen);
-
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
-				&fi_ctx_av);
-		if (ret != 1) {
-			FT_PRINTERR("fi_av_insert", ret);
-			return ret;
-		}
-
-		/* Send ACK */
-		ret = send_msg(16);
-		if (ret)
-			return ret;
-	}
-
-	/* Post first recv */
-	ret = fi_recv(ep, rx_buf, rx_size, fi_mr_desc(mr), remote_fi_addr,
-			&fi_ctx_recv);
-	if (ret)
-		FT_PRINTERR("fi_recv", ret);
-	recv_outs++;
-
-	return ret;
 }
 
 static int run(void)
@@ -340,9 +199,11 @@ static int run(void)
 	if (ret)
 		return ret;
 
-	ret = init_av();
+	ret = ft_init_av();
 	if (ret)
 		goto out;
+	send_count++;
+	recv_outs++;
 
 	if (!(opts.options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -42,24 +42,6 @@
 #include <shared.h>
 
 
-static int alloc_ep_res(struct fi_info *fi)
-{
-	int ret;
-
-	ret = ft_alloc_bufs();
-	if (ret)
-		return ret;
-
-	cq_attr.format = FI_CQ_FORMAT_DATA;
-	cq_attr.wait_obj = FI_WAIT_UNSPEC;
-
-	ret = ft_alloc_active_res(fi);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
 static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
@@ -87,11 +69,11 @@ static int server_connect(void)
 		goto err;
 	}
 
-	ret = alloc_ep_res(info);
+	ret = ft_alloc_active_res(info);
 	if (ret)
 		 goto err;
 
-	ret = ft_init_ep(buf);
+	ret = ft_init_ep();
 	if (ret)
 		goto err;
 
@@ -151,11 +133,11 @@ static int client_connect(void)
 		return ret;
 	}
 
-	ret = alloc_ep_res(fi);
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(buf);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
 
@@ -289,6 +271,9 @@ int main(int argc, char **argv)
 	hints->caps = FI_MSG;
 	hints->mode = FI_LOCAL_MR;
 	hints->addr_format = FI_SOCKADDR;
+
+	cq_attr.format = FI_CQ_FORMAT_DATA;
+	cq_attr.wait_obj = FI_WAIT_UNSPEC;
 
 	ret = run();
 

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -42,22 +42,10 @@
 #include <shared.h>
 
 
-static void *local_addr, *remote_addr;
-static size_t addrlen = 0;
-static fi_addr_t remote_fi_addr;
-struct fi_context fi_ctx_send;
-struct fi_context fi_ctx_recv;
-struct fi_context fi_ctx_av;
-
-
 static int alloc_ep_res(struct fi_info *fi)
 {
 	struct fi_wait_attr wait_attr;
 	int ret;
-
-	ret = ft_alloc_bufs();
-	if (ret)
-		return ret;
 
 	memset(&wait_attr, 0, sizeof wait_attr);
 	wait_attr.wait_obj = FI_WAIT_UNSPEC;
@@ -78,38 +66,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	return 0;
 }
 
-
-static int send_msg(int size)
-{
-	int ret;
-
-	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-			&fi_ctx_send);
-	if (ret) {
-		FT_PRINTERR("fi_send", ret);
-		return ret;
-	}
-
-	ret = ft_wait_for_comp(txcq, 1);
-
-	return ret;
-}
-
-static int recv_msg(void)
-{
-	int ret;
-
-	ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-
-	ret = ft_wait_for_comp(rxcq, 1);
-
-	return ret;
-}
-
 static int init_fabric(void)
 {
 	uint64_t flags = 0;
@@ -126,14 +82,7 @@ static int init_fabric(void)
 		return ret;
 	}
 
-	/* Get remote address */
-	if (opts.dst_addr) {
-		addrlen = fi->dest_addrlen;
-		remote_addr = malloc(addrlen);
-		memcpy(remote_addr, fi->dest_addr, addrlen);
-	}
-
-	ret = ft_open_fabric_res();
+		ret = ft_open_fabric_res();
 	if (ret)
 		return ret;
 
@@ -147,76 +96,11 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(NULL);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
 
 	return 0;
-}
-
-static int init_av(void)
-{
-	int ret;
-
-	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen
-		 * as 0 and fi_getname will return the actual addrlen. */
-		addrlen = 0;
-		ret = fi_getname(&ep->fid, local_addr, &addrlen);
-		if (ret != -FI_ETOOSMALL) {
-			FT_PRINTERR("fi_getname", ret);
-			return ret;
-		}
-
-		local_addr = malloc(addrlen);
-		ret = fi_getname(&ep->fid, local_addr, &addrlen);
-		if (ret) {
-			FT_PRINTERR("fi_getname", ret);
-			return ret;
-		}
-
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
-				&fi_ctx_av);
-		if (ret != 1) {
-			FT_PRINTERR("fi_av_insert", ret);
-			return ret;
-		}
-
-		/* Send local addr size and local addr */
-		memcpy(buf, &addrlen, sizeof(size_t));
-		memcpy(buf + sizeof(size_t), local_addr, addrlen);
-		ret = send_msg(sizeof(size_t) + addrlen);
-		if (ret)
-			return ret;
-
-		/* Receive ACK from server */
-		ret = recv_msg();
-		if (ret)
-			return ret;
-	} else {
-		/* Post a recv to get the remote address */
-		ret = recv_msg();
-		if (ret)
-			return ret;
-
-		memcpy(&addrlen, buf, sizeof(size_t));
-		remote_addr = malloc(addrlen);
-		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
-
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
-				&fi_ctx_av);
-		if (ret != 1) {
-			FT_PRINTERR("fi_av_insert", ret);
-			return ret;
-		}
-
-		/* Send ACK */
-		ret = send_msg(16);
-		if (ret)
-			return ret;
-	}
-
-	return ret;
 }
 
 static int send_recv()
@@ -226,7 +110,7 @@ static int send_recv()
 
 	fprintf(stdout, "Posting a recv...\n");
 	ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr),
-			remote_fi_addr, &fi_ctx_recv);
+			remote_fi_addr, &rx_ctx);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
 		return ret;
@@ -235,7 +119,7 @@ static int send_recv()
 
 	fprintf(stdout, "Posting a send...\n");
 	ret = fi_send(ep, buf, tx_size, fi_mr_desc(mr),
-			remote_fi_addr, &fi_ctx_send);
+			remote_fi_addr, &tx_ctx);
 	if (ret) {
 		FT_PRINTERR("fi_send", ret);
 		return ret;
@@ -319,7 +203,7 @@ int main(int argc, char **argv)
 	if (ret)
 		return -ret;
 
-	ret = init_av();
+	ret = ft_init_av();
 	if (ret)
 		return ret;
 

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -51,12 +51,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	struct epoll_event event;
 	int ret, fd;
 
-	ret = ft_alloc_bufs();
-	if (ret)
-		return ret;
-
-	cq_attr.wait_obj = FI_WAIT_FD;
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
@@ -135,7 +129,7 @@ static int server_connect(void)
 	if (ret)
 		 goto err;
 
-	ret = ft_init_ep(NULL);
+	ret = ft_init_ep();
 	if (ret)
 		goto err;
 
@@ -199,7 +193,7 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(NULL);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
 
@@ -333,6 +327,8 @@ int main(int argc, char **argv)
 	hints->caps		= FI_MSG;
 	hints->mode		= FI_LOCAL_MR;
 	hints->addr_format	= FI_SOCKADDR;
+
+	cq_attr.wait_obj = FI_WAIT_FD;
 
 	/* Fabric and connection setup */
 	if (!opts.dst_addr) {

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -134,21 +134,6 @@ static int check_address(struct fid *fid, const char *message)
 	return 0;
 }
 
-static int alloc_ep_res(struct fi_info *fi)
-{
-	int ret;
-
-	ret = ft_alloc_bufs();
-	if (ret)
-		return ret;
-
-	ret = ft_alloc_active_res(fi);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
 static int server_listen(void)
 {
 	int ret;
@@ -198,11 +183,11 @@ static int server_connect(void)
 		goto err;
 	}
 
-	ret = alloc_ep_res(info);
+	ret = ft_alloc_active_res(info);
 	if (ret)
 		 goto err;
 
-	ret = ft_init_ep(NULL);
+	ret = ft_init_ep();
 	if (ret)
 		goto err;
 
@@ -266,7 +251,7 @@ static int client_connect(void)
 		return ret;
 
 	assert(fi->handle == &pep->fid);
-	ret = alloc_ep_res(fi);
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
 
@@ -278,7 +263,7 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(NULL);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
 

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -42,30 +42,6 @@
 #include <shared.h>
 
 
-static void *remote_addr;
-static size_t addrlen = 0;
-static fi_addr_t remote_fi_addr;
-
-struct fi_context fi_ctx_send;
-struct fi_context fi_ctx_recv;
-struct fi_context fi_ctx_av;
-
-
-static int alloc_ep_res(struct fi_info *fi)
-{
-	int ret;
-
-	ret = ft_alloc_bufs();
-	if (ret)
-		return ret;
-
-	ret = ft_alloc_active_res(fi);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
 static int init_fabric(void)
 {
 	char *node, *service;
@@ -83,13 +59,6 @@ static int init_fabric(void)
 		return ret;
 	}
 
-	/* Get remote address of the server */
-	if (opts.dst_addr) {
-		addrlen = fi->dest_addrlen;
-		remote_addr = malloc(addrlen);
-		memcpy(remote_addr, fi->dest_addr, addrlen);
-	}
-
 	ret = ft_open_fabric_res();
 	if (ret)
 		return ret;
@@ -101,23 +70,13 @@ static int init_fabric(void)
 		return ret;
 	}
 
-	ret = alloc_ep_res(fi);
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(NULL);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
-
-	if (opts.dst_addr) {
-		/* Insert address to the AV and get the fabric address back */
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
-				&fi_ctx_av);
-		if (ret != 1) {
-			FT_PRINTERR("fi_av_insert", ret);
-			return ret;
-		}
-	}
 
 	return 0;
 }
@@ -128,17 +87,15 @@ static int send_recv()
 	int ret;
 
 	if (opts.dst_addr) {
-		/* Client */
-		fprintf(stdout, "Posting a send...\n");
+		fprintf(stdout, "Sending message...\n");
 		sprintf(buf, "Hello from Client!");
 		ret = fi_send(ep, buf, sizeof("Hello from Client!"),
-				fi_mr_desc(mr), remote_fi_addr, &fi_ctx_send);
+				fi_mr_desc(mr), remote_fi_addr, &tx_ctx);
 		if (ret) {
 			FT_PRINTERR("fi_send", ret);
 			return ret;
 		}
 
-		/* Read send queue */
 		do {
 			ret = fi_cq_read(txcq, &comp, 1);
 			if (ret < 0 && ret != -FI_EAGAIN) {
@@ -149,17 +106,7 @@ static int send_recv()
 
 		fprintf(stdout, "Send completion received\n");
 	} else {
-		/* Server */
-		fprintf(stdout, "Posting a recv...\n");
-		ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0,
-				&fi_ctx_recv);
-		if (ret) {
-			FT_PRINTERR("fi_recv", ret);
-			return ret;
-		}
-
-		/* Read recv queue */
-		fprintf(stdout, "Waiting for client...\n");
+		fprintf(stdout, "Waiting for message from client...\n");
 		do {
 			ret = fi_cq_read(rxcq, &comp, 1);
 			if (ret < 0 && ret != -FI_EAGAIN) {
@@ -207,8 +154,12 @@ int main(int argc, char **argv)
 
 	/* Fabric initialization */
 	ret = init_fabric();
-	if(ret)
+	if (ret)
 		return -ret;
+
+	ret = ft_init_av();
+	if (ret)
+		return ret;
 
 	/* Exchange data */
 	ret = send_recv();

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -47,47 +47,10 @@ static int ctx_cnt = 2;
 static int rx_ctx_bits = 0;
 static struct fid_ep *sep;
 static struct fid_ep **tx_ep, **rx_ep;
-static struct fid_cq **scq_array;
-static struct fid_cq **rcq_array;
-static void *local_addr, *remote_addr;
-static size_t addrlen = 0;
-static fi_addr_t remote_fi_addr;
-struct fi_context fi_ctx_send;
-struct fi_context fi_ctx_recv;
-struct fi_context fi_ctx_av;
+static struct fid_cq **txcq_array;
+static struct fid_cq **rxcq_array;
 static fi_addr_t *remote_rx_addr;
 
-static int send_msg(int size)
-{
-	int ret;
-
-	ret = fi_send(tx_ep[0], buf, (size_t) size, fi_mr_desc(mr),
-			remote_rx_addr[0], &fi_ctx_send);
-	if (ret) {
-		FT_PRINTERR("fi_send", ret);
-		return ret;
-	}
-
-	ret = ft_wait_for_comp(scq_array[0], 1);
-
-	return ret;
-}
-
-static int recv_msg(void)
-{
-	int ret;
-
-	/* Messages sent to scalable EP fi_addr are received in context 0 */
-	ret = fi_recv(rx_ep[0], buf, rx_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-
-	ret = ft_wait_for_comp(rcq_array[0], 1);
-
-	return ret;
-}
 
 static void free_res(void)
 {
@@ -101,25 +64,21 @@ static void free_res(void)
 		free(tx_ep);
 		tx_ep = NULL;
 	}
-	if (rcq_array) {
-		FT_CLOSEV_FID(rcq_array, ctx_cnt);
-		free(rcq_array);
-		rcq_array = NULL;
+	if (rxcq_array) {
+		FT_CLOSEV_FID(rxcq_array, ctx_cnt);
+		free(rxcq_array);
+		rxcq_array = NULL;
 	}
-	if (scq_array) {
-		FT_CLOSEV_FID(scq_array, ctx_cnt);
-		free(scq_array);
-		scq_array = NULL;
+	if (txcq_array) {
+		FT_CLOSEV_FID(txcq_array, ctx_cnt);
+		free(txcq_array);
+		txcq_array = NULL;
 	}
 }
 
 static int alloc_ep_res(struct fid_ep *sep)
 {
 	int i, ret;
-
-	ret = ft_alloc_bufs();
-	if (ret)
-		return ret;
 
 	/* Get number of bits needed to represent ctx_cnt */
 	while (ctx_cnt >> ++rx_ctx_bits)
@@ -133,13 +92,13 @@ static int alloc_ep_res(struct fid_ep *sep)
 
 	FT_CLOSE_FID(ep);
 
-	scq_array = calloc(ctx_cnt, sizeof *scq_array);
-	rcq_array = calloc(ctx_cnt, sizeof *rcq_array);
+	txcq_array = calloc(ctx_cnt, sizeof *txcq_array);
+	rxcq_array = calloc(ctx_cnt, sizeof *rxcq_array);
 	tx_ep = calloc(ctx_cnt, sizeof *tx_ep);
 	rx_ep = calloc(ctx_cnt, sizeof *rx_ep);
 	remote_rx_addr = calloc(ctx_cnt, sizeof *remote_rx_addr);
 
-	if (!buf || !scq_array || !rcq_array || !tx_ep || !rx_ep || !remote_rx_addr) {
+	if (!buf || !txcq_array || !rxcq_array || !tx_ep || !rx_ep || !remote_rx_addr) {
 		perror("malloc");
 		return -1;
 	}
@@ -151,7 +110,7 @@ static int alloc_ep_res(struct fid_ep *sep)
 			return ret;
 		}
 
-		ret = fi_cq_open(domain, &cq_attr, &scq_array[i], NULL);
+		ret = fi_cq_open(domain, &cq_attr, &txcq_array[i], NULL);
 		if (ret) {
 			FT_PRINTERR("fi_cq_open", ret);
 			return ret;
@@ -163,7 +122,7 @@ static int alloc_ep_res(struct fid_ep *sep)
 			return ret;
 		}
 
-		ret = fi_cq_open(domain, &cq_attr, &rcq_array[i], NULL);
+		ret = fi_cq_open(domain, &cq_attr, &rxcq_array[i], NULL);
 		if (ret) {
 			FT_PRINTERR("fi_cq_open", ret);
 			return ret;
@@ -178,7 +137,7 @@ static int bind_ep_res(void)
 	int i, ret;
 
 	for (i = 0; i < ctx_cnt; i++) {
-		ret = fi_ep_bind(tx_ep[i], &scq_array[i]->fid, FI_SEND);
+		ret = fi_ep_bind(tx_ep[i], &txcq_array[i]->fid, FI_SEND);
 		if (ret) {
 			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
@@ -192,7 +151,7 @@ static int bind_ep_res(void)
 	}
 
 	for (i = 0; i < ctx_cnt; i++) {
-		ret = fi_ep_bind(rx_ep[i], &rcq_array[i]->fid, FI_RECV);
+		ret = fi_ep_bind(rx_ep[i], &rxcq_array[i]->fid, FI_RECV);
 		if (ret) {
 			FT_PRINTERR("fi_ep_bind", ret);
 			return ret;
@@ -205,10 +164,17 @@ static int bind_ep_res(void)
 		}
 	}
 
-	/* Bind scalable EP with AV */
 	ret = fi_scalable_ep_bind(sep, &av->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	/* control message exchange is on tx/rx context 0 */
+	ret = fi_recv(rx_ep[0], rx_buf, MAX(rx_size, FT_MAX_CTRL_MSG),
+			fi_mr_desc(mr), 0, &rx_ctx);
+	if (ret) {
+		FT_PRINTERR("fi_recv", ret);
 		return ret;
 	}
 
@@ -219,7 +185,7 @@ static int run_test()
 {
 	int ret, i;
 
-	/* Post recvs */
+	/* TODO: This is racy -- assumes flow control if send is received first. */
 	for (i = 0; i < ctx_cnt; i++) {
 		fprintf(stdout, "Posting recv for ctx: %d\n", i);
 		ret = fi_recv(rx_ep[i], buf, rx_size, fi_mr_desc(mr), 0, NULL);
@@ -230,7 +196,6 @@ static int run_test()
 	}
 
 	if (opts.dst_addr) {
-		/* Post sends directly to each of the recv contexts */
 		for (i = 0; i < ctx_cnt; i++) {
 			fprintf(stdout, "Posting send for ctx: %d\n", i);
 			ret = fi_send(tx_ep[i], buf, tx_size, fi_mr_desc(mr),
@@ -240,12 +205,12 @@ static int run_test()
 				return ret;
 			}
 
-			ft_wait_for_comp(scq_array[i], 1);
+			ft_wait_for_comp(txcq_array[i], 1);
 		}
 	} else {
 		for (i = 0; i < ctx_cnt; i++) {
 			fprintf(stdout, "wait for recv completion for ctx: %d\n", i);
-			ft_wait_for_comp(rcq_array[i], 1);
+			ft_wait_for_comp(rxcq_array[i], 1);
 		}
 	}
 
@@ -274,13 +239,6 @@ static int init_fabric(void)
 	if (!ctx_cnt) {
 		fprintf(stderr, "Provider doesn't support contexts\n");
 		return 1;
-	}
-
-	/* Get remote address */
-	if (opts.dst_addr) {
-		addrlen = fi->dest_addrlen;
-		remote_addr = malloc(addrlen);
-		memcpy(remote_addr, fi->dest_addr, addrlen);
 	}
 
 	ret = ft_open_fabric_res();
@@ -313,71 +271,59 @@ static int init_fabric(void)
 
 static int init_av(void)
 {
-	int ret;
-	int i;
+	size_t addrlen;
+	int ret, i;
 
 	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen
-		 * as 0 and fi_getname will return the actual addrlen. */
-		addrlen = 0;
-		ret = fi_getname(&sep->fid, local_addr, &addrlen);
-		if (ret != -FI_ETOOSMALL) {
-			FT_PRINTERR("fi_getname", ret);
+		ret = fi_av_insert(av, fi->dest_addr, 1, &remote_fi_addr, 0, NULL);
+		if (ret != 1) {
+			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
-		local_addr = malloc(addrlen);
-		ret = fi_getname(&sep->fid, local_addr, &addrlen);
+		addrlen = FT_MAX_CTRL_MSG;
+		ret = fi_getname(&sep->fid, tx_buf, &addrlen);
 		if (ret) {
 			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
 
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
-		if (ret != 1) {
-			FT_PRINTERR("fi_av_insert", ret);
+		ret = fi_send(tx_ep[0], tx_buf, addrlen,
+				fi_mr_desc(mr), remote_fi_addr, &tx_ctx);
+		if (ret) {
+			FT_PRINTERR("fi_send", ret);
 			return ret;
 		}
 
-		for (i = 0; i < ctx_cnt; i++)
-			remote_rx_addr[i] = fi_rx_addr(remote_fi_addr, i, rx_ctx_bits);
-
-		/* Send local addr size and local addr */
-		memcpy(buf, &addrlen, sizeof(size_t));
-		memcpy(buf + sizeof(size_t), local_addr, addrlen);
-		ret = send_msg(sizeof(size_t) + addrlen);
+		ret = ft_wait_for_comp(rxcq_array[0], 1);
 		if (ret)
 			return ret;
-
-		/* Receive ACK from server */
-		ret = recv_msg();
-		if (ret)
-			return ret;
-
 	} else {
-		/* Post a recv to get the remote address */
-		ret = recv_msg();
+		ret = ft_wait_for_comp(rxcq_array[0], 1);
 		if (ret)
 			return ret;
 
-		memcpy(&addrlen, buf, sizeof(size_t));
-		remote_addr = malloc(addrlen);
-		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
-
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0, &fi_ctx_av);
+		ret = fi_av_insert(av, rx_buf, 1, &remote_fi_addr, 0, NULL);
 		if (ret != 1) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
 		}
 
-		/* Send ACK */
-		ret = send_msg(16);
-		if (ret)
+		ret = fi_send(tx_ep[0], tx_buf, 1,
+				fi_mr_desc(mr), remote_fi_addr, &tx_ctx);
+		if (ret) {
+			FT_PRINTERR("fi_send", ret);
 			return ret;
+		}
 	}
 
-	return 0;
+	for (i = 0; i < ctx_cnt; i++)
+		remote_rx_addr[i] = fi_rx_addr(remote_fi_addr, i, rx_ctx_bits);
+
+	ret = ft_wait_for_comp(txcq_array[0], 1);
+	return ret;
 }
+
 
 static int run(void)
 {
@@ -394,7 +340,7 @@ static int run(void)
 	ret = run_test();
 
 	/*TODO: Add a local finalize applicable for scalable ep */
-	//ft_finalize(fi, tx_ep[0], scq_array[0], rcq_array[0], remote_rx_addr[0]);
+	//ft_finalize(fi, tx_ep[0], txcq_array[0], rxcq_array[0], remote_rx_addr[0]);
 
 	return ret;
 }

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -240,7 +240,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	uint64_t access_mode;
 	int ret;
 
-	ret = ft_alloc_bufs();
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
 
@@ -257,15 +257,11 @@ static int alloc_ep_res(struct fi_info *fi)
 		return -FI_EINVAL;
 	}
 	ret = fi_mr_reg(domain, buf, buf_size,
-			access_mode, 0, 0, 0, &mr, NULL);
+			access_mode, 0, FT_MR_KEY, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
 	}
-
-	ret = ft_alloc_active_res(fi);
-	if (ret)
-		return ret;
 
 	return 0;
 }
@@ -302,7 +298,7 @@ static int server_connect(void)
 	if (ret)
 		 goto err;
 
-	ret = ft_init_ep(buf);
+	ret = ft_init_ep();
 	if (ret)
 		goto err;
 
@@ -367,7 +363,7 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(buf);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
 

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -50,22 +50,17 @@ static struct timespec start, end;
 struct fi_rma_iov remote;
 static uint64_t cq_data = 1;
 
-static void *local_addr, *remote_addr;
-static size_t addrlen = 0;
-static fi_addr_t remote_fi_addr;
-struct fi_context fi_ctx_send;
-struct fi_context fi_ctx_recv;
 struct fi_context fi_ctx_write;
 struct fi_context fi_ctx_writedata;
 struct fi_context fi_ctx_read;
-struct fi_context fi_ctx_av;
+
 
 static int send_msg(int size)
 {
 	int ret;
 
 	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-			&fi_ctx_send);
+			&tx_ctx);
 	if (ret) {
 		FT_PRINTERR("fi_send", ret);
 		return ret;
@@ -80,7 +75,7 @@ static int recv_msg(void)
 {
 	int ret;
 
-	ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
+	ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0, &rx_ctx);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
 		return ret;
@@ -154,11 +149,11 @@ static int wait_remote_writedata_completion(void)
 		fprintf(stderr, "Got unexpected completion data %" PRIu64 "\n",
 			comp.data);
 	}
-	assert(comp.op_context == &fi_ctx_recv || comp.op_context == NULL);
-	if (comp.op_context == &fi_ctx_recv) {
+	assert(comp.op_context == &rx_ctx || comp.op_context == NULL);
+	if (comp.op_context == &rx_ctx) {
 		/* We need to repost the receive */
 		ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr),
-				remote_fi_addr, &fi_ctx_recv);
+				remote_fi_addr, &rx_ctx);
 		if (ret)
 			FT_PRINTERR("fi_recv", ret);
 	}
@@ -225,7 +220,7 @@ static int alloc_ep_res(struct fi_info *fi)
 	uint64_t access_mode;
 	int ret;
 
-	ret = ft_alloc_bufs();
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
 
@@ -243,15 +238,11 @@ static int alloc_ep_res(struct fi_info *fi)
 		exit(1);
 	}
 	ret = fi_mr_reg(domain, buf, buf_size,
-			access_mode, 0, 0, 0, &mr, NULL);
+			access_mode, 0, FT_MR_KEY, 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
 	}
-
-	ret = ft_alloc_active_res(fi);
-	if (ret)
-		return ret;
 
 	return 0;
 }
@@ -272,13 +263,6 @@ static int init_fabric(void)
 		return ret;
 	}
 
-	/* Get remote address */
-	if (opts.dst_addr) {
-		addrlen = fi->dest_addrlen;
-		remote_addr = malloc(addrlen);
-		memcpy(remote_addr, fi->dest_addr, addrlen);
-	}
-
 	ret = ft_open_fabric_res();
 	if (ret)
 		return ret;
@@ -293,85 +277,11 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(NULL);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
 
 	return 0;
-}
-
-static int init_av(void)
-{
-	int ret;
-
-	if (opts.dst_addr) {
-		/* Get local address blob. Find the addrlen first. We set addrlen
-		 * as 0 and fi_getname will return the actual addrlen. */
-		addrlen = 0;
-		ret = fi_getname(&ep->fid, local_addr, &addrlen);
-		if (ret != -FI_ETOOSMALL) {
-			FT_PRINTERR("fi_getname", ret);
-			return ret;
-		}
-
-		local_addr = malloc(addrlen);
-		ret = fi_getname(&ep->fid, local_addr, &addrlen);
-		if (ret) {
-			FT_PRINTERR("fi_getname", ret);
-			return ret;
-		}
-
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
-				&fi_ctx_av);
-		if (ret != 1) {
-			FT_PRINTERR("fi_av_insert", ret);
-			return ret;
-		}
-
-		/* Send local addr size and local addr */
-		memcpy(buf, &addrlen, sizeof(size_t));
-		memcpy(buf + sizeof(size_t), local_addr, addrlen);
-		ret = send_msg(sizeof(size_t) + addrlen);
-		if (ret)
-			return ret;
-
-		/* Receive ACK from server */
-		ret = recv_msg();
-		if (ret)
-			return ret;
-
-	} else {
-		/* Post a recv to get the remote address */
-		ret = recv_msg();
-		if (ret)
-			return ret;
-
-		memcpy(&addrlen, buf, sizeof(size_t));
-		remote_addr = malloc(addrlen);
-		memcpy(remote_addr, buf + sizeof(size_t), addrlen);
-
-
-		ret = fi_av_insert(av, remote_addr, 1, &remote_fi_addr, 0,
-				&fi_ctx_av);
-		if (ret != 1) {
-			FT_PRINTERR("fi_av_insert", ret);
-			return ret;
-		}
-
-		/* Send ACK */
-		ret = send_msg(16);
-		if (ret)
-			return ret;
-	}
-
-	/* Post the first recv buffer */
-	ret = fi_recv(ep, buf, rx_size, fi_mr_desc(mr), 0, &fi_ctx_recv);
-	if (ret) {
-		FT_PRINTERR("fi_recv", ret);
-		return ret;
-	}
-
-	return ret;
 }
 
 static int exchange_addr_key(void)
@@ -418,7 +328,7 @@ static int run(void)
 	if (ret)
 		return ret;
 
-	ret = init_av();
+	ret = ft_init_av();
 	if (ret)
 		goto out;
 

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -60,11 +60,16 @@ static char err_buf[512];
 
 static void teardown_ep_fixture(void)
 {
+	FT_CLOSE_FID(mr);
 	FT_CLOSE_FID(ep);
 	FT_CLOSE_FID(txcq);
 	FT_CLOSE_FID(rxcq);
 	FT_CLOSE_FID(av);
-
+	if (buf) {
+		free(buf);
+		buf = rx_buf = tx_buf = NULL;
+		buf_size = rx_size = tx_size = 0;
+	}
 }
 
 /* returns 0 on success or a negative value that can be stringified with
@@ -77,7 +82,7 @@ static int setup_ep_fixture(void)
 	if (ret)
 		return ret;
 
-	ret = ft_init_ep(NULL);
+	ret = ft_init_ep();
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
Replace the dozen or so init_av() duplicate definitions of init_av()
with a common implementation.

In order to insert the remote address of the client side of the
test, a message exchange is needed to provide the server with the
client address.  This requires moving the initial control message
exchange into common code.

That address exchange trickles throughout the code in order to
ensure that receive buffers are posted before sends are initiated,
provide enough buffer space for addressing, and handle FI_PREFIX
correct (for those apps that already support it).

Signed-off-by: Sean Hefty <sean.hefty@intel.com>