### PR TITLE
Enable -vvv option for runfabtests to debug fi_msg_epoll failure in CI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -210,4 +210,4 @@ dist-hook: fabtests.spec
 	cp fabtests.spec $(distdir)
 
 test:
-	./scripts/runfabtests.sh
+	./scripts/runfabtests.sh -vvv


### PR DESCRIPTION
This is a test pull request.