### PR TITLE
Enable testing multiple endpoint types with size left test

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -71,7 +71,7 @@ pid_t ft_child_pid = 0;
 int ft_socket_pair[2];
 
 fi_addr_t remote_fi_addr = FI_ADDR_UNSPEC;
-void *buf, *tx_buf, *rx_buf;
+char *buf, *tx_buf, *rx_buf;
 size_t buf_size, tx_size, rx_size;
 int rx_fd = -1, tx_fd = -1;
 char default_port[8] = "9228";
@@ -260,7 +260,8 @@ int ft_alloc_msgs(void)
 			return -errno;
 		buf_size += alignment;
 
-		ret = posix_memalign(&buf, (size_t) alignment, buf_size);
+		ret = posix_memalign((void **) &buf, (size_t) alignment,
+				buf_size);
 		if (ret) {
 			FT_PRINTERR("posix_memalign", ret);
 			return ret;
@@ -771,7 +772,7 @@ int ft_exchange_keys(struct fi_rma_iov *peer_iov)
 	int ret;
 
 	if (opts.dst_addr) {
-		rma_iov = tx_buf + ft_tx_prefix_size();
+		rma_iov = (struct fi_rma_iov *) (tx_buf + ft_tx_prefix_size());
 		rma_iov->addr = fi->domain_attr->mr_mode == FI_MR_SCALABLE ?
 				0 : (uintptr_t) rx_buf + ft_rx_prefix_size();
 		rma_iov->key = fi_mr_key(mr);
@@ -783,7 +784,7 @@ int ft_exchange_keys(struct fi_rma_iov *peer_iov)
 		if (ret)
 			return ret;
 
-		rma_iov = rx_buf + ft_rx_prefix_size();
+		rma_iov = (struct fi_rma_iov *) (rx_buf + ft_rx_prefix_size());
 		*peer_iov = *rma_iov;
 		ret = ft_post_rx(ep, rx_size, &rx_ctx);
 	} else {
@@ -791,13 +792,13 @@ int ft_exchange_keys(struct fi_rma_iov *peer_iov)
 		if (ret)
 			return ret;
 
-		rma_iov = rx_buf + ft_rx_prefix_size();
+		rma_iov = (struct fi_rma_iov *) (rx_buf + ft_rx_prefix_size());
 		*peer_iov = *rma_iov;
 		ret = ft_post_rx(ep, rx_size, &rx_ctx);
 		if (ret)
 			return ret;
 
-		rma_iov = tx_buf + ft_tx_prefix_size();
+		rma_iov = (struct fi_rma_iov *) (tx_buf + ft_tx_prefix_size());
 		rma_iov->addr = fi->domain_attr->mr_mode == FI_MR_SCALABLE ?
 				0 : (uintptr_t) rx_buf + ft_rx_prefix_size();
 		rma_iov->key = fi_mr_key(mr);

--- a/configure.ac
+++ b/configure.ac
@@ -36,9 +36,21 @@ AM_CONDITIONAL([MACOS], [test $macos -eq 1])
 AM_CONDITIONAL([LINUX], [test $linux -eq 1])
 AM_CONDITIONAL([FREEBSD], [test $freebsd -eq 1])
 
+base_c_warn_flags="-Wall -Wundef -Wpointer-arith"
+
+AC_ARG_ENABLE([debug],
+	[AS_HELP_STRING([--enable-debug],
+			[Enable debugging - default NO])],
+	[CFLAGS="-g -O0 ${base_c_warn_flags} -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers $CFLAGS"
+	 dbg=1],
+	[dbg=0])
+
+AC_DEFINE_UNQUOTED([ENABLE_DEBUG], [$dbg],
+	[defined to 1 if configured with --enable-debug])
+
 dnl Fix autoconf's habit of adding -g -O2 by default
 AS_IF([test -z "$CFLAGS"],
-      [CFLAGS='-O2 -DNDEBUG -Wall'])
+      [CFLAGS="-O2 -DNDEBUG ${base_c_warn_flags}"])
 
 # AM PROG_AR did not exist pre AM 1.11.x (where x is somewhere >0 and
 # <3), but it is necessary in AM 1.12.x.

--- a/include/shared.h
+++ b/include/shared.h
@@ -146,7 +146,7 @@ extern struct fid_av *av;
 extern struct fid_eq *eq;
 
 extern fi_addr_t remote_fi_addr;
-extern void *buf, *tx_buf, *rx_buf;
+extern char *buf, *tx_buf, *rx_buf;
 extern size_t buf_size, tx_size, rx_size;
 extern int tx_fd, rx_fd;
 extern int timeout;

--- a/include/shared.h
+++ b/include/shared.h
@@ -228,6 +228,12 @@ int size_to_count(int size);
 #define FT_ERR(fmt, ...) FT_LOG("error", fmt, ##__VA_ARGS__)
 #define FT_WARN(fmt, ...) FT_LOG("warn", fmt, ##__VA_ARGS__)
 
+#if ENABLE_DEBUG
+#define FT_DEBUG(fmt, ...) FT_LOG("debug", fmt, ##__VA_ARGS__)
+#else
+#define FT_DEBUG(fmt, ...)
+#endif
+
 #define FT_EQ_ERR(eq, entry, buf, len) \
 	FT_ERR("eq_readerr: %s", fi_eq_strerror(eq, entry.prov_errno, \
 				entry.err_data, buf, len))

--- a/simple/shared_ctx.c
+++ b/simple/shared_ctx.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under the BSD license
  * below:
@@ -51,7 +52,7 @@ static int rx_shared_ctx = 1;
 static int ep_cnt = 4;
 static struct fid_ep **ep_array, *srx_ctx;
 static struct fid_stx *stx_ctx;
-static void *local_addr, *remote_addr;
+static char *local_addr, *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t *addr_array;
 

--- a/unit/common.c
+++ b/unit/common.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
- * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -54,13 +54,11 @@ run_tests(struct test_entry *test_array, char *err_buf)
 			printf("PASS!\n");
 			break;
 		case FAIL:
-			printf("FAIL\n");
-			printf("  %s\n", err_buf);
+			printf("FAIL: %s\n", err_buf);
 			failed++;
 			break;
 		case SKIPPED:
-			printf("skipped because:\n");
-			printf("  %s\n", err_buf);
+			printf("skipped because: %s\n", err_buf);
 			break;
 		case NOTSUPP:
 			printf("requires unsupported feature: %s\n", err_buf);

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -47,13 +47,6 @@
 #include "shared.h"
 #include "unit_common.h"
 
-
-#define DEBUG(...) \
-	if (fabtests_debug) { \
-		fprintf(stderr, __VA_ARGS__); \
-	}
-
-int fabtests_debug = 0;
 
 static char err_buf[512];
 
@@ -216,15 +209,9 @@ int main(int argc, char **argv)
 {
 	int op, ret;
 	int failed;
-	char *debug_str;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
-
-	debug_str = getenv("FABTESTS_DEBUG");
-	if (debug_str) {
-		fabtests_debug = atoi(debug_str);
-	}
 
 	hints = fi_allocinfo();
 	if (!hints)
@@ -258,7 +245,7 @@ int main(int argc, char **argv)
 		exit(-ret);
 	}
 
-	DEBUG("using provider \"%s\" and fabric \"%s\"\n",
+	FT_DEBUG("using provider \"%s\" and fabric \"%s\"\n",
 		fi->fabric_attr->prov_name,
 		fi->fabric_attr->name);
 

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -31,7 +31,6 @@
  * SOFTWARE.
  */
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -47,167 +46,213 @@
 #include "shared.h"
 #include "unit_common.h"
 
-
 static char err_buf[512];
 
-
-static void teardown_ep_fixture(void)
-{
-	if (mr != &no_mr)
-		FT_CLOSE_FID(mr);
-	FT_CLOSE_FID(ep);
-	FT_CLOSE_FID(txcq);
-	FT_CLOSE_FID(rxcq);
-	FT_CLOSE_FID(av);
-	if (buf) {
-		free(buf);
-		buf = rx_buf = tx_buf = NULL;
-		buf_size = rx_size = tx_size = 0;
-	}
-}
-
-/* returns 0 on success or a negative value that can be stringified with
- * fi_strerror on error */
-static int setup_ep_fixture(void)
+/* Need to define a separate setup function from the ft_* functions defined in
+ * common/shared.c, this is because extra flexibility is needed in this test.
+ * The ft_* functions have a couple of incompatibility issues with this test:
+ *
+ * - ft_free_res always frees the hints
+ * - ft_init_ep posts a recv
+ */
+static void setup_ep_fixture(void)
 {
 	int ret;
 
-	ret = ft_alloc_active_res(fi);
-	if (ret)
-		return ret;
-
-	ret = ft_init_ep();
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
-static int
-rx_size_left(void)
-{
-	int ret;
-	int testret;
-
-	testret = FAIL;
-
-	ret = setup_ep_fixture();
-	if (ret != 0) {
-		printf("failed to setup test fixture: %s\n", fi_strerror(-ret));
-		goto fail;
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_fabric", ret);
+		exit(EXIT_FAILURE);
 	}
 
-	ret = fi_rx_size_left(ep);
-	if (ret < 0) {
-		printf("fi_rx_size_left returned %d (-%s)\n", ret,
-			fi_strerror(-ret));
-		goto fail;
+	ret = fi_domain(fabric, fi, &domain, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_domain", ret);
+		exit(EXIT_FAILURE);
 	}
 
-	/* TODO: add basic sanity checking here */
+	/* Queues are opened for providers that need a queue bound before
+	 * calling fi_enable. This avoids getting back -FI_ENOCQ.
+	 */
+	cq_attr.format = FI_CQ_FORMAT_CONTEXT;
+	cq_attr.wait_obj = FI_WAIT_NONE;
 
-	testret = PASS;
-fail:
-	teardown_ep_fixture();
-	return TEST_RET_VAL(ret, testret);
-}
-
-static int
-rx_size_left_err(void)
-{
-	int ret;
-	int testret;
-
-	testret = FAIL;
-
-	/* datapath operation, not expected to be caught by libfabric */
-#if 0
-	ret = fi_rx_size_left(NULL);
-	if (ret != -FI_EINVAL) {
-		goto fail;
+	ret = fi_cq_open(domain, &cq_attr, &txcq, &txcq);
+	if (ret) {
+		FT_PRINTERR("fi_cq_open", ret);
+		exit(EXIT_FAILURE);
 	}
-#endif
+
+	ret = fi_cq_open(domain, &cq_attr, &rxcq, &rxcq);
+	if (ret) {
+		FT_PRINTERR("fi_cq_open", ret);
+		exit(EXIT_FAILURE);
+	}
 
 	ret = fi_endpoint(domain, fi, &ep, NULL);
-	if (ret != 0) {
-		printf("fi_endpoint %s\n", fi_strerror(-ret));
-		goto fail;
+	if (ret) {
+		FT_PRINTERR("fi_endpoint", ret);
+		exit(EXIT_FAILURE);
 	}
 
-	/* ep starts in a non-enabled state, so if supported this
-	 * should return -FI_EOPBADSTATE */
-	ret = fi_rx_size_left(ep);
-	if ((ret != -FI_EOPBADSTATE) && (ret != -FI_ENOSYS)) {
-		printf("fi_rx_size_left %s (%d)\n", fi_strerror(-ret), ret);
-		goto fail;
+	ret = fi_ep_bind(ep, &txcq->fid, FI_TRANSMIT);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		exit(EXIT_FAILURE);
 	}
 
-	testret = PASS;
-fail:
-	FT_CLOSE_FID(ep);
-	return TEST_RET_VAL(ret, testret);
+	ret = fi_ep_bind(ep, &rxcq->fid, FI_RECV);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		exit(EXIT_FAILURE);
+	}
 }
 
-static int
-tx_size_left(void)
+/* Teardown after every test. */
+static void teardown_ep_fixture(void)
 {
-	int ret;
+	FT_CLOSE_FID(ep);
+	FT_CLOSE_FID(rxcq);
+	FT_CLOSE_FID(txcq);
+	FT_CLOSE_FID(domain);
+	FT_CLOSE_FID(fabric);
+}
+
+/* Test that a provider returns -FI_EOPBADSTATE before an endpoint has been
+ * enabled.
+ */
+static int test_size_left_bad(void)
+{
+	ssize_t ret;
 	int testret;
 
-	testret = FAIL;
-
-	ret = setup_ep_fixture();
-	if (ret != 0) {
-		printf("failed to setup test fixture: %s\n", fi_strerror(-ret));
+	FT_DEBUG("testing fi_rx_size_left for -FI_EOPBADSTATE");
+	ret = fi_rx_size_left(ep);
+	if (ret != -FI_EOPBADSTATE)
 		goto fail;
-	}
 
+	FT_DEBUG("testing fi_tx_size_left for -FI_EOPBADSTATE");
 	ret = fi_tx_size_left(ep);
-	if (ret < 0) {
-		printf("fi_rx_size_left returned %d (-%s)\n", ret,
-			fi_strerror(-ret));
+	if (ret != -FI_EOPBADSTATE)
 		goto fail;
-	}
 
-	/* TODO: once fi_tx_attr's size field meaning has been fixed to refer to
-	 * queue depth instead of number of bytes, we can do a little basic
-	 * sanity checking here */
+	return PASS;
 
-	testret = PASS;
 fail:
-	teardown_ep_fixture();
-	return TEST_RET_VAL(ret, testret);
+	testret = TEST_RET_VAL(ret, FAIL);
+	if (testret == SKIPPED)
+		snprintf(err_buf, sizeof(err_buf),
+			 "provider returned: [%zd]: <%s>", ret,
+			 fi_strerror(-ret));
+	else
+		snprintf(err_buf, sizeof(err_buf),
+			 "%zd not equal to -FI_EOPBADSTATE", ret);
+
+	return testret;
 }
 
-struct test_entry test_rx_size_left[] = {
-	TEST_ENTRY(rx_size_left_err),
-	TEST_ENTRY(rx_size_left),
-	{ NULL, "" }
-};
-
-struct test_entry test_tx_size_left[] = {
-	TEST_ENTRY(tx_size_left),
-	{ NULL, "" }
-};
-
-/* TODO: Rewrite test to use size_left() during data transfers and check
- * that posted sends complete when indicated and check for proper failures
- * when size_left() returns 0.
+/* Test that the initial sizes are equal to the size attribute for the tx and rx
+ * context.
  */
-int run_test_set(void)
+static int test_size_left_good(void)
 {
-	int failed;
+	ssize_t expected;
+	ssize_t ret;
+	int testret;
 
-	failed = 0;
-	failed += run_tests(test_rx_size_left, err_buf);
-	failed += run_tests(test_tx_size_left, err_buf);
+	FT_DEBUG("testing fi_rx_size_left for size equal to or greater than fi->rx_attr->size");
+	expected = fi->rx_attr->size;
+
+	ret = fi_rx_size_left(ep);
+	if (ret < expected)
+		goto fail;
+
+	FT_DEBUG("testing fi_tx_size_left for size equal to or greater than fi->tx_attr->size");
+	expected = fi->tx_attr->size;
+
+	ret = fi_tx_size_left(ep);
+	if (ret < expected)
+		goto fail;
+
+	return PASS;
+
+fail:
+	testret = TEST_RET_VAL(ret, FAIL);
+	if (testret == SKIPPED)
+		snprintf(err_buf, sizeof(err_buf),
+			 "provider returned: [%zd]: <%s>", ret,
+			 fi_strerror(-ret));
+	else
+		snprintf(err_buf, sizeof(err_buf),
+			 "%zd not greater than or equal to %zd", ret, expected);
+
+	return testret;
+}
+
+/* Separate these into separate entries since one of them needs to get run
+ * before the endpoint is enabled, and one needs to be run after the endpoint is
+ * enabled.
+ */
+struct test_entry bad_tests[] = {
+	TEST_ENTRY(test_size_left_bad),
+	{ NULL, "" }
+};
+
+struct test_entry good_tests[] = {
+	TEST_ENTRY(test_size_left_good),
+	{ NULL, "" }
+};
+
+int run_test_set(struct fi_info *hints)
+{
+	struct fi_info *info;
+	int failed = 0;
+	int ep_type;
+	int ret;
+
+	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &info);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		exit(EXIT_FAILURE);
+	}
+
+	for (ep_type = FI_EP_MSG; ep_type <= FI_EP_RDM; ep_type++) {
+		for (fi = info; fi; fi = fi->next) {
+			if (fi->ep_attr->type == ep_type)
+				break;
+		}
+
+		if (!fi)
+			continue;
+
+		setup_ep_fixture();
+
+		printf("Testing provider %s on fabric %s with EP type %s\n",
+				fi->fabric_attr->prov_name,
+				fi->fabric_attr->name,
+				fi_tostr(&ep_type, FI_TYPE_EP_TYPE));
+
+		failed += run_tests(bad_tests, err_buf);
+
+		ret = fi_enable(ep);
+		if (ret) {
+			FT_PRINTERR("fi_enable", ret);
+			exit(EXIT_FAILURE);
+		}
+
+		failed += run_tests(good_tests, err_buf);
+
+		teardown_ep_fixture();
+	}
+
+	fi_freeinfo(info);
 
 	return failed;
 }
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op;
 	int failed;
 
 	opts = INIT_OPTS;
@@ -236,31 +281,16 @@ int main(int argc, char **argv)
 	}
 
 	hints->mode = ~0;
-	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
 
-	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
-	if (ret != 0) {
-		printf("fi_getinfo %s\n", fi_strerror(-ret));
-		exit(-ret);
-	}
+	failed = run_test_set(hints);
 
-	FT_DEBUG("using provider \"%s\" and fabric \"%s\"\n",
-		fi->fabric_attr->prov_name,
-		fi->fabric_attr->name);
-
-	ret = ft_open_fabric_res();
-	if (ret)
-		return ret;
-
-	failed = run_test_set();
-
-	if (failed > 0) {
+	if (failed)
 		printf("Summary: %d tests failed\n", failed);
-	} else {
-		printf("Summary: all tests passed\n");
-	}
+	else
+		printf("Summary: all tests passed!\n");
 
-	ft_free_res();
+	fi_freeinfo(hints);
+
 	return (failed > 0);
 }


### PR DESCRIPTION
This adds functionality to check the functionality of the size_left tests for `FI_EP_RDM`, `FI_EP_DGRAM`, and `FI_EP_MSG`. 

@shantonu I have issues with this with the sockets provider. The issue is that the size attribute of the tx or rx context is 256, but after enabling the endpoint the size left functions return 368. Is this a bug, or should I not count on those being the same in the test? 

Unfortunately, the common code was not flexible enough for me to really use. I had to add a separate setup/teardown function for the resources. I tried to leverage as much of the existing infrastructure as possible. 

This fixes #546.

Please review @jsquyres @goodell @shantonu