### PR TITLE
rdm_rma_trigger: Modified the test to use alias ep for triggered RMA

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -52,7 +52,7 @@ struct fid_wait *waitset;
 struct fid_domain *domain;
 struct fid_poll *pollset;
 struct fid_pep *pep;
-struct fid_ep *ep;
+struct fid_ep *ep, *alias_ep;
 struct fid_cq *txcq, *rxcq;
 struct fid_cntr *txcntr, *rxcntr;
 struct fid_mr *mr;
@@ -568,6 +568,17 @@ int ft_get_cq_fd(struct fid_cq *cq, int *fd)
 	return ret;
 }
 
+int ft_init_alias_ep(uint64_t flags)
+{
+	int ret;
+	ret = fi_ep_alias(ep, &alias_ep, flags);
+	if (ret) {
+		FT_PRINTERR("fi_ep_alias", ret);
+		return ret;
+	}
+	return 0;
+}
+
 int ft_init_ep(void)
 {
 	int flags, ret;
@@ -720,6 +731,7 @@ static void ft_close_fids(void)
 {
 	if (mr != &no_mr)
 		FT_CLOSE_FID(mr);
+	FT_CLOSE_FID(alias_ep);
 	FT_CLOSE_FID(ep);
 	FT_CLOSE_FID(pep);
 	FT_CLOSE_FID(pollset);

--- a/include/shared.h
+++ b/include/shared.h
@@ -127,7 +127,7 @@ extern struct fid_wait *waitset;
 extern struct fid_domain *domain;
 extern struct fid_poll *pollset;
 extern struct fid_pep *pep;
-extern struct fid_ep *ep;
+extern struct fid_ep *ep, *alias_ep;
 extern struct fid_cq *txcq, *rxcq;
 extern struct fid_cntr *txcntr, *rxcntr;
 extern struct fid_mr *mr, no_mr;
@@ -241,6 +241,7 @@ int ft_server_connect();
 int ft_client_connect();
 int ft_alloc_active_res(struct fi_info *fi);
 int ft_init_ep(void);
+int ft_init_alias_ep(uint64_t flags);
 int ft_av_insert(struct fid_av *av, void *addr, size_t count, fi_addr_t *fi_addr,
 		uint64_t flags, void *context);
 int ft_init_av(void);


### PR DESCRIPTION
Modified triggered RMA example to use alias_ep for triggered operation. This adds a test path for alias_ep.

@sayantansur @jithinjosepkl @shefty
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>