### PR TITLE
Fix seg fault in ubertest

### DIFF
--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -494,7 +494,7 @@ int main(int argc, char **argv)
 	while ((op = getopt(argc, argv, "f:u:t:q:xy:z:h" ADDR_OPTS)) != -1) {
 		switch (op) {
 		case 'u':
-			filename = optarg;
+			filename = strdup(optarg);
 			break;
 		case 'f':
 			provname = optarg;


### PR DESCRIPTION
If the -u option is specified, then the filename is provided via optarg
and should be copied with strdup.

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>