### PR TITLE
Fixed error during fi_close for scalable_ep and rdm_multi_recv

### DIFF
--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -89,7 +89,7 @@ static int alloc_ep_res(struct fid_ep *sep)
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
-
+	/* Closes non-scalable endpoint that was allocated in the common code */
 	FT_CLOSE_FID(ep);
 
 	txcq_array = calloc(ctx_cnt, sizeof *txcq_array);
@@ -380,6 +380,8 @@ int main(int argc, char **argv)
 	ret = run();
 
 	free_res();
+	/* Closes the scalable ep that was allocated in the test */
+	FT_CLOSE_FID(sep);
 	ft_free_res();
 	return -ret;
 }

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -341,7 +341,7 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
 	free_res();
+	ft_free_res();
 	return -ret;
 }


### PR DESCRIPTION
Both scalable_ep and rdm_multi_recv was printing the following error msg from <code>ft_free_res()</code>
<code>common/shared.c fi_close (-16) fid 2</code>

- scalable_ep was missing fi_close function call for scalable ep object.
- Fixed rdm_multi_recv so that it closes mr before closing domain in <code>ft_free_res()</code> call.

@a-ilango @shefty 