### PR TITLE
Enabled ubertest for OSX, fixed segfault and added valgrind cleanups in ubertest

### DIFF
--- a/complex/ft_comm.c
+++ b/complex/ft_comm.c
@@ -31,7 +31,6 @@
 
 #include "fabtest.h"
 
-
 static int ft_accept(void)
 {
 	struct fi_eq_cm_entry entry;
@@ -90,6 +89,7 @@ static int ft_load_av(void)
 	size_t len;
 	int ret;
 
+	memset(&msg, 0, sizeof(struct ft_msg));
 	len = sizeof(msg.data);
 	ret = fi_getname(&ep->fid, msg.data, &len);
 	if (ret) {

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -500,7 +500,7 @@ struct ft_series *fts_load(char *filename)
 	} else {
 		printf("No config file given. Using default tests.\n");
 		test_series.sets = test_sets_default;
-		test_series.nsets = sizeof(test_sets_default) / sizeof(test_sets_default[0]);;
+		test_series.nsets = sizeof(test_sets_default) / sizeof(test_sets_default[0]);
 	}
 
 	for (fts_start(&test_series, 0); !fts_end(&test_series, 0);

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -186,6 +186,8 @@ static int ft_setup_xcontrol_bufs(struct ft_xcontrol *ctrl)
 		ctrl->buf = calloc(1, size);
 		if (!ctrl->buf)
 			return -FI_ENOMEM;
+	} else {
+		memset(ctrl->buf, 0, size);
 	}
 
 	if ((fabric_info->mode & FI_LOCAL_MR) && !ctrl->mr) {

--- a/complex/ft_endpoint.c
+++ b/complex/ft_endpoint.c
@@ -43,10 +43,6 @@ int ft_open_passive(void)
 	if (pep)
 		return 0;
 
-	ret = ft_open_control();
-	if (ret)
-		return ret;
-
 	ret = fi_passive_ep(fabric, fabric_info, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
@@ -139,9 +135,8 @@ int ft_reset_ep(void)
 
 	memset(ft_tx_ctrl.buf, 0, ft_tx_ctrl.msg_size);
 	memset(ft_rx_ctrl.buf, 0, ft_rx_ctrl.msg_size);
-	ret = ft_post_recv_bufs();
-	if (ret)
-		return ret;
+	ft_tx_ctrl.seqno = 0;
+	ft_rx_ctrl.seqno = 0;
 
 	return 0;
 }

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -343,7 +343,7 @@ int ft_recv_dgram_flood(size_t *recv_cnt)
 		ret = ft_comp_rx(0);
 		cnt += ft_rx_ctrl.credits;
 
-	} while (!ret && (*(uint8_t *) ft_rx_ctrl.buf != (uint8_t) ~0));
+	} while (!ret && ((*(uint8_t *) ft_rx_ctrl.buf != (uint8_t) ~0) || !cnt));
 
 	*recv_cnt = cnt;
 	return ret;


### PR DESCRIPTION
- Fixed ubertest run command in <code>runfabtests.sh</code> to enable it in OSX
- Added failure check for ubertest in <code>runfabtests.sh</code>
- Minor cleanups in <code>runfabtests.sh</code>
- Fixed segfault in ubertest with sockets provider in travis ci environment
- Added cleanups reported by valgrind
- Removed redundant call of <code>ft_open_control</code>
- Removed extra <code>ft_post_recv_bufs</code> at the end of the test
- Added debug prints in ubertest

Fixes #459 
@jithinjosepkl @a-ilango @shefty
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>