### PR TITLE
fi_cq_test: Convert error into warning

### DIFF
--- a/unit/cq_test.c
+++ b/unit/cq_test.c
@@ -86,18 +86,17 @@ static int cq_open_close_simultaneous(void)
 		return -FI_ENOMEM;
 
 	ret = 0;
-	for (opened = 0; opened < count; opened++) {
+	for (opened = 0; opened < count && !ret; opened++) {
 		ret = create_cq(&cq_array[opened], 0, 0, FI_CQ_FORMAT_UNSPEC,
 				FI_WAIT_UNSPEC);
-		if (ret) {
-			FT_PRINTERR("fi_cq_open", ret);
-			goto cleanup;
-		}
+	}
+	if (ret) {
+		FT_WARN("fi_cq_open failed after %d (cq_cnt: %d): %s",
+			opened, count, fi_strerror(-ret));
 	}
 
 	testret = PASS;
 
-cleanup:
 	FT_CLOSEV_FID(cq_array, opened);
 	free(cq_array);
 


### PR DESCRIPTION
The CQ test attempts to open cq_cnt CQs, and errors if that fails.
This is resulting in travis errors as a result of open fd limits.
Because the cq_cnt is intended to reflect hardware limits, and not
system software limits, instead of having the test error, simply
report a warning and continue with additional tests.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>