### PR TITLE
unit-tests: Mark tests that return with -FI_ENOSYS as 'skipped', rather than failed.

### DIFF
--- a/include/unit_common.h
+++ b/include/unit_common.h
@@ -37,6 +37,9 @@
 enum { PASS, FAIL, NOTSUPP, SKIPPED };
 #define TEST_ENTRY(NAME) { NAME, #NAME }
 
+#define TEST_RET_VAL(_ret, _testret) \
+	(_ret == -FI_ENOSYS || -ret == -FI_ENODATA) ? SKIPPED : (_testret)
+
 struct test_entry {
 	int (*test)();
 	char *name;

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -198,7 +198,7 @@ av_open_close()
 	}
 	testret = PASS;
 fail:
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 static int
@@ -332,7 +332,7 @@ av_good_sync()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(av);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -388,7 +388,7 @@ av_bad_sync()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(av);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -459,7 +459,7 @@ av_goodbad_vector_sync()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(av);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -533,7 +533,7 @@ av_good_vector_async()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(av);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -585,7 +585,7 @@ av_zero_async()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(av);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -693,7 +693,7 @@ av_good_2vector_async()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(av);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -791,7 +791,7 @@ av_goodbad_vector_async()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(av);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -942,7 +942,7 @@ av_goodbad_2vector_async()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(av);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 struct test_entry test_array_good[] = {

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -98,7 +98,7 @@ eq_open_close()
 
 fail:
 	eq = NULL;
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -179,7 +179,7 @@ eq_write_read_self()
 
 fail:
 	FT_CLOSE_FID(eq);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -223,7 +223,7 @@ eq_write_overflow()
 
 fail:
 	FT_CLOSE_FID(eq);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -293,7 +293,7 @@ eq_wait_fd_poll()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(eq);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 /*
@@ -382,7 +382,7 @@ eq_wait_fd_sread()
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(eq);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 struct test_entry test_array[] = {

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -116,7 +116,7 @@ rx_size_left(void)
 	testret = PASS;
 fail:
 	teardown_ep_fixture();
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 static int
@@ -147,7 +147,7 @@ rx_size_left_err(void)
 	testret = PASS;
 fail:
 	FT_CLOSE_FID(ep);
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 static int
@@ -178,7 +178,7 @@ tx_size_left(void)
 	testret = PASS;
 fail:
 	teardown_ep_fixture();
-	return testret;
+	return TEST_RET_VAL(ret, testret);
 }
 
 struct test_entry test_rx_size_left[] = {


### PR DESCRIPTION
unit-tests: Mark tests that return with -FI_ENOSYS as 'skipped', rather than failed.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>