### PR TITLE
Make fi_msg_epoll no-op on systems without it.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ bin_PROGRAMS = \
 	simple/fi_poll \
 	simple/fi_scalable_ep \
 	simple/fi_rdm_shared_ctx \
+	simple/fi_msg_epoll \
 	streaming/fi_msg_rma \
 	streaming/fi_rdm_atomic \
 	streaming/fi_rdm_multi_recv \
@@ -31,10 +32,6 @@ bin_PROGRAMS = \
 	ported/libibverbs/fi_rc_pingpong \
 	ported/librdmacm/fi_cmatose \
 	complex/fi_ubertest
-
-if HAVE_EPOLL
-bin_PROGRAMS += simple/fi_msg_epoll
-endif
 
 dist_bin_SCRIPTS = \
 	scripts/runfabtests.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -77,8 +77,9 @@ AC_CHECK_HEADER(valgrind/memcheck.h, [],
     AC_MSG_ERROR([valgrind requested but <valgrind/memcheck.h> not found.]))
 fi
 
-AC_CHECK_FUNC([epoll_create1], [HAVE_EPOLL=1], [HAVE_EPOLL=0])
-AM_CONDITIONAL(HAVE_EPOLL, [test $HAVE_EPOLL -eq 1])
+AC_CHECK_FUNC([epoll_create1], [have_epoll=1], [have_epoll=0])
+AC_DEFINE_UNQUOTED([HAVE_EPOLL], [$have_epoll],
+		   [Defined to 1 if Linux epoll is available])
 
 AC_CONFIG_FILES([Makefile fabtests.spec])
 AC_OUTPUT

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -27,6 +27,10 @@
  * SOFTWARE.
  */
 
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -42,6 +46,7 @@
 #include <rdma/fi_cm.h>
 #include <shared.h>
 
+#if HAVE_EPOLL == 1
 
 static int epfd;
 
@@ -345,3 +350,13 @@ int main(int argc, char **argv)
 	close(epfd);
 	return ret;
 }
+
+#else
+
+#include <rdma/fi_errno.h>
+
+int main(int argc, char **argv)
+{
+	return -FI_ENOSYS;
+}
+#endif


### PR DESCRIPTION
Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>