### PR TITLE
Added option to run fi_ubertest from runfabtests.sh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
-AM_CFLAGS = -g -Wall -D_GNU_SOURCE -I$(srcdir)/include
+configdir = $(datarootdir)/${PACKAGE_NAME}
+AM_CFLAGS = -g -Wall -D_GNU_SOURCE -D 'CONFIG_PATH="${configdir}"' -I$(srcdir)/include
 ACLOCAL_AMFLAGS = -I config
 
 bin_PROGRAMS = \
@@ -40,6 +41,12 @@ dist_bin_SCRIPTS = \
 
 dist_noinst_SCRIPTS = \
 	scripts/parseyaml.py
+
+nobase_dist_config_DATA = \
+	test_configs/*.json \
+	test_configs/sockets/*.json \
+	test_configs/udp/*.json \
+	test_configs/verbs/*.json
 
 noinst_LTLIBRARIES = libfabtests.la
 libfabtests_la_SOURCES = \

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -42,7 +42,6 @@
 
 #include "fabtest.h"
 
-
 int listen_sock = -1;
 int sock = -1;
 static int persistent = 1;
@@ -463,14 +462,18 @@ static void ft_fw_show_results(void)
 
 static void ft_fw_usage(char *program)
 {
-	fprintf(stderr, "usage: %s [server_node]\n", program);
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "  %s [OPTIONS] \t\t\tstart server\n", program);
+	fprintf(stderr, "  %s [OPTIONS] <server_node> \tconnect to server\n", program);
 	fprintf(stderr, "\nOptions:\n");
 	FT_PRINT_OPTS_USAGE("-q <service_port>", "Management port for test");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
 	fprintf(stderr, "\nServer only options:\n");
 	FT_PRINT_OPTS_USAGE("-x", "exit after test run");
 	fprintf(stderr, "\nClient only options:\n");
-	FT_PRINT_OPTS_USAGE("-f <test_config_file>", "");
+	FT_PRINT_OPTS_USAGE("-u <test_config_file>", "config file path (Either config file path or both provider and test config name are required)");
+	FT_PRINT_OPTS_USAGE("-f <provider_name>", " provider name");
+	FT_PRINT_OPTS_USAGE("-t <test_config_name>", "test config name");
 	FT_PRINT_OPTS_USAGE("-y <start_test_index>", "");
 	FT_PRINT_OPTS_USAGE("-z <end_test_index>", "");
 	FT_PRINT_OPTS_USAGE("-s <address>", "source address");
@@ -483,13 +486,21 @@ int main(int argc, char **argv)
 {
 	char *service = "2710";
 	char *filename = NULL;
+	char *provname = NULL;
+	char *testname = NULL;
 	opts = INIT_OPTS;
 	int ret, op;
 
-	while ((op = getopt(argc, argv, "f:q:xy:z:h" ADDR_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "f:u:t:q:xy:z:h" ADDR_OPTS)) != -1) {
 		switch (op) {
-		case 'f':
+		case 'u':
 			filename = optarg;
+			break;
+		case 'f':
+			provname = optarg;
+			break;
+		case 't':
+			testname = optarg;
 			break;
 		case 'q':
 			service = optarg;
@@ -523,6 +534,18 @@ int main(int argc, char **argv)
 	if (opts.dst_addr) {
 		if (!opts.dst_port)
 			opts.dst_port = default_port;
+		if (!filename) {
+			if (!testname || !provname) {
+				ft_fw_usage(argv[0]);
+				exit(1);
+			} else {
+				asprintf(&filename, "%s/test_configs/%s/%s.json",
+					CONFIG_PATH, provname, testname);
+			}
+		} else {
+			testname = NULL;
+			provname = NULL;
+		}
 		series = fts_load(filename);
 		if (!series)
 			exit(1);
@@ -561,5 +584,7 @@ int main(int argc, char **argv)
 out:
 	if (opts.dst_addr)
 		fts_close(series);
+	if (filename && !testname && !provname)
+		free(filename);
 	return ret;
 }


### PR DESCRIPTION
Not ready to be merged yet. Wanted to get some early feedback :)
- Modified complex/ft_main.c and added provider and test name as new options for ubertest
- Added config path as a variable constructed from $datarootdir/${PACKAGE_NAME}
- Added a new option in runfabtests.sh to accept configuration for complex tests
- Added ubertest config files as a part of package distribution
- Added a function in runfabtests.sh to run complex tests

To run ubertest: <code>runfabtests.sh -v -p bin_path -t quick sockets node1 node2</code>
This will run fi_ubertests from <code>$datarootdir/${PACKAGE_NAME}/test_configs/sockets/quick.json</code> config file.

I'll update the config file structure and format after #419 is merged
@pmmccorm @a-ilango @shefty
 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>