### PR TITLE
touch memory locations to allocate pages

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -233,6 +233,7 @@ int ft_alloc_msgs(void)
 			FT_PRINTERR("posix_memalign", ret);
 			return ret;
 		}
+		memset(buf, 0, buf_size);
 	} else {
 		buf = malloc(buf_size);
 		if (!buf) {


### PR DESCRIPTION
When using the aligned option, also touch the memory
location so that the pages get allocated.

The MPI/SHMEM benchmarks seem to touch the locations first.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>