### PR TITLE
runfabtests: Decreased the number of iters in rdm_atomic

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -88,7 +88,7 @@ standard_tests=(
 	"msg_rma -o write"
 	"msg_rma -o read"
 	"msg_rma -o writedata"
-	"rdm_atomic -o all -I 10000"
+	"rdm_atomic -o all -I 1000"
 	"rdm_cntr_pingpong"
 	"rdm_inject_pingpong"
 	"rdm_multi_recv"


### PR DESCRIPTION
Since we extended rdm_atomic to run for all datatypes and all atomic ops in #405, now it takes longer time to finish. I decreased the iteration count so that it finishes in a reasonable time.

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>