### PR TITLE
Close the pollset before closing the associated CQs.

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -608,13 +608,13 @@ static void ft_close_fids(void)
 		FT_CLOSE_FID(mr);
 	FT_CLOSE_FID(ep);
 	FT_CLOSE_FID(pep);
+	FT_CLOSE_FID(pollset);
 	FT_CLOSE_FID(rxcq);
 	FT_CLOSE_FID(txcq);
 	FT_CLOSE_FID(rxcntr);
 	FT_CLOSE_FID(txcntr);
 	FT_CLOSE_FID(av);
 	FT_CLOSE_FID(eq);
-	FT_CLOSE_FID(pollset);
 	FT_CLOSE_FID(domain);
 	FT_CLOSE_FID(waitset);
 	FT_CLOSE_FID(fabric);


### PR DESCRIPTION
If the pollset bumps the refcnt on the CQ when being associated then an
error will be thrown. Close the pollset before closing the CQs so the
refcnt is 0 at time of closing the CQs.

While implementing the pollset support for the usnic provider I encountered
that the tests close the pollset after closing the CQs. I don't think it should be
valid to close CQs that have been associated with a pollset without them being
removed or the pollset being destroyed first.

@shantonu @shefty 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>