### PR TITLE
runfabtests: support bash in alternative location

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.


### PR DESCRIPTION
Better enable testing on FreeBSD, where the package system installs bash to /usr/local/bin.