### PR TITLE
runfabtests: Remove set -x for test commands.

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -246,11 +246,11 @@ function cs_test {
 
 	start_time=$(date '+%s')
 
-	${SSH_SERVER} ${BIN_PATH} "set -x; ${test_exe} -s $S_INTERFACE" &> $s_outp &
+	${SSH_SERVER} ${BIN_PATH} "${test_exe} -s $S_INTERFACE" &> $s_outp &
 	p1=$!
 	sleep 1s
 
-	${SSH_CLIENT} ${BIN_PATH} "set -x; ${test_exe} -s $C_INTERFACE $S_INTERFACE" &> $c_outp &
+	${SSH_CLIENT} ${BIN_PATH} "${test_exe} -s $C_INTERFACE $S_INTERFACE" &> $c_outp &
 	p2=$!
 
 	wait $p1


### PR DESCRIPTION
Remove the set -x command that prevents PATH variable from getting set for the test_exe command. Will add this again in another PR.