### PR TITLE
benchmarks: Reduce iterations for bandwidth tests.

### DIFF
--- a/benchmarks/msg_bw.c
+++ b/benchmarks/msg_bw.c
@@ -91,6 +91,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.options |= FT_OPT_BW;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/benchmarks/msg_rma_bw.c
+++ b/benchmarks/msg_rma_bw.c
@@ -97,6 +97,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.options |= FT_OPT_BW;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/benchmarks/rdm_tagged_bw.c
+++ b/benchmarks/rdm_tagged_bw.c
@@ -113,6 +113,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.options |= FT_OPT_BW;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/common/shared.c
+++ b/common/shared.c
@@ -938,11 +938,11 @@ char *cnt_str(char str[FT_STR_LEN], long long cnt)
 int size_to_count(int size)
 {
 	if (size >= (1 << 20))
-		return 100;
+		return (opts.options & FT_OPT_BW) ? 200 : 100;
 	else if (size >= (1 << 16))
-		return 1000;
+		return (opts.options & FT_OPT_BW) ? 2000 : 1000;
 	else
-		return 10000;
+		return (opts.options & FT_OPT_BW) ? 20000: 10000;
 }
 
 void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len)

--- a/include/shared.h
+++ b/include/shared.h
@@ -101,6 +101,7 @@ enum {
 	FT_OPT_TX_CNTR		= 1 << 6,
 	FT_OPT_VERIFY_DATA	= 1 << 7,
 	FT_OPT_ALIGN		= 1 << 8,
+	FT_OPT_BW		= 1 << 9,
 };
 
 /* for RMA tests --- we want to be able to select fi_writedata, but there is no


### PR DESCRIPTION
Bandwidth tests use windows which increases the # of transfers. Reduce
iterations so that tests don't timeout when running runfabtests.sh