### PR TITLE
cm_data: Handled fi_shutdown event and added code to synchronize via socket communication

### DIFF
--- a/complex/ft_comm.c
+++ b/complex/ft_comm.c
@@ -98,11 +98,11 @@ static int ft_load_av(void)
 	}
 
 	msg.len = (uint32_t) len;
-	ret = ft_fw_send(sock, &msg, sizeof msg);
+	ret = ft_sock_send(sock, &msg, sizeof msg);
 	if (ret)
 		return ret;
 
-	ret = ft_fw_recv(sock, &msg, sizeof msg);
+	ret = ft_sock_recv(sock, &msg, sizeof msg);
 	if (ret)
 		return ret;
 

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -247,21 +247,6 @@ void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt)
 		ctrl->iov_iter = 0;
 }
 
-static int ft_fw_sync(int value)
-{
-	int result = -FI_EOTHER;
-
-	if (listen_sock < 0) {
-		ft_fw_send(sock, &value,  sizeof value);
-		ft_fw_recv(sock, &result, sizeof result);
-	} else {
-		ft_fw_recv(sock, &result, sizeof result);
-		ft_fw_send(sock, &value,  sizeof value);
-	}
-
-	return result;
-}
-
 static int ft_sync_test(int value)
 {
 	int ret;
@@ -270,7 +255,7 @@ static int ft_sync_test(int value)
 	if (ret)
 		return ret;
 
-	return ft_fw_sync(value);
+	return ft_sock_sync(value);
 }
 
 static int ft_pingpong(void)
@@ -542,7 +527,7 @@ int ft_run_test()
 		}
 	}
 
-	ft_fw_sync(0);
+	ft_sock_sync(0);
 
 	ret = ft_enable_comm();
 	if (ret) {

--- a/include/shared.h
+++ b/include/shared.h
@@ -37,6 +37,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <inttypes.h>
+#include <netinet/tcp.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_eq.h>
@@ -173,9 +174,18 @@ void ft_csusage(char *name, char *desc);
 void ft_fill_buf(void *buf, int size);
 int ft_check_buf(void *buf, int size);
 uint64_t ft_init_cq_data(struct fi_info *info);
+int ft_sock_listen(char *service);
+int ft_sock_connect(char *node, char *service);
+int ft_sock_accept();
+int ft_sock_send(int fd, void *msg, size_t len);
+int ft_sock_recv(int fd, void *msg, size_t len);
+int ft_sock_sync(int value);
+void ft_sock_shutdown(int fd);
 extern int ft_skip_mr;
 extern int ft_parent_proc;
 extern int ft_socket_pair[2];
+extern int sock;
+extern int listen_sock;
 #define ADDR_OPTS "b:p:s:a:"
 #define INFO_OPTS "n:f:e:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"

--- a/man/fabtests.7.md
+++ b/man/fabtests.7.md
@@ -37,6 +37,7 @@ These tests are a mix of very basic functionality tests that show major features
 	fi_rdm_shared_ctx: An RDM client-server example that uses shared context
 	fi_rdm_tagged_peek: An RDM client-server example that uses tagged FI_PEEK
 	fi_scalable_ep: An RDM client-server example with scalable endpoints
+	fi_cm_data: A MSG client-server example that uses CM data
 
 ## Benchmarks
 

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -81,6 +81,7 @@ neg_unit_tests=(
 )
 
 simple_tests=(
+	"cm_data"
 	"cq_data"
 	"dgram"
 	"dgram_waitset"

--- a/simple/cm_data.c
+++ b/simple/cm_data.c
@@ -388,8 +388,8 @@ static int run(void)
 	}
 
 	/* Despite server not being setup to handle this, the client should fail
-	* with -FI_EINVAL since this exceeds its max data size.
-	*/
+	 * with -FI_EINVAL since this exceeds its max data size.
+	 */
 	if (opts.dst_addr) {
 		printf("trying with data size exceeding maximum: %zu\n",
 				cm_data_size + 1);


### PR DESCRIPTION
- According to manpage <code>fi_shutdown</code> generates an FI_SHUTDOWN event. Added <code>fi_eq_sread</code> to handle the event.
- Added a memset before eq_sread after fi_listen
- Used FT_EQ_ERR macro for fi_eq_readerr case
- Added cm_data into runfabtests.sh
- Moved sockets communication code from complex folder to <code>common/shared.c</code> and <code>include/shared.h</code>
- Renamed ft_fw_* functions as ft_sock_* functions for clarification
- Added sockets synchronization code to address Travis failures
- Added an entry for cm_data in the manpage

@jithinjosepkl @bturrubiates 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>