### PR TITLE
av_insert: Fixed the return value of the calling function

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -361,9 +361,12 @@ int ft_init_av(void)
 
 	if (opts.dst_addr) {
 		ret = fi_av_insert(av, fi->dest_addr, 1, &remote_fi_addr, 0, NULL);
-		if (ret != 1) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
+		} else if (ret != 1) {
+			FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+			return -1;
 		}
 
 		addrlen = FT_MAX_CTRL_MSG;
@@ -391,9 +394,12 @@ int ft_init_av(void)
 
 		ret = fi_av_insert(av, (char *) rx_buf + ft_rx_prefix_size(),
 				   1, &remote_fi_addr, 0, NULL);
-		if (ret != 1) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
+		} else if (ret != 1) {
+			FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+			return -1;
 		}
 
 		ret = fi_send(ep, tx_buf, ft_tx_prefix_size() + 1,

--- a/complex/ft_comm.c
+++ b/complex/ft_comm.c
@@ -107,9 +107,12 @@ static int ft_load_av(void)
 		return ret;
 
 	ret = fi_av_insert(av, msg.data, 1, &ft_tx.addr, 0, NULL);
-	if (ret != 1) {
+	if (ret < 0) {
 		FT_PRINTERR("fi_av_insert", ret);
 		return ret;
+	} else if (ret != 1) {
+		FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+		return -1;
 	}
 
 	return 0;

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -304,9 +304,12 @@ static int init_av(void)
 
 	if (opts.dst_addr) {
 		ret = fi_av_insert(av, remote_addr, 1, &addr_array[0], 0, NULL);
-		if (ret != 1) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
+		} else if (ret != 1) {
+			FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+			return -1;
 		}
 
 		/* Send local EP addresses to one of the remote endpoints */
@@ -328,9 +331,12 @@ static int init_av(void)
 		 * Skip the first address since we already have it in AV */
 		ret = fi_av_insert(av, remote_addr + addrlen, ep_cnt - 1,
 				addr_array + 1, 0, NULL);
-		if (ret != ep_cnt - 1) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
+		} else if (ret != (ep_cnt - 1)) {
+			FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+			return -1;
 		}
 
 		/* Send ACK */
@@ -350,9 +356,12 @@ static int init_av(void)
 
 		/* Insert remote addresses into AV */
 		ret = fi_av_insert(av, remote_addr, ep_cnt, addr_array, 0, NULL);
-		if (ret != ep_cnt) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
+		} else if (ret != ep_cnt) {
+			FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+			return -1;
 		}
 
 		/* Send local EP addresses to one of the remote endpoints */

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -270,9 +270,12 @@ static int init_av(void)
 
 	if (opts.dst_addr) {
 		ret = fi_av_insert(av, fi->dest_addr, 1, &remote_fi_addr, 0, NULL);
-		if (ret != 1) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
+		} else if (ret != 1) {
+			FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+			return -1;
 		}
 
 		addrlen = FT_MAX_CTRL_MSG;
@@ -298,9 +301,12 @@ static int init_av(void)
 			return ret;
 
 		ret = fi_av_insert(av, rx_buf, 1, &remote_fi_addr, 0, NULL);
-		if (ret != 1) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
+		} else if (ret != 1) {
+			FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+			return -1;
 		}
 
 		ret = fi_send(tx_ep[0], tx_buf, 1,

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -279,9 +279,12 @@ static int init_av(void)
 
 	if (opts.dst_addr) {
 		ret = fi_av_insert(av, fi->dest_addr, 1, &remote_fi_addr, 0, NULL);
-		if (ret != 1) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
+		} else if (ret != 1) {
+			FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+			return -1;
 		}
 
 		addrlen = 64;
@@ -300,9 +303,12 @@ static int init_av(void)
 			return ret;
 
 		ret = fi_av_insert(av, rx_buf, 1, &remote_fi_addr, 0, NULL);
-		if (ret != 1) {
+		if (ret < 0) {
 			FT_PRINTERR("fi_av_insert", ret);
 			return ret;
+		} else if (ret != 1) {
+			FT_ERR("fi_av_insert: number of inserted address = %d\n", ret);
+			return -1;
 		}
 	}
 


### PR DESCRIPTION
Chnaged the return value of the calling function from <code>return ret</code> to <code>return -1</code>. Since we treat 0 as a successful return value and in case, we insert 1 address and av_insert returns 0, the calling function will return 0(success) which is wrong. Resolves #163 

@a-ilango, can you please review?

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>