### PR TITLE
freebsd/osd.h: Include header for protocol macros

### DIFF
--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -32,6 +32,7 @@
 
 #include <sys/endian.h>
 #include <pthread_np.h>
+#include <netinet/in.h>
 
 
 #define bswap_64 bswap64


### PR DESCRIPTION
Caught by our FreeBSD tests.