### PR TITLE
minor cleanups to benchmarks

### DIFF
--- a/benchmarks/pingpong_shared.h
+++ b/benchmarks/pingpong_shared.h
@@ -47,8 +47,6 @@ void ft_parsepongopts(int op, char *optarg);
 void ft_pongusage(void);
 int pingpong();
 
-extern int max_inject_size;
-
 #ifdef __cplusplus
 }
 #endif

--- a/benchmarks/rdm_cntr_pingpong.c
+++ b/benchmarks/rdm_cntr_pingpong.c
@@ -120,9 +120,10 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS PONG_OPTS)) != -1) {
 		switch (op) {
 		default:
+			ft_parsepongopts(op, optarg);
 			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
 			break;


### PR DESCRIPTION
Missed a call to ft_parsepongopts() that led to a program not reading inject size argument.

Missed removing an extern variable that is no longer needed.