### PR TITLE
Use common code for message processing

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013,2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under the BSD license below:
  *
@@ -72,6 +72,7 @@ enum {
 	FT_OPT_TX_CQ		= 1 << 3,
 	FT_OPT_RX_CNTR		= 1 << 4,
 	FT_OPT_TX_CNTR		= 1 << 5,
+	FT_OPT_VERIFY_DATA	= 1 << 6,
 };
 
 struct ft_opts {
@@ -107,7 +108,7 @@ extern size_t buf_size, tx_size, rx_size;
 
 extern struct fi_context tx_ctx, rx_ctx;
 
-extern size_t tx_credits;
+extern uint64_t tx_seq, rx_seq, tx_cq_cntr, rx_cq_cntr;
 extern struct fi_av_attr av_attr;
 extern struct fi_eq_attr eq_attr;
 extern struct fi_cq_attr cq_attr;
@@ -178,14 +179,19 @@ int ft_init_ep();
 int ft_init_av();
 void ft_free_res();
 void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len);
+int ft_sync();
 int ft_finalize(struct fi_info *fi, struct fid_ep *tx_ep, struct fid_cq *txcq,
 		struct fid_cq *rxcq, fi_addr_t addr);
 
 size_t ft_rx_prefix_size();
 size_t ft_tx_prefix_size();
+ssize_t ft_rx();
+ssize_t ft_tx(size_t size);
+ssize_t ft_rx_tag(uint64_t tag);
+ssize_t ft_tx_tag(size_t size, uint64_t tag);
 
-int ft_get_rx_comp(int count);
-int ft_get_tx_comp(int count);
+int ft_get_rx_comp(uint64_t total);
+int ft_get_tx_comp(uint64_t total);
 
 int ft_wait_for_comp(struct fid_cq *cq, int num_completions);
 void cq_readerr(struct fid_cq *cq, const char *cq_str);

--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -55,13 +55,13 @@ static int run_test()
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	for (i = 0; i < opts.iterations; i++) {
-		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
+		ret = opts.dst_addr ? ft_sendmsg(opts.transfer_size) :
 				 recv_xfer(opts.transfer_size, false);
 		if (ret)
 			return ret;
 
 		ret = opts.dst_addr ? recv_xfer(opts.transfer_size, false) :
-				 send_xfer(opts.transfer_size);
+				ft_sendmsg(opts.transfer_size);
 		if (ret)
 			return ret;
 	}

--- a/pingpong/pingpong_shared.c
+++ b/pingpong/pingpong_shared.c
@@ -98,29 +98,6 @@ int wait_for_completion_timeout(struct fid_cq *cq, int num_completions)
 	return 0;
 }
 
-int send_xfer(size_t size)
-{
-	int ret;
-
-	if (!tx_credits) {
-		ret = ft_wait_for_comp(txcq, 1);
-		if (ret)
-			return ret;
-	} else {
-		tx_credits--;
-	}
-
-	if (verify_data)
-		ft_fill_buf((char *) tx_buf + ft_tx_prefix_size(), size);
-
-	ret = fi_send(ep, tx_buf, size + ft_tx_prefix_size(),
-			fi_mr_desc(mr), remote_fi_addr, &tx_ctx);
-	if (ret)
-		FT_PRINTERR("fi_send", ret);
-
-	return ret;
-}
-
 int recv_xfer(size_t size, bool enable_timeout)
 {
 	int ret;
@@ -155,9 +132,9 @@ int sync_test(bool enable_timeout)
 		return ret;
 	tx_credits = fi->tx_attr->size;
 
-	ret = opts.dst_addr ? send_xfer(16) : recv_xfer(16, enable_timeout);
+	ret = opts.dst_addr ? ft_sendmsg(1) : recv_xfer(16, enable_timeout);
 	if (ret)
 		return ret;
 
-	return opts.dst_addr ? recv_xfer(16, enable_timeout) : send_xfer(16);
+	return opts.dst_addr ? recv_xfer(16, enable_timeout) : ft_sendmsg(1);
 }

--- a/pingpong/pingpong_shared.h
+++ b/pingpong/pingpong_shared.h
@@ -42,7 +42,6 @@ extern "C" {
 
 #define PONG_OPTS "vP"
 
-extern int verify_data;
 extern int timeout;
 
 void ft_parsepongopts(int op);
@@ -50,7 +49,6 @@ void ft_pongusage(void);
 
 int wait_for_completion_timeout(struct fid_cq *cq, int num_completions);
 
-int send_xfer(size_t size);
 int recv_xfer(size_t size, bool enable_timeout);
 int sync_test(bool enable_timeout);
 

--- a/pingpong/rdm_cntr_pingpong.c
+++ b/pingpong/rdm_cntr_pingpong.c
@@ -114,11 +114,11 @@ static int sync_test(void)
 	if (ret)
 		return ret;
 
-	ret = opts.dst_addr ? send_xfer(16) : recv_xfer(16);
+	ret = opts.dst_addr ? ft_sendmsg(1) : recv_xfer(16);
 	if (ret)
 		return ret;
 
-	return opts.dst_addr ? recv_xfer(16) : send_xfer(16);
+	return opts.dst_addr ? recv_xfer(16) : ft_sendmsg(1);
 }
 
 static int run_test(void)
@@ -131,13 +131,13 @@ static int run_test(void)
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	for (i = 0; i < opts.iterations; i++) {
-		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
+		ret = opts.dst_addr ? ft_sendmsg(opts.transfer_size) :
 				 recv_xfer(opts.transfer_size);
 		if (ret)
 			goto out;
 
 		ret = opts.dst_addr ? recv_xfer(opts.transfer_size) :
-				 send_xfer(opts.transfer_size);
+				ft_sendmsg(opts.transfer_size);
 		if (ret)
 			goto out;
 	}

--- a/pingpong/rdm_pingpong.c
+++ b/pingpong/rdm_pingpong.c
@@ -57,13 +57,13 @@ static int run_test(void)
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	for (i = 0; i < opts.iterations; i++) {
-		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
+		ret = opts.dst_addr ? ft_sendmsg(opts.transfer_size) :
 				 recv_xfer(opts.transfer_size, false);
 		if (ret)
 			goto out;
 
 		ret = opts.dst_addr ? recv_xfer(opts.transfer_size, false) :
-				 send_xfer(opts.transfer_size);
+				ft_sendmsg(opts.transfer_size);
 		if (ret)
 			goto out;
 	}

--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -53,36 +53,6 @@ struct fi_context fi_ctx_trecv;
 static uint64_t tag_data = 0;
 
 
-
-static int send_xfer(int size)
-{
-	struct fi_cq_tagged_entry comp;
-	int ret;
-
-	while (!tx_credits) {
-		ret = fi_cq_read(txcq, &comp, 1);
-		if (ret > 0) {
-			goto post;
-		} else if (ret < 0 && ret != -FI_EAGAIN) {
-			if (ret == -FI_EAVAIL) {
-				cq_readerr(txcq, "txcq");
-			} else {
-				FT_PRINTERR("fi_cq_read", ret);
-			}
-			return ret;
-		}
-	}
-
-	tx_credits--;
-post:
-	ret = fi_tsend(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-			tag_data, &fi_ctx_tsend);
-	if (ret)
-		FT_PRINTERR("fi_tsend", ret);
-
-	return ret;
-}
-
 static int recv_xfer(int size)
 {
 	struct fi_cq_tagged_entry comp;
@@ -163,13 +133,13 @@ static int run_test(void)
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	for (i = 0; i < opts.iterations; i++) {
-		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
+		ret = opts.dst_addr ? ft_tsendmsg(opts.transfer_size) :
 				 recv_xfer(opts.transfer_size);
 		if (ret)
 			goto out;
 
 		ret = opts.dst_addr ? recv_xfer(opts.transfer_size) :
-				 send_xfer(opts.transfer_size);
+				ft_tsendmsg(opts.transfer_size);
 		if (ret)
 			goto out;
 

--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -62,13 +62,13 @@ static int run_test(void)
 
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	for (i = 0; i < opts.iterations; i++) {
-		ret = opts.dst_addr ? send_xfer(opts.transfer_size) :
+		ret = opts.dst_addr ? ft_sendmsg(opts.transfer_size) :
 				 recv_xfer(opts.transfer_size, true);
 		if (ret)
 			return ret;
 
 		ret = opts.dst_addr ? recv_xfer(opts.transfer_size, true) :
-				 send_xfer(opts.transfer_size);
+				ft_sendmsg(opts.transfer_size);
 		if (ret)
 			return ret;
 	}

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -50,20 +50,6 @@ static uint64_t tag_control = 0x12345678;
 
 
 
-static int send_msg(int size, uint64_t tag)
-{
-	int ret;
-
-	ret = fi_tsend(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-			tag, &tx_ctx);
-	if (ret)
-		FT_PRINTERR("fi_tsend", ret);
-
-	ret = ft_wait_for_comp(txcq, 1);
-
-	return ret;
-}
-
 static int recv_msg(uint64_t tag)
 {
 	int ret;
@@ -93,11 +79,11 @@ static int sync_test(void)
 {
 	int ret;
 
-	ret = opts.dst_addr ? send_msg(16, tag_control) : recv_msg(tag_control);
+	ret = opts.dst_addr ? ft_tsendmsg(1, tag_control) : recv_msg(tag_control);
 	if (ret)
 		return ret;
 
-	ret = opts.dst_addr ? recv_msg(tag_control) : send_msg(16, tag_control);
+	ret = opts.dst_addr ? recv_msg(tag_control) : ft_tsendmsg(1, tag_control);
 
 	return ret;
 }
@@ -212,13 +198,13 @@ static int run(void)
 
 		fprintf(stdout, "Sending msg with tag [%" PRIu64 "]\n",
 			tag_data);
-		ret = send_msg(16, tag_data);
+		ret = ft_tsendmsg(1, tag_data);
 		if (ret)
 			goto out;
 
 		fprintf(stdout, "Sending msg with tag [%" PRIu64 "]\n",
 			tag_data + 1);
-		ret = send_msg(16, tag_data + 1);
+		ret = ft_tsendmsg(1, tag_data + 1);
 		if (ret)
 			goto out;
 	}

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -114,29 +114,15 @@ static int post_recv(void)
 	return ft_wait_for_comp(rxcq, 1);
 }
 
-static int send_msg(int size)
-{
-	int ret;
-
-	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-			&tx_ctx);
-	if (ret) {
-		FT_PRINTERR("fi_send", ret);
-		return ret;
-	}
-
-	return ft_wait_for_comp(txcq, 1);
-}
-
 static int sync_test(void)
 {
 	int ret;
 
-	ret = opts.dst_addr ? send_msg(16) : post_recv();
+	ret = opts.dst_addr ? ft_sendmsg(1) : post_recv();
 	if (ret)
 		return ret;
 
-	return opts.dst_addr ? post_recv() : send_msg(16);
+	return opts.dst_addr ? post_recv() : ft_sendmsg(1);
 }
 
 static int is_valid_base_atomic_op(enum fi_op op)
@@ -440,13 +426,14 @@ static int exchange_addr_key(void)
 	struct fi_rma_iov *rma_iov;
 	int ret;
 
+	/* FIXME: Tx/Rx buffers are overlapping */
 	rma_iov = buf;
 
 	if (opts.dst_addr) {
 		rma_iov->addr = fi->domain_attr->mr_mode == FI_MR_SCALABLE ?
 				0 : (uintptr_t) buf;
 		rma_iov->key = fi_mr_key(mr);
-		ret = send_msg(sizeof *rma_iov);
+		ret = ft_sendmsg(sizeof *rma_iov);
 		if (ret)
 			return ret;
 
@@ -463,7 +450,7 @@ static int exchange_addr_key(void)
 		rma_iov->addr = fi->domain_attr->mr_mode == FI_MR_SCALABLE ?
 				0 : (uintptr_t) buf;
 		rma_iov->key = fi_mr_key(mr);
-		ret = send_msg(sizeof *rma_iov);
+		ret = ft_sendmsg(sizeof *rma_iov);
 		if (ret)
 			return ret;
 	}

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -90,29 +90,15 @@ int wait_for_recv_completion(int num_completions)
 	return 0;
 }
 
-static int send_msg(size_t size)
-{
-	int ret;
-
-	ret = fi_send(ep, tx_buf, size, fi_mr_desc(mr), remote_fi_addr, &tx_ctx);
-	if (ret) {
-		FT_PRINTERR("fi_send", ret);
-		return ret;
-	}
-
-	ret = ft_wait_for_comp(txcq, 1);
-	return ret;
-}
-
 static int sync_test(void)
 {
 	int ret;
 
-	ret = opts.dst_addr ? send_msg(16) : wait_for_recv_completion(1);
+	ret = opts.dst_addr ? ft_sendmsg(1) : wait_for_recv_completion(1);
 	if (ret)
 		return ret;
 
-	return opts.dst_addr ? wait_for_recv_completion(1) : send_msg(16);
+	return opts.dst_addr ? wait_for_recv_completion(1) : ft_sendmsg(1);
 }
 
 /*
@@ -149,7 +135,7 @@ static int run_test(void)
 	clock_gettime(CLOCK_MONOTONIC, &start);
 	if (opts.dst_addr) {
 		for (i = 0; i < opts.iterations; i++) {
-			ret = send_msg(opts.transfer_size);
+			ret = ft_sendmsg(opts.transfer_size);
 			if (ret)
 				goto out;
 		}
@@ -294,7 +280,7 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = send_msg(addrlen);
+		ret = ft_sendmsg(addrlen);
 		if (ret)
 			return ret;
 	} else {

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -55,22 +55,6 @@ struct fi_context fi_ctx_writedata;
 struct fi_context fi_ctx_read;
 
 
-static int send_msg(int size)
-{
-	int ret;
-
-	ret = fi_send(ep, buf, (size_t) size, fi_mr_desc(mr), remote_fi_addr,
-			&tx_ctx);
-	if (ret) {
-		FT_PRINTERR("fi_send", ret);
-		return ret;
-	}
-
-	ret = ft_wait_for_comp(txcq, 1);
-
-	return ret;
-}
-
 static int recv_msg(void)
 {
 	int ret;
@@ -165,11 +149,11 @@ static int sync_test(void)
 {
 	int ret;
 
-	ret = opts.dst_addr ? send_msg(16) : recv_msg();
+	ret = opts.dst_addr ? ft_sendmsg(1) : recv_msg();
 	if (ret)
 		return ret;
 
-	return opts.dst_addr ? recv_msg() : send_msg(16);
+	return opts.dst_addr ? recv_msg() : ft_sendmsg(1);
 }
 
 static int run_test(void)
@@ -283,13 +267,14 @@ static int exchange_addr_key(void)
 	struct fi_rma_iov *rma_iov;
 	int ret;
 
+	/* FIXME: Rx/Tx buffers overlap */
 	rma_iov = buf;
 
 	if (opts.dst_addr) {
 		rma_iov->addr = fi->domain_attr->mr_mode == FI_MR_SCALABLE ?
 				0 : (uintptr_t) buf;
 		rma_iov->key = fi_mr_key(mr);
-		ret = send_msg(sizeof *rma_iov);
+		ret = ft_sendmsg(sizeof *rma_iov);
 		if (ret)
 			return ret;
 
@@ -306,7 +291,7 @@ static int exchange_addr_key(void)
 		rma_iov->addr = fi->domain_attr->mr_mode == FI_MR_SCALABLE ?
 				0 : (uintptr_t) buf;
 		rma_iov->key = fi_mr_key(mr);
-		ret = send_msg(sizeof *rma_iov);
+		ret = ft_sendmsg(sizeof *rma_iov);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
Provide a common implementation for sending, receiving,
and completion process.
This will help all test apps support (with additional changes)
the FI_PREFIX and FI_CONTEXT mode bits.

As part of this change, we assign a virtual tx sequence number
to each sent message.  The receiving side matches this with
an rx sequence number.  The sequence numbers are used as tags
when dealing with the tag matching interface.

Completion processing is updated to count the number of entries
that have been retrieved from a CQ.  Calls are updated to wait
until a total number of completions have occurred, rather than
waiting for X new completions.  This will allow CQs to be
converted to counters more easily.

This change fixes several places where fi_context structures
were reused before a previous request completed.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>