### PR TITLE
Fixed build warnings in travis

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1519,7 +1519,7 @@ int send_recv_greeting(void)
 
 	if (opts.dst_addr) {
 		fprintf(stdout, "Sending message...\n");
-		if (snprintf(tx_buf, message_len, message) >= message_len) {
+		if (snprintf(tx_buf, message_len, "%s", message) >= message_len) {
 			fprintf(stderr, "Transmit buffer too small.\n");
 			return -FI_ETOOSMALL;
 		}


### PR DESCRIPTION
Fixed the following build warning from travis-ci

<code>
common/shared.c:1522:37: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
                if (snprintf(tx_buf, message_len, message) >= message_len)
</code>

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>