### PR TITLE
Added rdm_shared_av in runfabtests.sh

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -13,7 +13,7 @@ declare CLIENT="127.0.0.1"
 declare EXCLUDE
 declare GOOD_ADDR="192.168.10.1"
 declare -i VERBOSE=0
-declare COMPLEX_CFG=quick
+declare COMPLEX_CFG="quick"
 
 # base ssh,  "short" and "long" timeout variants:
 declare bssh="ssh -n -o StrictHostKeyChecking=no -o ConnectTimeout=2 -o BatchMode=yes"
@@ -60,6 +60,7 @@ simple_tests=(
 	"rdm_tagged_peek"
 	"scalable_ep"
 	"cmatose"
+	"rdm_shared_av"
 )
 
 short_tests=(
@@ -260,7 +261,11 @@ function cs_test {
 	p1=$!
 	sleep 1s
 
-	${CLIENT_CMD} "${BIN_PATH}${test_exe} -s $C_INTERFACE $S_INTERFACE" &> $c_outp &
+	if [[ $test == "rdm_shared_av" ]]; then
+		${CLIENT_CMD} "${BIN_PATH}${test_exe} -s $C_INTERFACE -a foo $S_INTERFACE" &> $c_outp &
+	else
+		${CLIENT_CMD} "${BIN_PATH}${test_exe} -s $C_INTERFACE $S_INTERFACE" &> $c_outp &
+	fi
 	p2=$!
 
 	wait $p1

--- a/simple/rdm_shared_av.c
+++ b/simple/rdm_shared_av.c
@@ -203,11 +203,9 @@ int main(int argc, char **argv)
 	ret = run();
 
 	if (opts.dst_addr) {
-		ret = close(pair[0]);
-		if (ret)
+		if (close(pair[0]))
 			FT_PRINTERR("close", errno);
-		ret = close(pair[1]);
-		if (ret)
+		if (close(pair[1]))
 			FT_PRINTERR("close", errno);
 		if (parent) {
 			if (waitpid(child_pid, NULL, WCONTINUED) < 0) {


### PR DESCRIPTION
- Added check to pass shared_av name only for client since the test shares the av between two client threads. Now it works fine if the client and server are run in the same node which is the case in Travis. Fixes #423 
- Added a return variable to avoid overwriting -ENODATA return value for error case  .

@sayantansur @jithinjosepkl 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>