### PR TITLE
Add support rdm_tagged_peek test for ep_rdm without msg capability (verbs) 

### DIFF
--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -205,6 +205,12 @@ int main(int argc, char **argv)
 
 	ret = run();
 
+	if (ret == -ENODATA) {
+		hints->caps = FI_TAGGED;
+
+		ret = run();
+	}
+
 	ft_free_res();
 	return -ret;
 }

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -200,16 +200,10 @@ int main(int argc, char **argv)
 
 	hints->rx_attr->total_buffered_recv = 1024;
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_MSG | FI_TAGGED;
+	hints->caps = FI_TAGGED;
 	hints->mode = FI_CONTEXT | FI_LOCAL_MR;
 
 	ret = run();
-
-	if (ret == -ENODATA) {
-		hints->caps = FI_TAGGED;
-
-		ret = run();
-	}
 
 	ft_free_res();
 	return -ret;


### PR DESCRIPTION
Related changes for verbs provider is under refactoring, PR will be published bit later.
So, failing of this test with verbs provider from current libfabric/master on this test is expected.
@a-ilango @shefty 

Signed-off-by:Evgeny Leksikov <evgeny.leksikov@intel.com>