### PR TITLE
Only register local memory if needed

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -109,7 +109,7 @@ extern struct fid_pep *pep;
 extern struct fid_ep *ep;
 extern struct fid_cq *txcq, *rxcq;
 extern struct fid_cntr *txcntr, *rxcntr;
-extern struct fid_mr *mr;
+extern struct fid_mr *mr, no_mr;
 extern struct fid_av *av;
 extern struct fid_eq *eq;
 

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -60,7 +60,8 @@ static char err_buf[512];
 
 static void teardown_ep_fixture(void)
 {
-	FT_CLOSE_FID(mr);
+	if (mr != &no_mr)
+		FT_CLOSE_FID(mr);
 	FT_CLOSE_FID(ep);
 	FT_CLOSE_FID(txcq);
 	FT_CLOSE_FID(rxcq);


### PR DESCRIPTION
The UDP provider does not require memory registration, so does not
implement that call.  Modify the apps to avoid attempting to
register memory when it is not needed.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>