### PR TITLE
Pass struct fid_ep as an argument to send/recv call

### DIFF
--- a/benchmarks/benchmark_shared.c
+++ b/benchmarks/benchmark_shared.c
@@ -86,13 +86,13 @@ int pingpong(void)
 				ft_start();
 
 			if (opts.transfer_size < fi->tx_attr->inject_size)
-				ret = ft_inject(opts.transfer_size);
+				ret = ft_inject(ep, opts.transfer_size);
 			else
-				ret = ft_tx(opts.transfer_size);
+				ret = ft_tx(ep, opts.transfer_size);
 			if (ret)
 				return ret;
 
-			ret = ft_rx(opts.transfer_size);
+			ret = ft_rx(ep, opts.transfer_size);
 			if (ret)
 				return ret;
 		}
@@ -101,14 +101,14 @@ int pingpong(void)
 			if (i == opts.warmup_iterations)
 				ft_start();
 
-			ret = ft_rx(opts.transfer_size);
+			ret = ft_rx(ep, opts.transfer_size);
 			if (ret)
 				return ret;
 
 			if (opts.transfer_size < fi->tx_attr->inject_size)
-				ret = ft_inject(opts.transfer_size);
+				ret = ft_inject(ep, opts.transfer_size);
 			else
-				ret = ft_tx(opts.transfer_size);
+				ret = ft_tx(ep, opts.transfer_size);
 			if (ret)
 				return ret;
 		}
@@ -149,9 +149,9 @@ int bandwidth(void)
 
 			for(j = 0; j < opts.window_size; j++) {
 				if (opts.transfer_size < fi->tx_attr->inject_size)
-					ret = ft_inject(opts.transfer_size);
+					ret = ft_inject(ep, opts.transfer_size);
 				else
-					ret = ft_post_tx(opts.transfer_size,
+					ret = ft_post_tx(ep, opts.transfer_size,
 							 &ctx_arr[j]);
 				if (ret)
 					return ret;
@@ -159,7 +159,7 @@ int bandwidth(void)
 			ret = ft_get_tx_comp(tx_seq);
 			if (ret)
 				return ret;
-			ret = ft_rx(4);
+			ret = ft_rx(ep, 4);
 			if (ret)
 				return ret;
 		}
@@ -169,14 +169,14 @@ int bandwidth(void)
 				ft_start();
 
 			for(j = 0; j < opts.window_size; j++) {
-				ret = ft_post_rx(opts.transfer_size, &ctx_arr[j]);
+				ret = ft_post_rx(ep, opts.transfer_size, &ctx_arr[j]);
 				if (ret)
 					return ret;
 			}
 			ret = ft_get_rx_comp(rx_seq-1); /* rx_seq is always one ahead */
 			if (ret)
 				return ret;
-			ret = ft_tx(4);
+			ret = ft_tx(ep, 4);
 			if (ret)
 				return ret;
 		}

--- a/include/shared.h
+++ b/include/shared.h
@@ -238,10 +238,10 @@ int ft_alloc_bufs();
 int ft_open_fabric_res();
 int ft_start_server();
 int ft_alloc_active_res(struct fi_info *fi);
-int ft_init_ep();
+int ft_init_ep(void);
 int ft_av_insert(struct fid_av *av, void *addr, size_t count, fi_addr_t *fi_addr,
 		uint64_t flags, void *context);
-int ft_init_av();
+int ft_init_av(void);
 int ft_exchange_keys(struct fi_rma_iov *peer_iov);
 void ft_free_res();
 void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len);
@@ -260,15 +260,15 @@ int ft_sync();
 int ft_sync_pair(int status);
 int ft_fork_and_pair();
 int ft_wait_child();
-int ft_finalize();
+int ft_finalize(void);
 
 size_t ft_rx_prefix_size();
 size_t ft_tx_prefix_size();
-ssize_t ft_post_rx(size_t size, struct fi_context* ctx);
-ssize_t ft_post_tx(size_t size, struct fi_context* ctx);
-ssize_t ft_rx(size_t size);
-ssize_t ft_tx(size_t size);
-ssize_t ft_inject(size_t size);
+ssize_t ft_post_rx(struct fid_ep *ep, size_t size, struct fi_context* ctx);
+ssize_t ft_post_tx(struct fid_ep *ep, size_t size, struct fi_context* ctx);
+ssize_t ft_rx(struct fid_ep *ep, size_t size);
+ssize_t ft_tx(struct fid_ep *ep, size_t size);
+ssize_t ft_inject(struct fid_ep *ep, size_t size);
 
 int ft_cq_readerr(struct fid_cq *cq);
 int ft_get_rx_comp(uint64_t total);
@@ -282,7 +282,7 @@ void show_perf(char *name, int tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter);
 void show_perf_mr(int tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
-int send_recv_greeting(void);
+int send_recv_greeting(struct fid_ep *ep);
 int check_recv_msg(const char *message);
 
 #define FT_PROCESS_QUEUE_ERR(readerr, rd, queue, fn, str)	\

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -87,7 +87,7 @@ static int run(void)
 	if (ret)
 		return ret;
 
-	return send_recv_greeting();
+	return send_recv_greeting(ep);
 }
 
 int main(int argc, char **argv)

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -99,7 +99,7 @@ static int send_recv()
 	int ret;
 
 	fprintf(stdout, "Posting a send...\n");
-	ret = ft_post_tx(tx_size, &tx_ctx);
+	ret = ft_post_tx(ep, tx_size, &tx_ctx);
 	if (ret)
 		return ret;
 

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -172,7 +172,7 @@ static int run(void)
 		return ret;
 	}
 
-	ret = send_recv_greeting();
+	ret = send_recv_greeting(ep);
 
 	fi_shutdown(ep, 0);
 	return ret;

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -222,7 +222,7 @@ static int send_recv()
 			fprintf(stderr, "Transmit buffer too small.\n");
 			return -FI_ETOOSMALL;
 		}
-		ret = ft_post_tx(message_len, &tx_ctx);
+		ret = ft_post_tx(ep, message_len, &tx_ctx);
 		if (ret)
 			return ret;
 

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -434,7 +434,7 @@ static int run(void)
 		return ret;
 	}
 
-	ret = send_recv_greeting();
+	ret = send_recv_greeting(ep);
 
 	fi_shutdown(ep, 0);
 	return ret;

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -121,7 +121,7 @@ static int send_recv()
 //		return ret;
 
 	fprintf(stdout, "Posting a send...\n");
-	ret = ft_post_tx(tx_size, &tx_ctx);
+	ret = ft_post_tx(ep, tx_size, &tx_ctx);
 	if (ret)
 		return ret;
 

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -87,7 +87,7 @@ static int run(void)
 	if (ret)
 		return ret;
 
-	return send_recv_greeting();
+	return send_recv_greeting(ep);
 }
 
 int main(int argc, char **argv)

--- a/simple/rdm_shared_av.c
+++ b/simple/rdm_shared_av.c
@@ -99,7 +99,7 @@ static int send_recv()
 			return -FI_ETOOSMALL;
 		}
 
-		ret = ft_tx(message_len);
+		ret = ft_tx(ep, message_len);
 		if (ret)
 			return ret;
 

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -70,7 +70,7 @@ static int run_test(void)
 			if (ret)
 				FT_PRINTERR("fi_writedata", ret);
 
-			ret = ft_rx(0);
+			ret = ft_rx(ep, 0);
 			break;
 		case FT_RMA_READ:
 			ret = fi_read(ep, buf, opts.transfer_size, fi_mr_desc(mr),

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -489,7 +489,7 @@ static int run(void)
 		goto out;
 
 	ft_sync();
-	ft_finalize(fi, ep, txcq, rxcq, remote_fi_addr);
+	ft_finalize();
 out:
 	return ret;
 }

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -90,11 +90,11 @@ static int sync_test(void)
 {
 	int ret;
 
-	ret = opts.dst_addr ? ft_tx(1) : wait_for_recv_completion(1);
+	ret = opts.dst_addr ? ft_tx(ep, 1) : wait_for_recv_completion(1);
 	if (ret)
 		return ret;
 
-	ret = opts.dst_addr ? wait_for_recv_completion(1) : ft_tx(1);
+	ret = opts.dst_addr ? wait_for_recv_completion(1) : ft_tx(ep, 1);
 	return ret;
 }
 
@@ -132,7 +132,7 @@ static int run_test(void)
 	ft_start();
 	if (opts.dst_addr) {
 		for (i = 0; i < opts.iterations; i++) {
-			ret = ft_tx(opts.transfer_size);
+			ret = ft_tx(ep, opts.transfer_size);
 			if (ret)
 				goto out;
 		}
@@ -273,7 +273,7 @@ static int init_av(void)
 			return ret;
 		}
 
-		ret = ft_tx(addrlen);
+		ret = ft_tx(ep, addrlen);
 		if (ret)
 			return ret;
 	} else {
@@ -304,7 +304,7 @@ static int run(void)
 	ret = run_test();
 
 	rx_seq++;
-	ft_finalize(fi, ep, txcq, rxcq, remote_fi_addr);
+	ft_finalize();
 out:
 	return ret;
 }

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -78,7 +78,7 @@ static int run_test(void)
 				return ret;
 			}
 
-			ret = ft_rx(0);
+			ret = ft_rx(ep, 0);
 			break;
 		case FT_RMA_READ:
 			ret = fi_read(ep, buf, opts.transfer_size, fi_mr_desc(mr),
@@ -192,7 +192,7 @@ static int run(void)
 	}
 
 	ft_sync();
-	ft_finalize(fi, ep, txcq, rxcq, remote_fi_addr);
+	ft_finalize();
 out:
 	return ret;
 }


### PR DESCRIPTION
For different ep types e.g. scalable_ep, alias_ep etc. we need to send/recv data using a specific ep instead of the common <code>struct fid_ep</code> defined in <code>include/shared.h</code>. Instead of duplicating send/recv call in tests, this patch adds ep as an argument.
- Passed <code>struct fid_ep</code> as an argument to rx/tx/inject call
- Removed unused arguments for <code>ft_finalize</code> in some tests

@a-ilango @shefty 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>