### PR TITLE
Use common code for message processing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -134,7 +134,9 @@ pingpong_fi_ud_pingpong_SOURCES = \
 pingpong_fi_ud_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_rdm_cntr_pingpong_SOURCES = \
-	pingpong/rdm_cntr_pingpong.c
+	pingpong/rdm_cntr_pingpong.c \
+	pingpong/pingpong_shared.h \
+	pingpong/pingpong_shared.c
 pingpong_fi_rdm_cntr_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_rdm_pingpong_SOURCES = \
@@ -144,11 +146,15 @@ pingpong_fi_rdm_pingpong_SOURCES = \
 pingpong_fi_rdm_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_rdm_tagged_pingpong_SOURCES = \
-	pingpong/rdm_tagged_pingpong.c
+	pingpong/rdm_tagged_pingpong.c \
+	pingpong/pingpong_shared.h \
+	pingpong/pingpong_shared.c
 pingpong_fi_rdm_tagged_pingpong_LDADD = libfabtests.la
 
 pingpong_fi_rdm_inject_pingpong_SOURCES = \
-	pingpong/rdm_inject_pingpong.c
+	pingpong/rdm_inject_pingpong.c \
+	pingpong/pingpong_shared.h \
+	pingpong/pingpong_shared.c
 pingpong_fi_rdm_inject_pingpong_LDADD = libfabtests.la
 
 

--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -98,8 +98,8 @@ struct ft_control {
 	int			error;
 };
 
-extern struct ft_xcontrol ft_rx, ft_tx;
-extern struct ft_control ft;
+extern struct ft_xcontrol ft_rx_ctrl, ft_tx_ctrl;
+extern struct ft_control ft_ctrl;
 
 enum {
 	FT_MAX_CAPS		= 64,

--- a/complex/ft_comm.c
+++ b/complex/ft_comm.c
@@ -106,7 +106,7 @@ static int ft_load_av(void)
 	if (ret)
 		return ret;
 
-	ret = fi_av_insert(av, msg.data, 1, &ft_tx.addr, 0, NULL);
+	ret = fi_av_insert(av, msg.data, 1, &ft_tx_ctrl.addr, 0, NULL);
 	if (ret < 0) {
 		FT_PRINTERR("fi_av_insert", ret);
 		return ret;

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -181,7 +181,7 @@ static int ft_setup_xcontrol_bufs(struct ft_xcontrol *ctrl)
 	size_t size;
 	int i, ret;
 
-	size = ft.size_array[ft.size_cnt - 1];
+	size = ft_ctrl.size_array[ft_ctrl.size_cnt - 1];
 	if (!ctrl->buf) {
 		ctrl->buf = calloc(1, size);
 		if (!ctrl->buf)
@@ -198,7 +198,7 @@ static int ft_setup_xcontrol_bufs(struct ft_xcontrol *ctrl)
 		ctrl->memdesc = fi_mr_desc(ctrl->mr);
 	}
 
-	for (i = 0; i < ft.iov_cnt; i++)
+	for (i = 0; i < ft_ctrl.iov_cnt; i++)
 		ctrl->iov_desc[i] = ctrl->memdesc;
 
 	return 0;
@@ -208,11 +208,11 @@ static int ft_setup_bufs(void)
 {
 	int ret;
 
-	ret = ft_setup_xcontrol_bufs(&ft_rx);
+	ret = ft_setup_xcontrol_bufs(&ft_rx_ctrl);
 	if (ret)
 		return ret;
 
-	ret = ft_setup_xcontrol_bufs(&ft_tx);
+	ret = ft_setup_xcontrol_bufs(&ft_tx_ctrl);
 	if (ret)
 		return ret;
 

--- a/complex/ft_endpoint.c
+++ b/complex/ft_endpoint.c
@@ -89,8 +89,8 @@ int ft_open_active(void)
 		return ret;
 	}
 
-	ft_rx.ep = ep;
-	ft_tx.ep = ep;
+	ft_rx_ctrl.ep = ep;
+	ft_tx_ctrl.ep = ep;
 
 	ret = fi_ep_bind(ep, &eq->fid, 0);
 	if (ret) {
@@ -131,14 +131,14 @@ int ft_reset_ep(void)
 	if (ret)
 		return ret;
 
-	while (ft_tx.credits < ft_tx.max_credits) {
+	while (ft_tx_ctrl.credits < ft_tx_ctrl.max_credits) {
 		ret = ft_comp_tx(0);
 		if (ret)
 			return ret;
 	}
 
-	memset(ft_tx.buf, 0, ft_tx.msg_size);
-	memset(ft_rx.buf, 0, ft_rx.msg_size);
+	memset(ft_tx_ctrl.buf, 0, ft_tx_ctrl.msg_size);
+	memset(ft_rx_ctrl.buf, 0, ft_rx_ctrl.msg_size);
 	ret = ft_post_recv_bufs();
 	if (ret)
 		return ret;

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -53,8 +53,8 @@ static struct ft_series *series;
 static int test_start_index, test_end_index = INT_MAX;
 struct ft_info test_info;
 struct fi_info *fabric_info;
-struct ft_xcontrol ft_rx, ft_tx;
-struct ft_control ft;
+struct ft_xcontrol ft_rx_ctrl, ft_tx_ctrl;
+struct ft_control ft_ctrl;
 
 size_t recv_size, send_size;
 

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -40,27 +40,27 @@ static int ft_post_recv(void)
 
 	switch (test_info.class_function) {
 	case FT_FUNC_SENDV:
-		ft_format_iov(ft_rx.iov, ft.iov_array[ft_rx.iov_iter],
-				ft_rx.buf, ft_rx.msg_size);
-		ret = fi_recvv(ft_rx.ep, ft_rx.iov, ft_rx.iov_desc,
-				ft.iov_array[ft_rx.iov_iter], ft_rx.addr, NULL);
-		ft_next_iov_cnt(&ft_rx, fabric_info->rx_attr->iov_limit);
+		ft_format_iov(ft_rx_ctrl.iov, ft_ctrl.iov_array[ft_rx_ctrl.iov_iter],
+				ft_rx_ctrl.buf, ft_rx_ctrl.msg_size);
+		ret = fi_recvv(ft_rx_ctrl.ep, ft_rx_ctrl.iov, ft_rx_ctrl.iov_desc,
+				ft_ctrl.iov_array[ft_rx_ctrl.iov_iter], ft_rx_ctrl.addr, NULL);
+		ft_next_iov_cnt(&ft_rx_ctrl, fabric_info->rx_attr->iov_limit);
 		break;
 	case FT_FUNC_SENDMSG:
-		ft_format_iov(ft_rx.iov, ft.iov_array[ft_rx.iov_iter],
-				ft_rx.buf, ft_rx.msg_size);
-		msg.msg_iov = ft_rx.iov;
-		msg.desc = ft_rx.iov_desc;
-		msg.iov_count = ft.iov_array[ft_rx.iov_iter];
-		msg.addr = ft_rx.addr;
+		ft_format_iov(ft_rx_ctrl.iov, ft_ctrl.iov_array[ft_rx_ctrl.iov_iter],
+				ft_rx_ctrl.buf, ft_rx_ctrl.msg_size);
+		msg.msg_iov = ft_rx_ctrl.iov;
+		msg.desc = ft_rx_ctrl.iov_desc;
+		msg.iov_count = ft_ctrl.iov_array[ft_rx_ctrl.iov_iter];
+		msg.addr = ft_rx_ctrl.addr;
 		msg.context = NULL;
 		msg.data = 0;
-		ret = fi_recvmsg(ft_rx.ep, &msg, 0);
-		ft_next_iov_cnt(&ft_rx, fabric_info->rx_attr->iov_limit);
+		ret = fi_recvmsg(ft_rx_ctrl.ep, &msg, 0);
+		ft_next_iov_cnt(&ft_rx_ctrl, fabric_info->rx_attr->iov_limit);
 		break;
 	default:
-		ret = fi_recv(ft_rx.ep, ft_rx.buf, ft_rx.msg_size,
-				ft_rx.memdesc, ft_rx.addr, NULL);
+		ret = fi_recv(ft_rx_ctrl.ep, ft_rx_ctrl.buf, ft_rx_ctrl.msg_size,
+				ft_rx_ctrl.memdesc, ft_rx_ctrl.addr, NULL);
 		break;
 	}
 
@@ -74,29 +74,29 @@ static int ft_post_trecv(void)
 
 	switch (test_info.class_function) {
 	case FT_FUNC_SENDV:
-		ft_format_iov(ft_rx.iov, ft.iov_array[ft_rx.iov_iter],
-				ft_rx.buf, ft_rx.msg_size);
-		ret = fi_trecvv(ft_rx.ep, ft_rx.iov, ft_rx.iov_desc,
-				ft.iov_array[ft_rx.iov_iter], ft_rx.addr,
-				ft_rx.tag, 0, NULL);
-		ft_next_iov_cnt(&ft_rx, fabric_info->rx_attr->iov_limit);
+		ft_format_iov(ft_rx_ctrl.iov, ft_ctrl.iov_array[ft_rx_ctrl.iov_iter],
+				ft_rx_ctrl.buf, ft_rx_ctrl.msg_size);
+		ret = fi_trecvv(ft_rx_ctrl.ep, ft_rx_ctrl.iov, ft_rx_ctrl.iov_desc,
+				ft_ctrl.iov_array[ft_rx_ctrl.iov_iter], ft_rx_ctrl.addr,
+				ft_rx_ctrl.tag, 0, NULL);
+		ft_next_iov_cnt(&ft_rx_ctrl, fabric_info->rx_attr->iov_limit);
 		break;
 	case FT_FUNC_SENDMSG:
-		ft_format_iov(ft_rx.iov, ft.iov_array[ft_rx.iov_iter],
-				ft_rx.buf, ft_rx.msg_size);
-		msg.msg_iov = ft_rx.iov;
-		msg.desc = ft_rx.iov_desc;
-		msg.iov_count = ft.iov_array[ft_rx.iov_iter];
-		msg.addr = ft_rx.addr;
-		msg.tag = ft_rx.tag;
+		ft_format_iov(ft_rx_ctrl.iov, ft_ctrl.iov_array[ft_rx_ctrl.iov_iter],
+				ft_rx_ctrl.buf, ft_rx_ctrl.msg_size);
+		msg.msg_iov = ft_rx_ctrl.iov;
+		msg.desc = ft_rx_ctrl.iov_desc;
+		msg.iov_count = ft_ctrl.iov_array[ft_rx_ctrl.iov_iter];
+		msg.addr = ft_rx_ctrl.addr;
+		msg.tag = ft_rx_ctrl.tag;
 		msg.ignore = 0;
 		msg.context = NULL;
-		ret = fi_trecvmsg(ft_rx.ep, &msg, 0);
-		ft_next_iov_cnt(&ft_rx, fabric_info->rx_attr->iov_limit);
+		ret = fi_trecvmsg(ft_rx_ctrl.ep, &msg, 0);
+		ft_next_iov_cnt(&ft_rx_ctrl, fabric_info->rx_attr->iov_limit);
 		break;
 	default:
-		ret = fi_trecv(ft_rx.ep, ft_rx.buf, ft_rx.msg_size,
-				ft_rx.memdesc, ft_rx.addr, ft_rx.tag, 0, NULL);
+		ret = fi_trecv(ft_rx_ctrl.ep, ft_rx_ctrl.buf, ft_rx_ctrl.msg_size,
+				ft_rx_ctrl.memdesc, ft_rx_ctrl.addr, ft_rx_ctrl.tag, 0, NULL);
 		break;
 	}
 	return ret;
@@ -109,27 +109,27 @@ static int ft_post_send(void)
 
 	switch (test_info.class_function) {
 	case FT_FUNC_SENDV:
-		ft_format_iov(ft_tx.iov, ft.iov_array[ft_tx.iov_iter],
-				ft_tx.buf, ft_tx.msg_size);
-		ret = fi_sendv(ft_tx.ep, ft_tx.iov, ft_tx.iov_desc,
-				ft.iov_array[ft_tx.iov_iter], ft_tx.addr, NULL);
-		ft_next_iov_cnt(&ft_tx, fabric_info->tx_attr->iov_limit);
+		ft_format_iov(ft_tx_ctrl.iov, ft_ctrl.iov_array[ft_tx_ctrl.iov_iter],
+				ft_tx_ctrl.buf, ft_tx_ctrl.msg_size);
+		ret = fi_sendv(ft_tx_ctrl.ep, ft_tx_ctrl.iov, ft_tx_ctrl.iov_desc,
+				ft_ctrl.iov_array[ft_tx_ctrl.iov_iter], ft_tx_ctrl.addr, NULL);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
 		break;
 	case FT_FUNC_SENDMSG:
-		ft_format_iov(ft_tx.iov, ft.iov_array[ft_tx.iov_iter],
-				ft_tx.buf, ft_tx.msg_size);
-		msg.msg_iov = ft_tx.iov;
-		msg.desc = ft_tx.iov_desc;
-		msg.iov_count = ft.iov_array[ft_tx.iov_iter];
-		msg.addr = ft_tx.addr;
+		ft_format_iov(ft_tx_ctrl.iov, ft_ctrl.iov_array[ft_tx_ctrl.iov_iter],
+				ft_tx_ctrl.buf, ft_tx_ctrl.msg_size);
+		msg.msg_iov = ft_tx_ctrl.iov;
+		msg.desc = ft_tx_ctrl.iov_desc;
+		msg.iov_count = ft_ctrl.iov_array[ft_tx_ctrl.iov_iter];
+		msg.addr = ft_tx_ctrl.addr;
 		msg.context = NULL;
 		msg.data = 0;
-		ret = fi_sendmsg(ft_tx.ep, &msg, 0);
-		ft_next_iov_cnt(&ft_tx, fabric_info->tx_attr->iov_limit);
+		ret = fi_sendmsg(ft_tx_ctrl.ep, &msg, 0);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
 		break;
 	default:
-		ret = fi_send(ft_tx.ep, ft_tx.buf, ft_tx.msg_size,
-				ft_tx.memdesc, ft_tx.addr, NULL);
+		ret = fi_send(ft_tx_ctrl.ep, ft_tx_ctrl.buf, ft_tx_ctrl.msg_size,
+				ft_tx_ctrl.memdesc, ft_tx_ctrl.addr, NULL);
 		break;
 	}
 
@@ -143,29 +143,29 @@ static int ft_post_tsend(void)
 
 	switch (test_info.class_function) {
 	case FT_FUNC_SENDV:
-		ft_format_iov(ft_tx.iov, ft.iov_array[ft_tx.iov_iter],
-				ft_tx.buf, ft_tx.msg_size);
-		ret = fi_tsendv(ft_tx.ep, ft_tx.iov, ft_tx.iov_desc,
-				ft.iov_array[ft_tx.iov_iter], ft_tx.addr,
-				ft_tx.tag, NULL);
-		ft_next_iov_cnt(&ft_tx, fabric_info->tx_attr->iov_limit);
+		ft_format_iov(ft_tx_ctrl.iov, ft_ctrl.iov_array[ft_tx_ctrl.iov_iter],
+				ft_tx_ctrl.buf, ft_tx_ctrl.msg_size);
+		ret = fi_tsendv(ft_tx_ctrl.ep, ft_tx_ctrl.iov, ft_tx_ctrl.iov_desc,
+				ft_ctrl.iov_array[ft_tx_ctrl.iov_iter], ft_tx_ctrl.addr,
+				ft_tx_ctrl.tag, NULL);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
 		break;
 	case FT_FUNC_SENDMSG:
-		ft_format_iov(ft_tx.iov, ft.iov_array[ft_tx.iov_iter],
-				ft_tx.buf, ft_tx.msg_size);
-		msg.msg_iov = ft_tx.iov;
-		msg.desc = ft_tx.iov_desc;
-		msg.iov_count = ft.iov_array[ft_tx.iov_iter];
-		msg.addr = ft_tx.addr;
-		msg.tag = ft_tx.tag;
+		ft_format_iov(ft_tx_ctrl.iov, ft_ctrl.iov_array[ft_tx_ctrl.iov_iter],
+				ft_tx_ctrl.buf, ft_tx_ctrl.msg_size);
+		msg.msg_iov = ft_tx_ctrl.iov;
+		msg.desc = ft_tx_ctrl.iov_desc;
+		msg.iov_count = ft_ctrl.iov_array[ft_tx_ctrl.iov_iter];
+		msg.addr = ft_tx_ctrl.addr;
+		msg.tag = ft_tx_ctrl.tag;
 		msg.context = NULL;
 		msg.data = 0;
-		ret = fi_tsendmsg(ft_tx.ep, &msg, 0);
-		ft_next_iov_cnt(&ft_tx, fabric_info->tx_attr->iov_limit);
+		ret = fi_tsendmsg(ft_tx_ctrl.ep, &msg, 0);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
 		break;
 	default:
-		ret = fi_tsend(ft_tx.ep, ft_tx.buf, ft_tx.msg_size,
-				ft_tx.memdesc, ft_tx.addr, ft_tx.tag, NULL);
+		ret = fi_tsend(ft_tx_ctrl.ep, ft_tx_ctrl.buf, ft_tx_ctrl.msg_size,
+				ft_tx_ctrl.memdesc, ft_tx_ctrl.addr, ft_tx_ctrl.tag, NULL);
 		break;
 	}
 	return ret;
@@ -175,13 +175,13 @@ int ft_post_recv_bufs(void)
 {
 	int ret;
 
-	for (; ft_rx.credits; ft_rx.credits--) {
+	for (; ft_rx_ctrl.credits; ft_rx_ctrl.credits--) {
 		if (test_info.caps & FI_MSG) {
 			ret = ft_post_recv();
 		} else {
 			ret = ft_post_trecv();
 			if (!ret)
-				ft_rx.tag++;
+				ft_rx_ctrl.tag++;
 		}
 		if (ret) {
 			if (ret == -FI_EAGAIN)
@@ -197,18 +197,18 @@ int ft_recv_msg(void)
 {
 	int credits, ret;
 
-	if (ft_rx.credits > (ft_rx.max_credits >> 1)) {
+	if (ft_rx_ctrl.credits > (ft_rx_ctrl.max_credits >> 1)) {
 		ret = ft_post_recv_bufs();
 		if (ret)
 			return ret;
 	}
 
-	credits = ft_rx.credits;
+	credits = ft_rx_ctrl.credits;
 	do {
 		ret = ft_comp_rx(FT_COMP_TO);
 		if (ret)
 			return ret;
-	} while (credits == ft_rx.credits);
+	} while (credits == ft_rx_ctrl.credits);
 
 	return 0;
 }
@@ -217,26 +217,26 @@ int ft_send_msg(void)
 {
 	int ret;
 
-	while (!ft_tx.credits) {
+	while (!ft_tx_ctrl.credits) {
 		ret = ft_comp_tx(FT_COMP_TO);
 		if (ret)
 			return ret;
 	}
 
-	ft_tx.credits--;
+	ft_tx_ctrl.credits--;
 	if (test_info.caps & FI_MSG) {
 		ret = ft_post_send();
 	} else {
 		ret = ft_post_tsend();
 		if (!ret)
-			ft_tx.tag++;
+			ft_tx_ctrl.tag++;
 	}
 	if (ret) {
 		FT_PRINTERR("send", ret);
 		return ret;
 	}
 
-	if (!ft_tx.credits) {
+	if (!ft_tx_ctrl.credits) {
 		ret = ft_comp_tx(0);
 		if (ret)
 			return ret;
@@ -249,7 +249,7 @@ int ft_send_dgram(void)
 {
 	int ret;
 
-	*(uint8_t*) ft_tx.buf = ft_tx.seqno++;
+	*(uint8_t*) ft_tx_ctrl.buf = ft_tx_ctrl.seqno++;
 	ret = ft_send_msg();
 	return ret;
 }
@@ -258,9 +258,9 @@ int ft_send_dgram_flood(void)
 {
 	int i, ret = 0;
 
-	ft_tx.seqno = 0;
-	*(uint8_t*) ft_tx.buf = 0;
-	for (i = 0; i < ft.xfer_iter - 1; i++) {
+	ft_tx_ctrl.seqno = 0;
+	*(uint8_t*) ft_tx_ctrl.buf = 0;
+	for (i = 0; i < ft_ctrl.xfer_iter - 1; i++) {
 		ret = ft_send_msg();
 		if (ret)
 			break;
@@ -274,18 +274,18 @@ int ft_recv_dgram(void)
 	int credits, ret;
 
 	do {
-		if (ft_rx.credits > (ft_rx.max_credits >> 1)) {
+		if (ft_rx_ctrl.credits > (ft_rx_ctrl.max_credits >> 1)) {
 			ret = ft_post_recv_bufs();
 			if (ret)
 				return ret;
 		}
 
-		credits = ft_rx.credits;
+		credits = ft_rx_ctrl.credits;
 
 		ret = ft_comp_rx(FT_DGRAM_POLL_TO);
-		if ((credits != ft_rx.credits) &&
-		    (*(uint8_t *) ft_rx.buf == ft_rx.seqno)) {
-			ft_rx.seqno++;
+		if ((credits != ft_rx_ctrl.credits) &&
+		    (*(uint8_t *) ft_rx_ctrl.buf == ft_rx_ctrl.seqno)) {
+			ft_rx_ctrl.seqno++;
 			return 0;
 		}
 	} while (!ret);
@@ -304,9 +304,9 @@ int ft_recv_dgram_flood(size_t *recv_cnt)
 			break;
 
 		ret = ft_comp_rx(0);
-		cnt += ft_rx.credits;
+		cnt += ft_rx_ctrl.credits;
 
-	} while (!ret && (*(uint8_t *) ft_rx.buf != (uint8_t) ~0));
+	} while (!ret && (*(uint8_t *) ft_rx_ctrl.buf != (uint8_t) ~0));
 
 	*recv_cnt = cnt;
 	return ret;
@@ -327,8 +327,8 @@ int ft_sendrecv_dgram(void)
 
 		/* resend */
 		if (test_info.caps & FI_TAGGED)
-			ft_tx.tag--;
-		ft_tx.seqno--;
+			ft_tx_ctrl.tag--;
+		ft_tx_ctrl.seqno--;
 	}
 
 	return ret;

--- a/pingpong/pingpong_shared.h
+++ b/pingpong/pingpong_shared.h
@@ -42,17 +42,10 @@ extern "C" {
 
 #define PONG_OPTS "vP"
 
-extern int verify_data;
-extern int timeout;
-
 void ft_parsepongopts(int op);
 void ft_pongusage(void);
+int pingpong();
 
-int wait_for_completion_timeout(struct fid_cq *cq, int num_completions);
-
-int send_xfer(size_t size);
-int recv_xfer(size_t size, bool enable_timeout);
-int sync_test(bool enable_timeout);
 
 #ifdef __cplusplus
 }

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -306,7 +306,6 @@ eq_wait_fd_sread()
 {
 	struct fi_eq_entry entry;
 	uint32_t event;
-	struct timespec before, after;
 	uint64_t elapsed;
 	int testret;
 	int ret;
@@ -320,7 +319,7 @@ eq_wait_fd_sread()
 	}
 
 	/* timed sread on empty EQ, 2s timeout */
-	clock_gettime(CLOCK_MONOTONIC, &before);
+	ft_start();
 	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), 2000, 0);
 	if (ret != -FI_EAGAIN) {
 		sprintf(err_buf, "fi_eq_read of empty EQ returned %d", ret);
@@ -328,8 +327,8 @@ eq_wait_fd_sread()
 	}
 
 	/* check timeout accuracy */
-	clock_gettime(CLOCK_MONOTONIC, &after);
-	elapsed = get_elapsed(&before, &after, MILLI);
+	ft_stop();
+	elapsed = get_elapsed(&start, &end, MILLI);
 	if (elapsed < 1500 || elapsed > 2500) {
 		sprintf(err_buf, "fi_eq_sread slept %d ms, expected 2000",
 				(int)elapsed);
@@ -346,7 +345,7 @@ eq_wait_fd_sread()
 	}
 
 	/* timed sread on EQ with event, 2s timeout */
-	clock_gettime(CLOCK_MONOTONIC, &before);
+	ft_start();
 	event = ~0;
 	memset(&entry, 0, sizeof(entry));
 	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), 2000, 0);
@@ -356,8 +355,8 @@ eq_wait_fd_sread()
 	}
 
 	/* check that no undue waiting occurred */
-	clock_gettime(CLOCK_MONOTONIC, &after);
-	elapsed = get_elapsed(&before, &after, MILLI);
+	ft_stop();
+	elapsed = get_elapsed(&start, &end, MILLI);
 	if (elapsed > 5) {
 		sprintf(err_buf, "fi_eq_sread slept %d ms, expected immediate return",
 				(int)elapsed);


### PR DESCRIPTION
Provide a common implementation for sending, receiving,
and completion process.
This will help all test apps support (with additional changes)
the FI_PREFIX and FI_CONTEXT mode bits.

As part of this change, we assign a virtual tx sequence number
to each sent message.  The receiving side matches this with
an rx sequence number.  The sequence numbers are used as tags
when dealing with the tag matching interface.

Completion processing is updated to count the number of entries
that have been retrieved from a CQ.  Calls are updated to wait
until a total number of completions have occurred, rather than
waiting for X new completions.  This will allow CQs to be
converted to counters more easily.

This change fixes several places where fi_context structures
were reused before a previous request completed.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>