### PR TITLE
Extended rdm_atomic test to include all supported atomic ops and datatypes

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -65,7 +65,7 @@ size_t buf_size, tx_size, rx_size;
 int rx_fd = -1, tx_fd = -1;
 char default_port[8] = "9228";
 
-char test_name[10] = "custom";
+char test_name[50] = "custom";
 int timeout = -1;
 struct timespec start, end;
 
@@ -703,7 +703,8 @@ void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len)
 	char sstr[FT_STR_LEN];
 
 	size_str(sstr, opts->transfer_size);
-	snprintf(test_name, test_name_len, "%s_lat", sstr);
+	if (!strcmp(test_name, "custom"))
+		snprintf(test_name, test_name_len, "%s_lat", sstr);
 	if (!(opts->options & FT_OPT_ITER))
 		opts->iterations = size_to_count(opts->transfer_size);
 }
@@ -1043,12 +1044,12 @@ void show_perf(char *name, int tsize, int iters, struct timespec *start,
 	long long bytes = (long long) iters * tsize * xfers_per_iter;
 
 	if (header) {
-		printf("%-10s%-8s%-8s%-8s%8s %10s%13s\n",
+		printf("%-50s%-8s%-8s%-8s%8s %10s%13s\n",
 			"name", "bytes", "iters", "total", "time", "Gb/sec", "usec/xfer");
 		header = 0;
 	}
 
-	printf("%-10s", name);
+	printf("%-50s", name);
 
 	printf("%-8s", size_str(str, tsize));
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -127,7 +127,7 @@ extern struct fi_eq_attr eq_attr;
 extern struct fi_cq_attr cq_attr;
 extern struct fi_cntr_attr cntr_attr;
 
-extern char test_name[10];
+extern char test_name[50];
 extern struct timespec start, end;
 extern struct ft_opts opts;
 


### PR DESCRIPTION
Extended the existing structure so that the test 
- Runs for all supported atomic ops
- Runs for all supported datatype
- Reports perf data for running individual atomic op for a particular datatype
- Removed local tostr() functions to use fi_tostr

@a-ilango, @shefty, can you please review? 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>