### PR TITLE
unit: Add a unit test for CQ.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ bin_PROGRAMS = \
 	benchmarks/fi_rdm_tagged_pingpong \
 	benchmarks/fi_rdm_tagged_bw \
 	unit/fi_eq_test \
+	unit/fi_cq_test \
 	unit/fi_av_test \
 	unit/fi_size_left_test \
 	unit/fi_dom_test \
@@ -203,6 +204,11 @@ unit_fi_eq_test_SOURCES = \
 	unit/eq_test.c \
 	unit/common.c
 unit_fi_eq_test_LDADD = libfabtests.la
+
+unit_fi_cq_test_SOURCES = \
+	unit/cq_test.c \
+	unit/common.c
+unit_fi_cq_test_LDADD = libfabtests.la
 
 unit_fi_av_test_SOURCES = \
 	unit/av_test.c \

--- a/include/shared.h
+++ b/include/shared.h
@@ -353,7 +353,8 @@ int check_recv_msg(const char *message);
 #define FT_PROCESS_EQ_ERR(rd, eq, fn, str) \
 	FT_PROCESS_QUEUE_ERR(eq_readerr, rd, eq, fn, str)
 
-#define FT_PRINT_OPTS_USAGE(opt, desc) fprintf(stderr, " %-30s %s\n", opt, desc)
+#define FT_OPTS_USAGE_FORMAT "%-30s %s"
+#define FT_PRINT_OPTS_USAGE(opt, desc) fprintf(stderr, FT_OPTS_USAGE_FORMAT "\n", opt, desc)
 
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))

--- a/include/unit_common.h
+++ b/include/unit_common.h
@@ -34,6 +34,8 @@
 #ifndef _UNIT_COMMON_H_
 #define _UNIT_COMMON_H_
 
+#include <shared.h>
+
 enum { PASS, FAIL, NOTSUPP, SKIPPED };
 #define TEST_ENTRY(NAME) { NAME, #NAME }
 
@@ -45,6 +47,7 @@ struct test_entry {
 	char *name;
 };
 
+void ft_unit_usage(char *name, char *desc);
 int run_tests(struct test_entry *test_array, char *err_buf);
 
 #endif /* _UNIT_COMMON_H_ */

--- a/man/fabtests.7.md
+++ b/man/fabtests.7.md
@@ -34,8 +34,8 @@ These tests are a mix of very basic functionality tests that show major features
 	fi_rdm_rma_simple: A simple RDM client-server RMA example
 	fi_rdm_rma_trigger: A simple RDM client-server example that uses triggered RMA
 	fi_rdm_shared_av: A simple RDM client-server example where av is shared between two child processes
-	fi_rdm_shared_ctx: An RDM client-server example that uses shared context
 	fi_rdm_tagged_peek: An RDM client-server example that uses tagged FI_PEEK
+	fi_shared_ctx: An client-server example that uses shared context
 	fi_scalable_ep: An RDM client-server example with scalable endpoints
 	fi_cm_data: A MSG client-server example that uses CM data
 
@@ -61,6 +61,7 @@ These are one way streaming data tests.
 
 ## Unit
 	 fi_eq_test: Unit tests for event queue
+	 fi_cq_test: Unit tests for completion queue
 	 fi_dom_test: Unit tests for domain
 	 fi_av_test: Unit tests for address vector
 	 fi_size_left_test: Unit tests to query the lower bound of rx/tx entries

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -156,6 +156,7 @@ unit_tests=(
 	"av_test -d GOOD_ADDR -n 1 -s SERVER_ADDR"
 	"dom_test -n 2"
 	"eq_test"
+	"cq_test"
 	"size_left_test"
 )
 

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -983,6 +983,16 @@ run_test_set()
 	return failed;
 }
 
+static void usage(void)
+{
+	ft_unit_usage("av_test", "Unit test for Address Vector (AV)");
+	FT_PRINT_OPTS_USAGE("-d <good_address>", "");
+	FT_PRINT_OPTS_USAGE("-D <bad_address>]", "");
+	fprintf(stderr, FT_OPTS_USAGE_FORMAT " (max=%d)\n", "-n <num_good_addr>",
+			"Number of good addresses", MAX_ADDR - 1);
+	FT_PRINT_OPTS_USAGE("-s <source_address>", "");
+}
+
 int main(int argc, char **argv)
 {
 	int op, ret;
@@ -992,7 +1002,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:d:D:n:a:s:")) != -1) {
+	while ((op = getopt(argc, argv, "f:d:D:n:a:s:h")) != -1) {
 		switch (op) {
 		case 'd':
 			good_address = optarg;
@@ -1014,14 +1024,11 @@ int main(int argc, char **argv)
 		case 's':
 			src_addr_str = optarg;
 			break;
+		case 'h':
+			usage();
+			return EXIT_SUCCESS;
 		default:
-			printf("usage: %s\n", argv[0]);
-			printf("\t[-d good_address]\n");
-			printf("\t[-D bad_address]\n");
-			printf("\t[-a fabric_name]\n");
-			printf("\t[-n num_good_addr (max=%d)]\n", MAX_ADDR - 1);
-			printf("\t[-f provider_name]\n");
-			printf("\t[-s source_address]\n");
+			usage();
 			return EXIT_FAILURE;
 
 		}

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1048,25 +1048,26 @@ int main(int argc, char **argv)
 	hints->mode = ~0;
 	hints->addr_format = FI_SOCKADDR;
 
+	// TODO make this test accept endpoint type argument
 	hints->ep_attr->type = FI_EP_RDM;
 	ret = fi_getinfo(FT_FIVERSION, src_addr_str, 0, FI_SOURCE, hints, &fi);
-	if (ret != 0 && ret != -FI_ENODATA) {
-		printf("fi_getinfo %s\n", fi_strerror(-ret));
+	if (ret && ret != -FI_ENODATA) {
+		FT_PRINTERR("fi_getinfo", ret);
 		goto err;
 	}
 
 	if (ret == -FI_ENODATA) {
 		hints->ep_attr->type = FI_EP_DGRAM;
 		ret = fi_getinfo(FT_FIVERSION, src_addr_str, 0, FI_SOURCE, hints, &fi);
-		if (ret != 0) {
-			printf("fi_getinfo %s\n", fi_strerror(-ret));
+		if (ret) {
+			FT_PRINTERR("fi_getinfo", ret);
 			goto err;
 		}
 	}
 
 	ret = ft_open_fabric_res();
 	if (ret)
-		return ret;
+		goto err;
 
 	printf("Testing AVs on fabric %s\n", fi->fabric_attr->name);
 	failed = 0;
@@ -1091,9 +1092,7 @@ int main(int argc, char **argv)
 		printf("Summary: all tests passed\n");
 	}
 
-	ft_free_res();
-	return (failed > 0);
 err:
 	ft_free_res();
-	return -ret;
+	return ret ? -ret : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/common.c
+++ b/unit/common.c
@@ -35,6 +35,20 @@
 
 #include "unit_common.h"
 
+void ft_unit_usage(char *name, char *desc)
+{
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "  %s [OPTIONS]\n", name);
+
+	if (desc)
+		fprintf(stderr, "\n%s\n", desc);
+
+	fprintf(stderr, "\nOptions:\n");
+	FT_PRINT_OPTS_USAGE("-a <fabric_name>", "specific fabric to use");
+	FT_PRINT_OPTS_USAGE("-f <provider>", "specific provider name eg sockets, verbs");
+	FT_PRINT_OPTS_USAGE("-h", "display this help output");
+}
+
 int
 run_tests(struct test_entry *test_array, char *err_buf)
 {

--- a/unit/cq_test.c
+++ b/unit/cq_test.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2013-2016 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2014-2016 Cisco Systems, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+
+#include "unit_common.h"
+#include "shared.h"
+
+
+static char err_buf[512];
+
+static int
+create_cq(struct fid_cq **cq, size_t size, uint64_t flags,
+		enum fi_cq_format format, enum fi_wait_obj wait_obj)
+{
+	struct fi_cq_attr cq_attr;
+
+	memset(&cq_attr, 0, sizeof(cq_attr));
+	cq_attr.size = size;
+	cq_attr.flags = flags;
+	cq_attr.format = format;
+	cq_attr.wait_obj = wait_obj;
+
+	return fi_cq_open(domain, &cq_attr, cq, NULL);
+}
+
+/*
+ * Tests:
+ * - test open and close of CQ over a range of sizes
+ */
+static int
+cq_open_close()
+{
+	int i;
+	int ret;
+	int size;
+	int testret;
+	struct fid_cq *cq;
+
+	testret = FAIL;
+
+	for (i = -1; i < 17; ++i) {
+		size = (i < 0) ? 0 : 1 << i;
+
+		ret = create_cq(&cq, size, 0, FI_CQ_FORMAT_UNSPEC, FI_WAIT_UNSPEC);
+		if (ret == -FI_EINVAL) {
+			FT_WARN("\nSuccessfully completed %d iterations up to size %d "
+					"before the provider returned EINVAL...",
+					i + 1, size >> 1);
+			ret = 0;
+			goto pass;
+		}
+		if (ret != 0) {
+			sprintf(err_buf, "fi_cq_open(%d, 0, FI_CQ_FORMAT_UNSPEC, "
+					"FI_WAIT_UNSPEC) = %d, %s",
+					size, ret, fi_strerror(-ret));
+			goto fail;
+		}
+
+		ret = fi_close(&cq->fid);
+		if (ret != 0) {
+			sprintf(err_buf, "close(cq) = %d, %s", ret, fi_strerror(-ret));
+			goto fail;
+		}
+		cq = NULL;
+	}
+pass:
+	testret = PASS;
+fail:
+	cq = NULL;
+	return TEST_RET_VAL(ret, testret);
+}
+
+struct test_entry test_array[] = {
+	TEST_ENTRY(cq_open_close),
+	{ NULL, "" }
+};
+
+static void usage(void)
+{
+	ft_unit_usage("cq_test", "Unit test for Completion Queue (CQ)");
+}
+
+int main(int argc, char **argv)
+{
+	int op, ret;
+	int failed;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt(argc, argv, "f:a:h")) != -1) {
+		switch (op) {
+		case 'a':
+			free(hints->fabric_attr->name);
+			hints->fabric_attr->name = strdup(optarg);
+			break;
+		case 'f':
+			free(hints->fabric_attr->prov_name);
+			hints->fabric_attr->prov_name = strdup(optarg);
+			break;
+		case 'h':
+			usage();
+			return EXIT_SUCCESS;
+		default:
+			usage();
+			return EXIT_FAILURE;
+		}
+	}
+
+	hints->mode = ~0;
+
+	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		goto err;
+	}
+
+	ret = ft_open_fabric_res();
+	if (ret)
+		goto err;
+
+	printf("Testing CQs on fabric %s\n", fi->fabric_attr->name);
+
+	failed = run_tests(test_array, err_buf);
+	if (failed > 0) {
+		printf("Summary: %d tests failed\n", failed);
+	} else {
+		printf("Summary: all tests passed\n");
+	}
+
+err:
+	ft_free_res();
+	return ret ? -ret : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -77,8 +77,8 @@ int main(int argc, char **argv)
 	char *ptr;
 
 	hints = fi_allocinfo();
-	if (hints == NULL)
-		exit(EXIT_FAILURE);
+	if (!hints)
+		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "f:a:n:h")) != -1) {
 		switch (op) {
@@ -111,8 +111,8 @@ int main(int argc, char **argv)
 	hints->mode = ~0;
 
 	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
-	if (ret != 0) {
-		printf("fi_getinfo %s\n", fi_strerror(-ret));
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
 		goto out;
 	}
 
@@ -123,6 +123,7 @@ int main(int argc, char **argv)
 	domain_vec = calloc(num_domains, sizeof(*domain_vec));
 	if (domain_vec == NULL) {
 		perror("malloc");
+		ret = EXIT_FAILURE;
 		goto out;
 	}
 

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -63,6 +63,12 @@ static struct fid_domain **domain_vec = NULL;
  * - test open and close of a domain
  */
 
+static void usage(void)
+{
+	ft_unit_usage("dom_test", "Unit test for Domain");
+	FT_PRINT_OPTS_USAGE("-n <num_domains>", "num domains to open");
+}
+
 int main(int argc, char **argv)
 {
 	unsigned long i;
@@ -74,7 +80,7 @@ int main(int argc, char **argv)
 	if (hints == NULL)
 		exit(EXIT_FAILURE);
 
-	while ((op = getopt(argc, argv, "f:a:n:")) != -1) {
+	while ((op = getopt(argc, argv, "f:a:n:h")) != -1) {
 		switch (op) {
 		case 'a':
 			free(hints->fabric_attr->name);
@@ -93,12 +99,12 @@ int main(int argc, char **argv)
 			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
+		case 'h':
+			usage();
+			return EXIT_SUCCESS;
 		default:
-			printf("usage: %s\n", argv[0]);
-			printf("\t[-a fabric_name]\n");
-			printf("\t[-f provider_name]\n");
-			printf("\t[-n num domains to open]\n");
-			exit(EXIT_FAILURE);
+			usage();
+			return EXIT_FAILURE;
 		}
 	}
 

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -557,6 +557,11 @@ struct test_entry test_array[] = {
 	{ NULL, "" }
 };
 
+static void usage(void)
+{
+	ft_unit_usage("eq_test", "Unit test for Event Queue (EQ)");
+}
+
 int main(int argc, char **argv)
 {
 	int op, ret;
@@ -566,7 +571,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		exit(1);
 
-	while ((op = getopt(argc, argv, "f:a:")) != -1) {
+	while ((op = getopt(argc, argv, "f:a:h")) != -1) {
 		switch (op) {
 		case 'a':
 			free(hints->fabric_attr->name);
@@ -576,11 +581,12 @@ int main(int argc, char **argv)
 			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
+		case 'h':
+			usage();
+			return EXIT_SUCCESS;
 		default:
-			printf("usage: %s\n", argv[0]);
-			printf("\t[-a fabric_name]\n");
-			printf("\t[-f provider_name]\n");
-			exit(1);
+			usage();
+			return EXIT_FAILURE;
 		}
 	}
 

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -569,7 +569,7 @@ int main(int argc, char **argv)
 
 	hints = fi_allocinfo();
 	if (!hints)
-		exit(1);
+		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "f:a:h")) != -1) {
 		switch (op) {
@@ -593,15 +593,15 @@ int main(int argc, char **argv)
 	hints->mode = ~0;
 
 	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
-	if (ret != 0) {
-		printf("fi_getinfo %s\n", fi_strerror(-ret));
-		exit(-ret);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		goto err;
 	}
 
 	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
-	if (ret != 0) {
-		printf("fi_fabric %s\n", fi_strerror(-ret));
-		exit(1);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		goto err;
 	}
 
 	printf("Testing EQs on fabric %s\n", fi->fabric_attr->name);
@@ -613,6 +613,7 @@ int main(int argc, char **argv)
 		printf("Summary: all tests passed\n");
 	}
 
+err:
 	ft_free_res();
-	exit(failed > 0);
+	return ret ? -ret : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -284,7 +284,7 @@ int main(int argc, char **argv)
 
 	hints = fi_allocinfo();
 	if (!hints)
-		exit(1);
+		return EXIT_FAILURE;
 
 	while ((op = getopt(argc, argv, "f:a:h")) != -1) {
 		switch (op) {
@@ -317,5 +317,5 @@ int main(int argc, char **argv)
 
 	fi_freeinfo(hints);
 
-	return (failed > 0);
+	return (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -269,6 +269,11 @@ int run_test_set(struct fi_info *hints)
 	return failed;
 }
 
+static void usage(void)
+{
+	ft_unit_usage("size_left_test", "Unit test for checking TX and RX context sizes");
+}
+
 int main(int argc, char **argv)
 {
 	int op;
@@ -281,7 +286,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		exit(1);
 
-	while ((op = getopt(argc, argv, "f:a:")) != -1) {
+	while ((op = getopt(argc, argv, "f:a:h")) != -1) {
 		switch (op) {
 		case 'a':
 			free(hints->fabric_attr->name);
@@ -291,11 +296,12 @@ int main(int argc, char **argv)
 			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
+		case 'h':
+			usage();
+			return EXIT_SUCCESS;
 		default:
-			printf("usage: %s\n", argv[0]);
-			printf("\t[-a fabric_name]\n");
-			printf("\t[-f provider_name]\n");
-			exit(1);
+			usage();
+			return EXIT_FAILURE;
 		}
 	}
 


### PR DESCRIPTION
Added this test based on the unit test for EQ. For now it tests only opening and closing of a CQ. Sockets provider currently fails the test.

@shantonu @bturrubiates please review.

Update: Sockets provider doesn't exactly fail the test. It returns -FI_ENOSYS and the test is marked as skipped.