### PR TITLE
Fixed the steps that are required by travis ci to avoid an extra build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 os:
     - osx
     - linux
-before_install:
+install:
     - git clone https://github.com/ofiwg/libfabric.git
     - cd libfabric
     - ./autogen.sh
@@ -16,7 +16,7 @@ before_install:
     - cd ..
     - export LDFLAGS="-L$HOME/lib"
     - export CPPFLAGS="-I$HOME/include"
-install:
+script:
     - ./autogen.sh
     - ./configure --prefix=$HOME
     - make


### PR DESCRIPTION
The required steps of Travis CI are <code>install</code> and <code>script</code> where install is meant for installing the dependencies and script is for building. Without the script step, Travis CI was executing an default script step <code>./configure && make && make test</code> which was running the tests again.
- Moved libfabric installation as <code>install</code> step
- Moved fabtests build as <code>script</code> step

Fixes #471 @a-ilango 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>