### PR TITLE
rc_pingpong: Free info handle before reuse

### DIFF
--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -217,6 +217,7 @@ static int pp_accept_ctx(struct pingpong_context *ctx)
 		FT_PRINTERR("fi_endpoint", rc);
 		return 1;
 	}
+	fi_freeinfo(entry.info);
 
 	/* Create event queue */
 	if (pp_cq_create(ctx)) {
@@ -266,7 +267,6 @@ static int pp_accept_ctx(struct pingpong_context *ctx)
 	}
 	printf("Connection accepted\n");
 
-	fi_freeinfo(entry.info);
 	return 0;
 }
 


### PR DESCRIPTION
Our Jenkins testing was hanging on this test on some platforms. I tracked the issue down to what I think is incorrect usage of `fi_freeinfo`. My fix is based on the usage in `simple/cm_data.c`.