### PR TITLE
Misc fixes for fi_rdm_shared_av test

### DIFF
--- a/simple/rdm_shared_av.c
+++ b/simple/rdm_shared_av.c
@@ -181,12 +181,15 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	if (opts.dst_addr) {
+		if (!opts.av_name)
+			opts.av_name = "client_av";
+
 		ret = ft_fork_and_pair();
 		if (ret)
 			return ret;
-
+	} else {
 		if (!opts.av_name)
-			opts.av_name = "foo";
+			opts.av_name = "server_av";
 	}
 
 	hints->ep_attr->type	= FI_EP_RDM;

--- a/simple/rdm_shared_av.c
+++ b/simple/rdm_shared_av.c
@@ -44,6 +44,7 @@
 static int init_fabric(void)
 {
 	int ret;
+	int ret2;
 
 	ret = ft_getinfo(hints, &fi);
 	if (ret)
@@ -55,19 +56,20 @@ static int init_fabric(void)
 
 	if (opts.dst_addr && !ft_parent_proc) {
 		/* child waits until parent is done creating AV */
-		ret = ft_sync_pair(FI_SUCCESS);
-
-		if (ret)
-			return ret;
+		ret2 = ft_sync_pair(FI_SUCCESS);
+		if (ret2)
+			return ret2;
 
 		/* child needs to open AV in read only mode */
 		av_attr.flags = FI_READ;
 	}
-	ret = ft_alloc_active_res(fi);
 
+	ret = ft_alloc_active_res(fi);
 	if (opts.dst_addr && ft_parent_proc) {
 		/* parent lets the child know its status */
-		ret = ft_sync_pair(ret);
+		ret2 = ft_sync_pair(ret);
+		if (ret2)
+			return ret2;
 	}
 
 	/* handle the failed alloc_active_res call */
@@ -115,6 +117,7 @@ static int send_recv()
 static int run(void)
 {
 	int ret;
+	int ret2;
 
 	ret = init_fabric();
 	if (ret)
@@ -125,17 +128,18 @@ static int run(void)
 			/* parent inits AV and lets child proceed,
 			 * and itself returns without sending a message */
 			ret = ft_init_av();
-
-			ret = ft_sync_pair(ret);
+			ret2 = ft_sync_pair(ret);
+			if (ret2)
+				return ret2;
 
 			/* parent doesn't run the send_recv loop,
 			 * it waits for the child until it is done
 			 * with send_recv */
 			return ret;
 		} else {
-			ret = ft_sync_pair(FI_SUCCESS);
-			if (ret)
-				return ret;
+			ret2 = ft_sync_pair(FI_SUCCESS);
+			if (ret2)
+				return ret2;
 
 			remote_fi_addr = ((fi_addr_t *)av_attr.map_addr)[0];
 		}


### PR DESCRIPTION
- Fix segfault on client side when client does not support shared AV
- Fix hang that manifests when providers don't support shared AV by opening a shared AV on both ends

@shantonu @sungeunchoi