### PR TITLE
complex: Add fi_ubertest config files for verbs and sockets providers

### DIFF
--- a/complex/test_configs/sockets.json
+++ b/complex/test_configs/sockets.json
@@ -1,0 +1,102 @@
+{
+	"prov_name": "sockets",
+	"test_type": [
+		"FT_TEST_LATENCY",
+		"FT_TEST_BANDWIDTH",
+	],
+	"class_function": [
+		"FT_FUNC_SEND",
+		"FT_FUNC_SENDV",
+		"FT_FUNC_SENDMSG"
+	],
+	"ep_type": [
+		"FI_EP_MSG",
+		"FI_EP_DGRAM",
+		"FI_EP_RDM"
+	],
+	"av_type": [
+		"FI_AV_TABLE",
+		"FI_AV_MAP"
+	],
+	"comp_type": [
+		"FT_COMP_QUEUE"
+	],
+	"mode": [
+		"FT_MODE_ALL"
+	],
+	"caps": [
+		"FT_CAP_MSG",
+		"FT_CAP_TAGGED"
+	],
+	"test_flags": "FT_FLAG_QUICKTEST"
+},
+{
+	"prov_name": "sockets",
+	"test_type": [
+		"FT_TEST_LATENCY",
+	],
+	"class_function": [
+		"FT_FUNC_SEND",
+	],
+	"ep_type": [
+		"FI_EP_MSG",
+	],
+	"av_type": [
+		"FI_AV_TABLE",
+	],
+	"comp_type": [
+		"FT_COMP_QUEUE"
+	],
+	"eq_wait_obj": [
+		"FI_WAIT_NONE"
+		"FI_WAIT_UNSPEC",
+		"FI_WAIT_FD",
+		"FI_WAIT_MUTEX_COND",
+	],
+	"cq_wait_obj": [
+		"FI_WAIT_NONE"
+	],
+	"mode": [
+		"FT_MODE_ALL"
+	],
+	"caps": [
+		"FT_CAP_MSG",
+	],
+	"test_flags": "FT_FLAG_QUICKTEST"
+},
+{
+	"prov_name": "sockets",
+	"test_type": [
+		"FT_TEST_LATENCY",
+		"FT_TEST_BANDWIDTH",
+	],
+	"class_function": [
+		"FT_FUNC_SEND",
+	],
+	"ep_type": [
+		"FI_EP_MSG",
+		"FI_EP_DGRAM",
+	],
+	"av_type": [
+		"FI_AV_TABLE",
+	],
+	"comp_type": [
+		"FT_COMP_QUEUE"
+	],
+	"eq_wait_obj": [
+		"FI_WAIT_NONE"
+	],
+	"cq_wait_obj": [
+		"FI_WAIT_NONE"
+		"FI_WAIT_UNSPEC",
+		"FI_WAIT_FD",
+		"FI_WAIT_MUTEX_COND",
+	],
+	"mode": [
+		"FT_MODE_ALL"
+	],
+	"caps": [
+		"FT_CAP_MSG",
+	],
+	"test_flags": "FT_FLAG_QUICKTEST"
+},

--- a/complex/test_configs/verbs.json
+++ b/complex/test_configs/verbs.json
@@ -1,0 +1,86 @@
+{
+	"prov_name": "verbs",
+	"test_type": [
+		"FT_TEST_LATENCY",
+		"FT_TEST_BANDWIDTH",
+	],
+	"class_function": [
+		"FT_FUNC_SEND",
+		"FT_FUNC_SENDV",
+		"FT_FUNC_SENDMSG"
+	],
+	"ep_type": [
+		"FI_EP_MSG",
+	],
+	"comp_type": [
+		"FT_COMP_QUEUE"
+	],
+	"mode": [
+		"FT_MODE_ALL"
+	],
+	"caps": [
+		"FT_CAP_MSG",
+	],
+	"test_flags": "FT_FLAG_QUICKTEST"
+},
+{
+	"prov_name": "verbs",
+	"test_type": [
+		"FT_TEST_LATENCY",
+	],
+	"class_function": [
+		"FT_FUNC_SEND",
+	],
+	"ep_type": [
+		"FI_EP_MSG",
+	],
+	"comp_type": [
+		"FT_COMP_QUEUE"
+	],
+	"eq_wait_obj": [
+		"FI_WAIT_NONE"
+		"FI_WAIT_UNSPEC",
+		"FI_WAIT_FD",
+	],
+	"cq_wait_obj": [
+		"FI_WAIT_NONE"
+	],
+	"mode": [
+		"FT_MODE_ALL"
+	],
+	"caps": [
+		"FT_CAP_MSG",
+	],
+	"test_flags": "FT_FLAG_QUICKTEST"
+},
+{
+	"prov_name": "verbs",
+	"test_type": [
+		"FT_TEST_LATENCY",
+		"FT_TEST_BANDWIDTH",
+	],
+	"class_function": [
+		"FT_FUNC_SEND",
+	],
+	"ep_type": [
+		"FI_EP_MSG",
+	],
+	"comp_type": [
+		"FT_COMP_QUEUE"
+	],
+	"eq_wait_obj": [
+		"FI_WAIT_NONE"
+	],
+	"cq_wait_obj": [
+		"FI_WAIT_NONE"
+		"FI_WAIT_UNSPEC",
+		"FI_WAIT_FD",
+	],
+	"mode": [
+		"FT_MODE_ALL"
+	],
+	"caps": [
+		"FT_CAP_MSG",
+	],
+	"test_flags": "FT_FLAG_QUICKTEST"
+},


### PR DESCRIPTION
This commit adds config files that runs tests specific for one provider. Verbs and sockets provider tests are added now. PSM tests would be added later.
