### PR TITLE
Use correct MR access flags.

### DIFF
--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -189,8 +189,8 @@ static int ft_setup_xcontrol_bufs(struct ft_xcontrol *ctrl)
 	}
 
 	if ((fabric_info->mode & FI_LOCAL_MR) && !ctrl->mr) {
-		ret = fi_mr_reg(domain, ctrl->buf, size,
-				0, 0, 0, 0, &ctrl->mr, NULL);
+		ret = fi_mr_reg(domain, ctrl->buf, size, FI_RECV | FI_SEND,
+				0, 0, 0, &ctrl->mr, NULL);
 		if (ret) {
 			FT_PRINTERR("fi_mr_reg", ret);
 			return ret;

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -110,10 +110,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	switch (op_type) {
 	case FT_RMA_READ:
 		access_mode = FI_REMOTE_READ;
+		if (fi->mode & FI_LOCAL_MR)
+			access_mode |= FI_READ;
 		break;
 	case FT_RMA_WRITE:
 	case FT_RMA_WRITEDATA:
 		access_mode = FI_REMOTE_WRITE;
+		if (fi->mode & FI_LOCAL_MR)
+			access_mode |= FI_WRITE;
 		break;
 	default:
 		assert(0);

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -118,10 +118,14 @@ static int alloc_ep_res(struct fi_info *fi)
 	switch (op_type) {
 	case FT_RMA_READ:
 		access_mode = FI_REMOTE_READ;
+		if (fi->mode & FI_LOCAL_MR)
+			access_mode |= FI_READ;
 		break;
 	case FT_RMA_WRITE:
 	case FT_RMA_WRITEDATA:
 		access_mode = FI_REMOTE_WRITE;
+		if (fi->mode & FI_LOCAL_MR)
+			access_mode |= FI_WRITE;
 		break;
 	default:
 		/* Impossible to reach here */


### PR DESCRIPTION
RMA data sinks and sources should use FI_READ and FI_WRITE
MR access permissions respectively.

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>