### PR TITLE
runfabtests: Disable running of fi_ubertest

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -387,7 +387,7 @@ function complex_test {
 
 function main {
 	if [[ $1 == "quick" ]]; then
-		local -r tests="unit simple short complex"
+		local -r tests="unit simple short"
 		local complex_cfg=$1
 	else
 		local -r tests=$(echo $1 | sed 's/all/unit,simple,standard,complex/g' | tr ',' ' ')


### PR DESCRIPTION
Travis reports frequent, but inconsistent failures with ubertest.
Disable ubertest until it runs more reliably.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>