### PR TITLE
Move fi_domain() into ft_open_fabric_res()

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -175,6 +175,12 @@ int ft_open_fabric_res(void)
 		return ret;
 	}
 
+	ret = fi_domain(fabric, fi, &domain, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_domain", ret);
+		return ret;
+	}
+
 	return 0;
 }
 
@@ -259,9 +265,17 @@ int ft_start_server(void)
 		return ret;
 	}
 
-	ret = ft_open_fabric_res();
-	if (ret)
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_fabric", ret);
 		return ret;
+	}
+
+	ret = fi_eq_open(fabric, &eq_attr, &eq, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_eq_open", ret);
+		return ret;
+	}
 
 	ret = fi_passive_ep(fabric, fi, &pep, NULL);
 	if (ret) {

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -160,12 +160,6 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -174,12 +174,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/pingpong/rdm_inject_pingpong.c
+++ b/pingpong/rdm_inject_pingpong.c
@@ -164,12 +164,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	/* TODO:
 	 * Memory registration not required for send_buf since we use fi_inject.
 	 * fi_inject copies the buffer of data that needs to be sent.

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -100,12 +100,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -208,12 +208,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -104,12 +104,6 @@ static int common_setup(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -127,12 +127,6 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -63,13 +63,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	/* Open domain */
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -82,15 +82,9 @@ static int init_fabric(void)
 		return ret;
 	}
 
-		ret = ft_open_fabric_res();
+	ret = ft_open_fabric_res();
 	if (ret)
 		return ret;
-
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
 
 	ret = alloc_ep_res(fi);
 	if (ret)

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -122,13 +122,6 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	/* Open domain */
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -182,13 +182,6 @@ static int client_connect(void)
 	if (ret)
 		return ret;
 
-	/* Open domain */
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = alloc_ep_res(fi);
 	if (ret)
 		return ret;

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -138,14 +138,12 @@ static int server_listen(void)
 {
 	int ret;
 
-	/* Bind EQ to passive endpoint */
 	ret = fi_pep_bind(pep, &eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_pep_bind", ret);
 		return ret;
 	}
 
-	/* Listen for incoming connections */
 	ret = fi_listen(pep);
 	if (ret) {
 		FT_PRINTERR("fi_listen", ret);
@@ -232,14 +230,12 @@ static int client_connect(void)
 	ssize_t rd;
 	int ret;
 
-	/* Get fabric info */
 	ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, opts.dst_port, 0, hints, &fi);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
-	/* Open domain */
 	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
@@ -381,9 +377,17 @@ static int setup_handle(void)
 	fi->src_addr = NULL;
 	fi->src_addrlen = 0;
 
-	ret = ft_open_fabric_res();
-	if (ret)
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_fabric", ret);
 		return ret;
+	}
+
+	ret = fi_eq_open(fabric, &eq_attr, &eq, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_eq_open", ret);
+		return ret;
+	}
 
 	/* Open a passive endpoint */
 	ret = fi_passive_ep(fabric, fi, &pep, NULL);

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -96,12 +96,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = alloc_ep_res(fi);
 	if (ret)
 		return ret;

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -63,13 +63,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	/* Open domain */
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -103,12 +103,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = alloc_ep_res(fi);
 	if (ret)
 		return ret;

--- a/simple/rdm_rma_trigger.c
+++ b/simple/rdm_rma_trigger.c
@@ -128,12 +128,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = alloc_ep_res(fi);
 	if (ret)
 		return ret;

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -263,12 +263,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	fi->ep_attr->tx_ctx_cnt = FI_SHARED_CONTEXT;
 	fi->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;
 

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -122,12 +122,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -245,12 +245,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	/* Set the required number of TX and RX context counts */
 	fi->ep_attr->tx_ctx_cnt = ctx_cnt;
 	fi->ep_attr->rx_ctx_cnt = ctx_cnt;

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -353,12 +353,6 @@ static int client_connect(void)
 		return ret;
 
 	mr_mode = fi->domain_attr->mr_mode;
- 	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = alloc_ep_res(fi);
 	if (ret)
 		return ret;

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -424,12 +424,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = alloc_ep_res(fi);
 	if (ret)
 		return ret;

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -254,12 +254,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = alloc_ep_res(fi);
 	if (ret)
 		return ret;

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -267,12 +267,6 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret) {
-		FT_PRINTERR("fi_domain", ret);
-		return ret;
-	}
-
 	ret = alloc_ep_res(fi);
 	if (ret)
 		return ret;

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1058,12 +1058,6 @@ int main(int argc, char **argv)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret != 0) {
-		printf("fi_domain %s\n", fi_strerror(-ret));
-		goto err;
-	}
-
 	printf("Testing AVs on fabric %s\n", fi->fabric_attr->name);
 	failed = 0;
 

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -109,7 +109,8 @@ int main(int argc, char **argv)
 		goto out;
 	}
 
-	for (i = 0; i < num_domains; i++) {
+	/* Common code will open one domain */
+	for (i = 1; i < num_domains; i++) {
 		ret = fi_domain(fabric, fi, &domain_vec[i], NULL);
 		if (ret != FI_SUCCESS) {
 			printf("fi_domain num %d %s\n", i, fi_strerror(-ret));
@@ -117,7 +118,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	while (--i >= 0) {
+	while (--i > 0) {
 		ret = fi_close(&domain_vec[i]->fid);
 		if (ret != FI_SUCCESS) {
 			printf("Error %d closing domain num %d: %s\n", ret,

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -255,12 +255,6 @@ int main(int argc, char **argv)
 	if (ret)
 		return ret;
 
-	ret = fi_domain(fabric, fi, &domain, NULL);
-	if (ret != 0) {
-		printf("fi_domain %s\n", fi_strerror(-ret));
-		exit(1);
-	}
-
 	failed = run_test_set();
 
 	if (failed > 0) {


### PR DESCRIPTION
Nearly all tests open the domain immediately after opening
the fabric resources (fabric and eq).  Move opening the
domain into the common code.

There are a couple of exceptions to this.  The server
side of connected endpoints defer opening the domain until
the connreq is received.  And a couple of unit tests open
the domain differently.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>