### PR TITLE
rdm_tagged_pingpong: Remove need for FI_MSG support

### DIFF
--- a/pingpong/rdm_tagged_pingpong.c
+++ b/pingpong/rdm_tagged_pingpong.c
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_MSG | FI_TAGGED;
+	hints->caps = FI_TAGGED;
 	hints->mode = FI_LOCAL_MR;
 
 	ret = run();


### PR DESCRIPTION
This test only uses the tagged interfaces.  Remove the
request for FI_MSG interfaces.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>