### PR TITLE
Added a recv to avoid occasional rdm_shared_ctx test fail

### DIFF
--- a/simple/rdm_shared_ctx.c
+++ b/simple/rdm_shared_ctx.c
@@ -277,6 +277,13 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
+	/* Post recv */
+	ret = fi_recv(srx_ctx, buf, rx_size, fi_mr_desc(mr), 0, &rx_ctx);
+	if (ret) {
+		FT_PRINTERR("fi_recv", ret);
+		return ret;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Modified <code>rdm_shared_ctx.c</code> to include a pre-posted buffer to be consistent with other fabtests. 
@jithinjosepkl @shefty @sayantansur 

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>