### PR TITLE
fixups for get_elapsed implementation and usage

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1231,11 +1231,11 @@ int ft_finalize(void)
 int64_t get_elapsed(const struct timespec *b, const struct timespec *a,
 		    enum precision p)
 {
-    int64_t elapsed;
+	int64_t elapsed;
 
-    elapsed = difftime(a->tv_sec, b->tv_sec) * 1000 * 1000 * 1000;
-    elapsed += a->tv_nsec - b->tv_nsec;
-    return elapsed / p;
+	elapsed = difftime(a->tv_sec, b->tv_sec) * 1000 * 1000 * 1000;
+	elapsed += a->tv_nsec - b->tv_nsec;
+	return elapsed / p;
 }
 
 void show_perf(char *name, int tsize, int iters, struct timespec *start,

--- a/common/shared.c
+++ b/common/shared.c
@@ -1233,7 +1233,7 @@ int64_t get_elapsed(const struct timespec *b, const struct timespec *a,
 {
     int64_t elapsed;
 
-    elapsed = (a->tv_sec - b->tv_sec) * 1000 * 1000 * 1000;
+    elapsed = difftime(a->tv_sec, b->tv_sec) * 1000 * 1000 * 1000;
     elapsed += a->tv_nsec - b->tv_nsec;
     return elapsed / p;
 }

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -350,7 +350,7 @@ static int read_events(size_t count, uint64_t flags)
 static int sread_event(int timeout, uint64_t flags)
 {
 	struct fi_eq_entry entry;
-	uint64_t elapsed;
+	int64_t elapsed;
 	uint32_t event;
 	int ret;
 
@@ -467,7 +467,7 @@ eq_wait_fd_sread()
 {
 	struct fi_eq_entry entry;
 	uint32_t event;
-	uint64_t elapsed;
+	int64_t elapsed;
 	int testret;
 	int ret;
 


### PR DESCRIPTION
These fixes should eliminate an occasional failure on our FreeBSD 32-bit testing platform.