### PR TITLE
travis: Ensure that we have good GNU Autotools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ compiler:
 os:
     - osx
     - linux
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew upgrade automake libtool; fi
 install:
     - git clone https://github.com/ofiwg/libfabric.git
     - cd libfabric


### PR DESCRIPTION
- Autogen.sh failure in OS X similar to libfabric was seen with https://travis-ci.org/ofiwg/fabtests/builds/162009293. Added @jsquyres's fix (https://github.com/ofiwg/libfabric/pull/2360) that updates GNU Autotools.

@a-ilango 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>