### PR TITLE
Fix rx_size_left_err

### DIFF
--- a/include/unit_common.h
+++ b/include/unit_common.h
@@ -38,7 +38,7 @@ enum { PASS, FAIL, NOTSUPP, SKIPPED };
 #define TEST_ENTRY(NAME) { NAME, #NAME }
 
 #define TEST_RET_VAL(_ret, _testret) \
-	(_ret == -FI_ENOSYS || -ret == -FI_ENODATA) ? SKIPPED : (_testret)
+	(_ret == -FI_ENOSYS || _ret == -FI_ENODATA) ? SKIPPED : (_testret)
 
 struct test_entry {
 	int (*test)();

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -141,8 +141,13 @@ rx_size_left_err(void)
 		goto fail;
 	}
 
-	/* ep starts in a non-enabled state, may fail, should not SEGV */
-	fi_rx_size_left(ep);
+	/* ep starts in a non-enabled state, so if supported this
+	 * should return -FI_EOPBADSTATE */
+	ret = fi_rx_size_left(ep);
+	if ((ret != -FI_EOPBADSTATE) && (ret != -FI_ENOSYS)) {
+		printf("fi_rx_size_left %s (%d)\n", fi_strerror(-ret), ret);
+		goto fail;
+	}
 
 	testret = PASS;
 fail:


### PR DESCRIPTION
- Check for correct return value from fi_rx_size_left (-FI_EOPBADSTATE)
- Fix small type-o in TEST_RET_VAL macro

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>