### PR TITLE
FI_CONTEXT for rdm/tagged benchmarks

### DIFF
--- a/benchmarks/benchmark_shared.c
+++ b/benchmarks/benchmark_shared.c
@@ -129,9 +129,7 @@ int bandwidth(void)
 	if (ret)
 		return ret;
 
-	struct fi_context *ctx_tx = 
-		calloc(opts.window_size, sizeof(struct fi_context));
-	struct fi_context *ctx_rx = 
+	struct fi_context *ctx_arr = 
 		calloc(opts.window_size, sizeof(struct fi_context));
 
 	/* The loop structured allows for the possibility that the sender
@@ -152,10 +150,10 @@ int bandwidth(void)
 					if (ret == -FI_EAGAIN)
 						ret = ft_post_tx(
 							opts.transfer_size,
-							&ctx_tx[j]);
+							&ctx_arr[j]);
 				} else
 					ret = ft_post_tx(opts.transfer_size,
-							 &ctx_tx[j]);
+							 &ctx_arr[j]);
 				if (ret)
 					goto out;
 			}
@@ -172,7 +170,7 @@ int bandwidth(void)
 				ft_start();
 
 			for(j = 0; j < opts.window_size; j++) {
-				ret = ft_post_rx(opts.transfer_size, &ctx_rx[j]);
+				ret = ft_post_rx(opts.transfer_size, &ctx_arr[j]);
 				if (ret)
 					goto out;
 			}
@@ -194,8 +192,7 @@ int bandwidth(void)
 				opts.window_size);
 
 out:
-	free(ctx_tx);
-	free(ctx_rx);
+	free(ctx_arr);
 
 	return 0;
 }

--- a/benchmarks/benchmark_shared.c
+++ b/benchmarks/benchmark_shared.c
@@ -142,9 +142,11 @@ int bandwidth(void)
 				ft_start();
 
 			for(j = 0; j < opts.window_size; j++) {
-				if (opts.transfer_size < fi->tx_attr->inject_size)
+				if (opts.transfer_size < fi->tx_attr->inject_size) {
 					ret = ft_inject(opts.transfer_size);
-				else
+					if (ret == -FI_EAGAIN)
+						ret = ft_post_tx(opts.transfer_size);
+				} else
 					ret = ft_post_tx(opts.transfer_size);
 				if (ret)
 					return ret;

--- a/benchmarks/rdm_tagged_bw.c
+++ b/benchmarks/rdm_tagged_bw.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->caps = FI_TAGGED;
-	hints->mode = FI_LOCAL_MR;
+	hints->mode = FI_LOCAL_MR | FI_CONTEXT;
 
 	ret = run();
 

--- a/benchmarks/rdm_tagged_pingpong.c
+++ b/benchmarks/rdm_tagged_pingpong.c
@@ -56,6 +56,7 @@ static int init_fabric(void)
 		return ret;
 
 	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &fi);
+
 	if (ret) {
 		FT_PRINTERR("fi_getinfo", ret);
 		return ret;
@@ -140,7 +141,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_TAGGED;
-	hints->mode = FI_LOCAL_MR;
+	hints->mode = FI_LOCAL_MR | FI_CONTEXT;
 
 	ret = run();
 

--- a/common/shared.c
+++ b/common/shared.c
@@ -61,6 +61,7 @@ struct fid_eq *eq;
 
 struct fid_mr no_mr;
 struct fi_context tx_ctx, rx_ctx;
+struct fi_context *ctx_arr = NULL;
 
 uint64_t tx_seq, rx_seq, tx_cq_cntr, rx_cq_cntr;
 int ft_skip_mr = 0;
@@ -787,6 +788,9 @@ void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len)
 		snprintf(test_name, test_name_len, "%s_lat", sstr);
 	if (!(opts->options & FT_OPT_ITER))
 		opts->iterations = size_to_count(opts->transfer_size);
+	if (opts->window_size > 0) {
+		ctx_arr = calloc(opts->window_size, sizeof(struct fi_context));
+	}
 }
 
 ssize_t ft_post_tx(size_t size, struct fi_context* ctx)
@@ -1225,6 +1229,10 @@ int ft_finalize(void)
 	if (ret)
 		return ret;
 
+	if (ctx_arr) {
+		free(ctx_arr);
+		ctx_arr = NULL;
+	}
 	return 0;
 }
 

--- a/common/shared.c
+++ b/common/shared.c
@@ -1189,6 +1189,7 @@ int ft_finalize(void)
 {
 	struct iovec iov;
 	int ret;
+	struct fi_context ctx;
 
 	strcpy(tx_buf + ft_tx_prefix_size(), "fin");
 	iov.iov_base = tx_buf;
@@ -1203,6 +1204,8 @@ int ft_finalize(void)
 		tmsg.addr = remote_fi_addr;
 		tmsg.tag = tx_seq;
 		tmsg.ignore = 0;
+		if (hints->mode & FI_CONTEXT)
+			tmsg.context = &ctx;
 
 		ret = fi_tsendmsg(ep, &tmsg, FI_INJECT | FI_TRANSMIT_COMPLETE);
 	} else {
@@ -1212,6 +1215,8 @@ int ft_finalize(void)
 		msg.msg_iov = &iov;
 		msg.iov_count = 1;
 		msg.addr = remote_fi_addr;
+		if (hints->mode & FI_CONTEXT)
+			msg.context = &ctx;
 
 		ret = fi_sendmsg(ep, &msg, FI_INJECT | FI_TRANSMIT_COMPLETE);
 	}

--- a/include/shared.h
+++ b/include/shared.h
@@ -264,8 +264,8 @@ int ft_finalize();
 
 size_t ft_rx_prefix_size();
 size_t ft_tx_prefix_size();
-ssize_t ft_post_rx(size_t size);
-ssize_t ft_post_tx(size_t size);
+ssize_t ft_post_rx(size_t size, struct fi_context* ctx);
+ssize_t ft_post_tx(size_t size, struct fi_context* ctx);
 ssize_t ft_rx(size_t size);
 ssize_t ft_tx(size_t size);
 ssize_t ft_inject(size_t size);

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -99,7 +99,7 @@ static int send_recv()
 	int ret;
 
 	fprintf(stdout, "Posting a send...\n");
-	ret = ft_post_tx(tx_size);
+	ret = ft_post_tx(tx_size, &tx_ctx);
 	if (ret)
 		return ret;
 

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -225,7 +225,7 @@ static int send_recv()
 			fprintf(stderr, "Transmit buffer too small.\n");
 			return -FI_ETOOSMALL;
 		}
-		ret = ft_post_tx(message_len);
+		ret = ft_post_tx(message_len, &tx_ctx);
 		if (ret)
 			return ret;
 

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -121,7 +121,7 @@ static int send_recv()
 //		return ret;
 
 	fprintf(stdout, "Posting a send...\n");
-	ret = ft_post_tx(tx_size);
+	ret = ft_post_tx(tx_size, &tx_ctx);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
Add support of FI_CONTEXT for rdm/tagged benchmarks
Add handling of -FI_EAGAIN from inject in bandwith benchmark