### PR TITLE
Pr/cleanup: Handled boundary check, memory leak and other minor fixes

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1076,7 +1076,7 @@ void ft_fill_buf(void *buf, int size)
 {
 	char *msg_buf;
 	int msg_index;
-	static int iter = 0;
+	static unsigned int iter = 0;
 	int i;
 
 	msg_index = ((iter++)*INTEG_SEED) % integ_alphabet_length;
@@ -1092,7 +1092,7 @@ int ft_check_buf(void *buf, int size)
 {
 	char *recv_data;
 	char c;
-	static int iter = 0;
+	static unsigned int iter = 0;
 	int msg_index;
 	int i;
 

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -329,7 +329,7 @@ static struct pingpong_context *pp_init_ctx(struct fi_info *info, int size,
 
 	if (posix_memalign(&(ctx->buf), page_size, size)) {
 		fprintf(stderr, "Couldn't allocate work buf.\n");
-		goto clean_ctx;
+		goto err1;
 	}
 
 	/* FIXME memset(ctx->buf, 0, size); */
@@ -339,12 +339,14 @@ static struct pingpong_context *pp_init_ctx(struct fi_info *info, int size,
 	rc = fi_fabric(info->fabric_attr, &ctx->fabric, NULL);
 	if (rc) {
 		FT_PRINTERR("fi_fabric", rc);
-		goto clean_ctx;
+		goto err2;
 	}
 
 	return ctx;
 
-clean_ctx:
+err2:
+	free(ctx->buf);
+err1:
 	free(ctx);
 	return NULL;
 }

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -132,7 +132,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 static int bind_ep_res(void)
 {
-	int i, ret;
+	int i, ret = 0;
 
 	for (i = 0; i < ep_cnt; i++) {
 		ret = fi_ep_bind(ep_array[i], &stx_ctx->fid, 0);
@@ -294,6 +294,10 @@ static int init_av(void)
 		return ret;
 	}
 
+	if (ep_cnt <= 0) {
+		fprintf(stderr, "ep_cnt needs to be greater than 0\n");
+		return -EXIT_FAILURE;
+	}
 	local_addr = malloc(addrlen * ep_cnt);
 
 	/* Get local addresses for all EPs */

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1000,12 +1000,14 @@ int main(int argc, char **argv)
 			bad_address = optarg;
 			break;
 		case 'a':
+			free(hints->fabric_attr->name);
 			hints->fabric_attr->name = strdup(optarg);
 			break;
 		case 'n':
 			num_good_addr = atoi(optarg);
 			break;
 		case 'f':
+			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		case 's':

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -77,6 +77,7 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:a:n:")) != -1) {
 		switch (op) {
 		case 'a':
+			free(hints->fabric_attr->name);
 			hints->fabric_attr->name = strdup(optarg);
 			break;
 		case 'n':
@@ -89,6 +90,7 @@ int main(int argc, char **argv)
 			}
 			break;
 		case 'f':
+			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		default:

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -43,6 +43,7 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <inttypes.h>
+#include <limits.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
@@ -64,8 +65,10 @@ static struct fid_domain **domain_vec = NULL;
 
 int main(int argc, char **argv)
 {
-	int i;
-	int op, ret, num_domains = 1;
+	unsigned long i;
+	int op, ret = 0;
+	unsigned long num_domains = 1;
+	char *ptr;
 
 	hints = fi_allocinfo();
 	if (hints == NULL)
@@ -77,7 +80,13 @@ int main(int argc, char **argv)
 			hints->fabric_attr->name = strdup(optarg);
 			break;
 		case 'n':
-			num_domains = atoi(optarg);
+			errno = 0;
+			num_domains = strtol(optarg, &ptr, 10);
+			if (ptr == optarg || *ptr != '\0' ||
+				((num_domains == LONG_MIN || num_domains == LONG_MAX) && errno == ERANGE)) {
+				fprintf(stderr, "Cannot convert from string to long\n");
+				goto out;
+			}
 			break;
 		case 'f':
 			hints->fabric_attr->prov_name = strdup(optarg);
@@ -113,7 +122,7 @@ int main(int argc, char **argv)
 	for (i = 1; i < num_domains; i++) {
 		ret = fi_domain(fabric, fi, &domain_vec[i], NULL);
 		if (ret != FI_SUCCESS) {
-			printf("fi_domain num %d %s\n", i, fi_strerror(-ret));
+			printf("fi_domain num %lu %s\n", i, fi_strerror(-ret));
 			break;
 		}
 	}
@@ -121,7 +130,7 @@ int main(int argc, char **argv)
 	while (--i > 0) {
 		ret = fi_close(&domain_vec[i]->fid);
 		if (ret != FI_SUCCESS) {
-			printf("Error %d closing domain num %d: %s\n", ret,
+			printf("Error %d closing domain num %lu: %s\n", ret,
 				i, fi_strerror(-ret));
 			break;
 		}

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -406,9 +406,11 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:a:")) != -1) {
 		switch (op) {
 		case 'a':
+			free(hints->fabric_attr->name);
 			hints->fabric_attr->name = strdup(optarg);
 			break;
 		case 'f':
+			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		default:

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -210,12 +210,14 @@ int main(int argc, char **argv)
 {
 	int op, ret;
 	int failed;
+	char *debug_str;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
 
-	if (getenv("FABTESTS_DEBUG")) {
-		fabtests_debug = atoi(getenv("FABTESTS_DEBUG"));
+	debug_str = getenv("FABTESTS_DEBUG");
+	if (debug_str) {
+		fabtests_debug = atoi(debug_str);
 	}
 
 	hints = fi_allocinfo();

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -225,9 +225,11 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:a:")) != -1) {
 		switch (op) {
 		case 'a':
+			free(hints->fabric_attr->name);
 			hints->fabric_attr->name = strdup(optarg);
 			break;
 		case 'f':
+			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		default:


### PR DESCRIPTION
- Used strtol which detect errors during conversion, instead of atoi
- Fixed some uninitialized variables
- Fixed potential memory when dynamic memory stored in 'hints->fabric_attr->prov_name/name' allocated via strdup can be lost if the option is supplied multiple times
- Added check in error path
- iters could overflow and make msg_index -ve. Used an unsigned type to fix it
- sockaddrstr could return NULL and FT_ERR would try to deference it. Added a NULL check to fix it

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>