### PR TITLE
fabtests: Update tests to use fi_trywait

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -952,20 +952,25 @@ static int ft_fdwait_for_comp(struct fid_cq *cq, uint64_t *cur,
 			    uint64_t total, int timeout)
 {
 	struct fi_cq_err_entry comp;
+	struct fid *fids[1];
 	int fd, ret;
 
 	fd = cq == txcq ? tx_fd : rx_fd;
+	fids[0] = &cq->fid;
 
 	while (total - *cur > 0) {
-		ret = fi_cq_sread(cq, &comp, 1, NULL, 0);
+		ret = fi_trywait(fabric, fids, 1);
+		if (ret == FI_SUCCESS) {
+			ret = ft_poll_fd(fd, timeout);
+			if (ret)
+				return ret;
+		}
+
+		ret = fi_cq_read(cq, &comp, 1);
 		if (ret > 0) {
 			(*cur)++;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			return ret;
-		} else {
-			ret = ft_poll_fd(fd, timeout);
-			if (ret)
-				return ret;
 		}
 	}
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -47,9 +47,8 @@
 extern "C" {
 #endif
 
-/* all tests should work with 1.0 API or newer */
 #ifndef FT_FIVERSION
-#define FT_FIVERSION FI_VERSION(1,1)
+#define FT_FIVERSION FI_VERSION(1,3)
 #endif
 
 #ifdef __APPLE__

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -238,6 +238,7 @@ eq_wait_fd_poll()
 	int fd;
 	struct fi_eq_entry entry;
 	struct pollfd pfd;
+	struct fid *fids[1];
 	int testret;
 	int ret;
 
@@ -255,7 +256,12 @@ eq_wait_fd_poll()
 		goto fail;
 	}
 
-	/* poll on empty EQ */
+	fids[0] = &eq->fid;
+	if (fi_trywait(fabric, fids, 1) != FI_SUCCESS) {
+		sprintf(err_buf, "fi_trywait ret=%d, %s", ret, fi_strerror(-ret));
+		goto fail;
+	}
+
 	pfd.fd = fd;
 	pfd.events = POLLIN;
 	ret = poll(&pfd, 1, 0);
@@ -277,7 +283,6 @@ eq_wait_fd_poll()
 		goto fail;
 	}
 
-	/* poll on EQ with event */
 	pfd.fd = fd;
 	pfd.events = POLLIN;
 	ret = poll(&pfd, 1, 0);


### PR DESCRIPTION
Require libfabric version 1.3 and use fi_trywait when checking
native wait objects.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

This PR will likely fail all travis testing.