### PR TITLE
cm_data.c: use the right item size

### DIFF
--- a/simple/cm_data.c
+++ b/simple/cm_data.c
@@ -56,7 +56,7 @@ static int server_setup(void)
 		return ret;
 
 	/* Get the maximum cm_size supported in all domains */
-	opt_size = sizeof(opt_size);
+	opt_size = sizeof(cm_data_size);
 	return fi_getopt(&pep->fid, FI_OPT_ENDPOINT, FI_OPT_CM_DATA_SIZE,
 		&cm_data_size, &opt_size);
 }


### PR DESCRIPTION
This previously worked because opt_size and cm_data_size are both size_t, but technically, we should be using the size of cm_data_size, because that's the item we want filled.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@shefty @bturrubiates This seems like a no-brainer, but please provide another pair of eyes to check this...