### PR TITLE
Fix machine readable output.

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1311,7 +1311,7 @@ void show_perf_mr(int tsize, int iters, struct timespec *start,
 	printf("total: %lld, ", total);
 	printf("time: %f, ", elapsed / 1000000.0);
 	printf("MB/sec: %f, ", (total) / (1.0 * elapsed));
-	printf("usec/xfer: %f", usec_per_xfer);
+	printf("usec/xfer: %f, ", usec_per_xfer);
 	printf("Mxfers/sec: %f", 1.0/usec_per_xfer);
 	printf(" }\n");
 }


### PR DESCRIPTION
Without: 

```
{ xfer_size: 64, iterations: 10000, total: 1280000, time: 1.199834, MB/sec: 1.066814, usec/xfer: 59.991699Mxfers/sec: 0.016669 }
```

With: 

```
{ xfer_size: 64, iterations: 10000, total: 1280000, time: 1.199910, MB/sec: 1.066747, usec/xfer: 59.995499, Mxfers/sec: 0.016668 }
```

@sayantansur 
@shefty 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>