### PR TITLE
Remove unused FI_SOCKADDR addr_format specifications

### DIFF
--- a/pingpong/msg_pingpong.c
+++ b/pingpong/msg_pingpong.c
@@ -231,7 +231,6 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_MSG;
 	hints->caps = FI_MSG;
 	hints->mode = FI_LOCAL_MR;
-	hints->addr_format = FI_SOCKADDR;
 
 	ret = run();
 

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -527,7 +527,6 @@ int main(int argc, char *argv[])
 	hints->ep_attr->type = FI_EP_MSG;
 	hints->caps = FI_MSG;
 	hints->mode = FI_LOCAL_MR;
-	hints->addr_format = FI_SOCKADDR;
 
 	rc = ft_read_addr_opts(&node, &service, hints, &flags, &opts);
 	if (rc)

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -269,7 +269,6 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_MSG;
 	hints->caps = FI_MSG;
 	hints->mode = FI_LOCAL_MR;
-	hints->addr_format = FI_SOCKADDR;
 
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -233,7 +233,6 @@ int main(int argc, char **argv)
 	hints->ep_attr->type	= FI_EP_MSG;
 	hints->caps		= FI_MSG;
 	hints->mode		= FI_LOCAL_MR;
-	hints->addr_format	= FI_SOCKADDR;
 
 	ret = run();
 

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -342,7 +342,6 @@ int main(int argc, char **argv)
 	hints->ep_attr->type	= FI_EP_MSG;
 	hints->caps		= FI_MSG;
 	hints->mode		= FI_LOCAL_MR;
-	hints->addr_format	= FI_SOCKADDR;
 
 	ret = run();
 

--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -424,7 +424,6 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_NAMED_RX_CTX;
 	hints->mode = FI_CONTEXT | FI_LOCAL_MR;
-	hints->addr_format = FI_SOCKADDR;
 
 	ret = run();
 

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -376,7 +376,6 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_NAMED_RX_CTX;
 	hints->mode = FI_LOCAL_MR;
-	hints->addr_format = FI_SOCKADDR;
 
 	ret = run();
 

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -331,7 +331,6 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_MSG;
 	hints->caps = FI_MSG | FI_RMA;
 	hints->mode = FI_LOCAL_MR | FI_RX_CQ_DATA;
-	hints->addr_format = FI_SOCKADDR;
 
 	ret = run();
 


### PR DESCRIPTION
Rationale: requiring usage of FI_SOCKADDR address format makes sense only if you are actually planning to manipulate a struct sockaddr in your application code. In many test this isn't the case, as addressing information is treated as opaque. For this use case it's better to use FI_FORMAT_UNSPEC (which is valued as 0, so it is the default if nothing is specified thanks to calloc). This pull request allows many tests to run on providers which are unable to handle IP addresses, such as https://github.com/alpha-unito/libfabric-provider-dpa.

Signed-off-by: Paolo Inaudi <p91paul@gmail.com>