### PR TITLE
runfabtests: Rename foo host

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -64,9 +64,9 @@ declare -ri FI_ENODATA=$(python -c 'import errno; print(errno.ENODATA)')
 declare -ri FI_ENOSYS=$(python -c 'import errno; print(errno.ENOSYS)')
 
 neg_unit_tests=(
-	"dgram foo"
-	"rdm foo"
-	"msg foo"
+	"dgram g00n13s"
+	"rdm g00n13s"
+	"msg g00n13s"
 )
 
 simple_tests=(


### PR DESCRIPTION
Yes, foo is so common that there are actually servers named
'foo', which causes it NOT to be a negative test case.  Use
a random string of garbage which is less likely to be a real
name.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>