### PR TITLE
configure.ac: update version and email address

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT([fabtests], [1.2.0], [linux-rdma@vger.kernel.org])
+AC_INIT([fabtests], [1.3.0a1], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)


### PR DESCRIPTION
Update the version number to 1.3.0a1 and update the long-stale email
address to point to the OFI WG mailing list.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>