### PR TITLE
common: Use a separate fi_info struct for passive EPs

### DIFF
--- a/benchmarks/msg_pingpong.c
+++ b/benchmarks/msg_pingpong.c
@@ -47,7 +47,6 @@ static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
 
@@ -57,20 +56,20 @@ static int server_connect(void)
 		return (int) rd;
 	}
 
-	info = entry.info;
+	fi = entry.info;
 	if (event != FI_CONNREQ) {
 		fprintf(stderr, "Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err;
 	}
 
-	ret = fi_domain(fabric, info, &domain, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err;
 	}
 
-	ret = ft_alloc_active_res(info);
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		 goto err;
 
@@ -98,12 +97,10 @@ static int server_connect(void)
 		goto err;
 	}
 
-	fi_freeinfo(info);
 	return 0;
 
 err:
-	fi_reject(pep, info->handle, NULL, 0);
-	fi_freeinfo(info);
+	fi_reject(pep, fi->handle, NULL, 0);
 	return ret;
 }
 

--- a/common/shared.c
+++ b/common/shared.c
@@ -44,7 +44,7 @@
 
 #include <shared.h>
 
-struct fi_info *fi, *hints;
+struct fi_info *fi_pep, *fi, *hints;
 struct fid_fabric *fabric;
 struct fid_wait *waitset;
 struct fid_domain *domain;
@@ -409,13 +409,13 @@ int ft_start_server(void)
 	int ret;
 
 	ret = fi_getinfo(FT_FIVERSION, opts.src_addr, opts.src_port, FI_SOURCE,
-			 hints, &fi);
+			 hints, &fi_pep);
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
 	}
 
-	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
+	ret = fi_fabric(fi_pep->fabric_attr, &fabric, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_fabric", ret);
 		return ret;
@@ -427,7 +427,7 @@ int ft_start_server(void)
 		return ret;
 	}
 
-	ret = fi_passive_ep(fabric, fi, &pep, NULL);
+	ret = fi_passive_ep(fabric, fi_pep, &pep, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_passive_ep", ret);
 		return ret;
@@ -626,6 +626,10 @@ void ft_free_res(void)
 		buf = rx_buf = tx_buf = NULL;
 		buf_size = rx_size = tx_size = 0;
 	}
+	if (fi_pep) {
+		fi_freeinfo(fi_pep);
+		fi_pep = NULL;
+	}
 	if (fi) {
 		fi_freeinfo(fi);
 		fi = NULL;
@@ -681,6 +685,7 @@ static int getaddr(char *node, char *service,
 				fi->dest_addr, fi->dest_addrlen);
 	}
 
+	fi_freeinfo(fi);
 	return ret;
 }
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -121,7 +121,7 @@ struct ft_opts {
 	char **argv;
 };
 
-extern struct fi_info *fi, *hints;
+extern struct fi_info *fi_pep, *fi, *hints;
 extern struct fid_fabric *fabric;
 extern struct fid_wait *waitset;
 extern struct fid_domain *domain;

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -46,7 +46,6 @@ static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
 
@@ -56,20 +55,20 @@ static int server_connect(void)
 		return (int) rd;
 	}
 
-	info = entry.info;
+	fi = entry.info;
 	if (event != FI_CONNREQ) {
 		fprintf(stderr, "Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err;
 	}
 
-	ret = fi_domain(fabric, info, &domain, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err;
 	}
 
-	ret = ft_alloc_active_res(info);
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		 goto err;
 
@@ -97,12 +96,10 @@ static int server_connect(void)
 		goto err;
 	}
 
-	fi_freeinfo(info);
 	return 0;
 
 err:
-	fi_reject(pep, info->handle, NULL, 0);
-	fi_freeinfo(info);
+	fi_reject(pep, fi->handle, NULL, 0);
 	return ret;
 }
 

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -42,7 +42,6 @@ static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
 
@@ -53,20 +52,20 @@ static int server_connect(void)
 		return (int) rd;
 	}
 
-	info = entry.info;
+	fi = entry.info;
 	if (event != FI_CONNREQ) {
 		FT_ERR("Unexpected CM event %d", event);
 		ret = -FI_EOTHER;
 		goto err;
 	}
 
-	ret = fi_domain(fabric, info, &domain, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err;
 	}
 
-	ret = ft_alloc_active_res(info);
+	ret = ft_alloc_active_res(fi);
 	if (ret)
 		 goto err;
 
@@ -95,12 +94,10 @@ static int server_connect(void)
 		goto err;
 	}
 
-	fi_freeinfo(info);
 	return 0;
 
 err:
-	fi_reject(pep, info->handle, NULL, 0);
-	fi_freeinfo(info);
+	fi_reject(pep, fi->handle, NULL, 0);
 	return ret;
 }
 

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -106,7 +106,6 @@ static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
 
@@ -117,20 +116,20 @@ static int server_connect(void)
 		return (int) rd;
 	}
 
-	info = entry.info;
+	fi = entry.info;
 	if (event != FI_CONNREQ) {
 		fprintf(stderr, "Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err;
 	}
 
-	ret = fi_domain(fabric, info, &domain, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err;
 	}
 
-	ret = alloc_ep_res(info);
+	ret = alloc_ep_res(fi);
 	if (ret)
 		 goto err;
 
@@ -160,12 +159,10 @@ static int server_connect(void)
 		goto err;
 	}
 
-	fi_freeinfo(info);
 	return 0;
 
 err:
-	fi_reject(pep, info->handle, NULL, 0);
-	fi_freeinfo(info);
+	fi_reject(pep, fi->handle, NULL, 0);
 	return ret;
 }
 

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -123,7 +123,6 @@ static int server_connect(void)
 {
 	struct fi_eq_cm_entry entry;
 	uint32_t event;
-	struct fi_info *info = NULL;
 	ssize_t rd;
 	int ret;
 
@@ -133,20 +132,20 @@ static int server_connect(void)
 		return (int) rd;
 	}
 
-	info = entry.info;
+	fi = entry.info;
 	if (event != FI_CONNREQ) {
 		fprintf(stderr, "Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
 		goto err;
 	}
 
-	ret = fi_domain(fabric, info, &domain, NULL);
+	ret = fi_domain(fabric, fi, &domain, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_domain", ret);
 		goto err;
 	}
 
-	ret = alloc_ep_res(info);
+	ret = alloc_ep_res(fi);
 	if (ret)
 		 goto err;
 
@@ -174,12 +173,10 @@ static int server_connect(void)
  		goto err;
  	}
 
- 	fi_freeinfo(info);
  	return 0;
 
 err:
- 	fi_reject(pep, info->handle, NULL, 0);
- 	fi_freeinfo(info);
+	fi_reject(pep, fi->handle, NULL, 0);
  	return ret;
 }
 


### PR DESCRIPTION
We use fi_info fields like tx_attr.inject_size in benchmark
tests. On the server side, the fi_info got from fi_getinfo
may not have complete info if the user hasn't specified a
particular domain. So wait until we get an fi_info through a
connection request and use it for reading attributes. Using a
separate fi_info struct for passive EP should help with this.

Also fix a memory leak in getaddr.