### PR TITLE
shared: reduce iteration count

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -740,10 +740,8 @@ int size_to_count(int size)
 		return 100;
 	else if (size >= (1 << 16))
 		return 1000;
-	else if (size >= (1 << 10))
-		return 10000;
 	else
-		return 100000;
+		return 10000;
 }
 
 void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len)


### PR DESCRIPTION
100k iterations take a long time, and don't really work for
any bandwidth tests that might have to do a window of outstanding
sends. For example, a typical bandwidth test might have to do 64 window
which means 640K iterations!

Besides, the performance data reported doesn't vary between 100k and 10k
(attached).

The MPI benchmarks seem to use 10k iterations for small messages.

On a decent server with sockets provider.

100K iterations:
[ssur@f006 fabtests]$ time ./benchmarks/fi_rdm_tagged_pingpong -f sockets -S all
bytes   iters   total       time     Gb/sec    usec/xfer
2       100k    390k        2.97s      0.00      14.86
3       100k    585k        3.08s      0.00      15.41
4       100k    781k        3.07s      0.00      15.36
6       100k    1.1m        3.10s      0.00      15.52
8       100k    1.5m        3.07s      0.00      15.36
12      100k    2.2m        3.00s      0.01      15.02
16      100k    3m          2.96s      0.01      14.82
24      100k    4.5m        2.99s      0.01      14.93
32      100k    6.1m        2.97s      0.02      14.87
48      100k    9.1m        2.95s      0.03      14.73
64      100k    12m         2.95s      0.03      14.74
96      100k    18m         2.98s      0.05      14.88
128     100k    24m         2.95s      0.07      14.77
192     100k    36m         2.97s      0.10      14.85
256     100k    48m         3.12s      0.13      15.59
384     100k    73m         3.15s      0.20      15.74
512     100k    97m         3.42s      0.24      17.11
768     100k    146m        3.68s      0.33      18.39
1k      10k     19m         0.47s      0.35      23.53
1.5k    10k     29m         0.38s      0.64      19.08
2k      10k     39m         0.38s      0.87      18.81
3k      10k     58m         0.36s      1.38      17.83
4k      10k     78m         0.36s      1.84      17.83
6k      10k     117m        0.36s      2.72      18.09
8k      10k     156m        0.39s      3.38      19.40
12k     10k     234m        0.43s      4.62      21.27
16k     10k     312m        0.45s      5.85      22.40
24k     10k     468m        0.50s      7.81      25.16
32k     10k     625m        0.56s      9.40      27.88
48k     10k     937m        0.70s     11.31      34.76
64k     1k      125m        0.09s     11.59      45.22
96k     1k      187m        0.11s     14.89      52.83
128k    1k      250m        0.13s     16.31      64.29
192k    1k      375m        0.16s     19.15      82.13
256k    1k      500m        0.20s     20.77     100.99
384k    1k      750m        0.27s     23.44     134.21
512k    1k      1000m       0.33s     25.32     165.67
768k    1k      1.4g        0.46s     27.25     230.85
1m      100     200m        0.06s     28.52     294.09
1.5m    100     300m        0.09s     29.41     427.90
2m      100     400m        0.11s     29.75     563.88
3m      100     600m        0.17s     29.83     843.51
4m      100     800m        0.24s     27.68    1212.36
6m      100     1.1g        0.33s     30.14    1670.16
8m      100     1.5g        0.45s     29.55    2270.75

real    1m6.727s
user    0m48.795s
sys     1m21.984s

With 10K iterations:

[ssur@f006 fabtests]$ time ./benchmarks/fi_rdm_tagged_pingpong -f sockets -S all
bytes   iters   total       time     Gb/sec    usec/xfer
2       10k     39k         0.29s      0.00      14.64
3       10k     58k         0.29s      0.00      14.59
4       10k     78k         0.29s      0.00      14.74
6       10k     117k        0.29s      0.00      14.70
8       10k     156k        0.29s      0.00      14.73
12      10k     234k        0.29s      0.01      14.63
16      10k     312k        0.29s      0.01      14.68
24      10k     468k        0.29s      0.01      14.60
32      10k     625k        0.29s      0.02      14.63
48      10k     937k        0.30s      0.03      14.77
64      10k     1.2m        0.29s      0.03      14.67
96      10k     1.8m        0.29s      0.05      14.69
128     10k     2.4m        0.29s      0.07      14.69
192     10k     3.6m        0.33s      0.09      16.44
256     10k     4.8m        0.36s      0.11      18.07
384     10k     7.3m        0.36s      0.17      18.17
512     10k     9.7m        0.40s      0.21      19.84
768     10k     14m         0.42s      0.29      21.18
1k      10k     19m         0.49s      0.33      24.66
1.5k    10k     29m         0.39s      0.64      19.34
2k      10k     39m         0.39s      0.85      19.37
3k      10k     58m         0.39s      1.26      19.55
4k      10k     78m         0.39s      1.66      19.69
6k      10k     117m        0.40s      2.47      19.87
8k      10k     156m        0.41s      3.22      20.33
12k     10k     234m        0.43s      4.58      21.45
16k     10k     312m        0.47s      5.60      23.39
24k     10k     468m        0.53s      7.48      26.29
32k     10k     625m        0.56s      9.36      28.01
48k     10k     937m        0.71s     11.02      35.69
64k     1k      125m        0.09s     11.27      46.50
96k     1k      187m        0.11s     14.67      53.59
128k    1k      250m        0.13s     15.79      66.42
192k    1k      375m        0.17s     18.62      84.49
256k    1k      500m        0.21s     20.10     104.31
384k    1k      750m        0.29s     21.74     144.68
512k    1k      1000m       0.36s     23.27     180.21
768k    1k      1.4g        0.50s     25.42     247.51
1m      100     200m        0.06s     27.01     310.52
1.5m    100     300m        0.09s     27.93     450.52
2m      100     400m        0.12s     28.34     592.01
3m      100     600m        0.18s     28.28     889.89
4m      100     800m        0.25s     26.48    1267.15
6m      100     1.1g        0.36s     27.96    1799.93
8m      100     1.5g        0.48s     27.79    2415.10

real    0m16.247s
user    0m9.836s
sys     0m21.233s


Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>