### PR TITLE
fi_msg_epoll: Remove unneeded fi_recv call from simple server tests

### DIFF
--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -222,7 +222,6 @@ static int send_recv()
 	int ret;
 
 	if (opts.dst_addr) {
-		/* Client */
 		fprintf(stdout, "Posting a send...\n");
 		sprintf(buf, "Hello World!");
 		ret = ft_post_tx(sizeof("Hello World!"));
@@ -251,12 +250,6 @@ static int send_recv()
 
 		fprintf(stdout, "Send completion received\n");
 	} else {
-		/* Server */
-		fprintf(stdout, "Posting a recv...\n");
-		ret = ft_post_rx(rx_size);
-		if (ret)
-			return ret;
-
 		fprintf(stdout, "Waiting for client...\n");
 
 		memset((void *)&event, 0, sizeof event);


### PR DESCRIPTION
The server pre-posts a receive buffer during initialization.
Posting again can result in the receive being posted after
the client has disconnected, resulting in a test failure.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>