### PR TITLE
Makefile: Add udp testing to make test option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -213,3 +213,4 @@ dist-hook: fabtests.spec
 
 test:
 	./scripts/runfabtests.sh -vvv
+	./scripts/runfabtests.sh -vvv udp


### PR DESCRIPTION
This will add the UDP provider to the Travis CI validation.