### PR TITLE
Updated tests using fi_cq_sread to use FI_WAIT_UNSPEC instead of FI_WAIT_NONE

### DIFF
--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -136,7 +136,7 @@ static int pp_cq_create(struct pingpong_context *ctx)
 	if (ctx->use_event)
 		cq_attr.wait_obj = FI_WAIT_FD;				
 	else
-		cq_attr.wait_obj = FI_WAIT_NONE;
+		cq_attr.wait_obj = FI_WAIT_UNSPEC;
 	cq_attr.size 		= ctx->rx_depth + 1;
 
 	rc = fi_cq_open(ctx->dom, &cq_attr, &ctx->cq, NULL);

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -159,7 +159,7 @@ static int send_recv()
 				if (ret == -FI_EAVAIL) {
 					ret = ft_cq_readerr(cq);
 				} else {
-					FT_PRINTERR("fi_cq_sread", ret);
+					FT_PRINTERR("fi_cq_read", ret);
 				}
 				return ret;
 			}

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -96,7 +96,7 @@ static int tagged_peek(uint64_t tag)
 		if (ret == -FI_EAVAIL)
 			ret = ft_cq_readerr(rxcq);
 		else
-			FT_PRINTERR("fi_cq_read", ret);
+			FT_PRINTERR("fi_cq_sread", ret);
 	}
 	return ret;
 }
@@ -174,6 +174,7 @@ int main(int argc, char **argv)
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
+	opts.comp_method = FT_COMP_SREAD;
 
 	hints = fi_allocinfo();
 	if (!hints) {


### PR DESCRIPTION
- According to manpage, fi_cq_sread() cannot use FI_WAIT_NONE as wait_obj. Updated <code>rdm_tagged_peek.c</code> to specify completion method FT_COMP_SREAD which overrides the default wait_obj from FI_WAIT_NONE to FI_WAIT_UNSPEC. Updated <code>rc_pingpong.c</code> to use FI_WAIT_UNSPEC directly in cq_attr
- Fixed a typo in log message

Verified with fabtests. Fixes #411.@shefty can you please review?

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>