### PR TITLE
unit/size_left_test: For MSG endpoints an EQ should be bound before enabling it.

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -242,16 +242,18 @@ int size_to_count(int size);
 	FT_ERR("cq_readerr: %s", fi_cq_strerror(cq, entry.prov_errno, \
 				entry.err_data, buf, len))
 
-#define FT_CLOSE_FID(fd)					\
-	do {							\
-		int ret;					\
-		if ((fd)) {					\
-			ret = fi_close(&(fd)->fid);		\
-			if (ret)				\
-				FT_ERR("fi_close (%d) fid %d",	\
-					ret, (int) (fd)->fid.fclass);	\
-			fd = NULL;				\
-		}						\
+#define FT_CLOSE_FID(fd)						\
+	do {								\
+		int ret;						\
+		if ((fd)) {						\
+			ret = fi_close(&(fd)->fid);			\
+			if (ret)					\
+				FT_ERR("fi_close: %s(%d) fid %d",	\
+					fi_strerror(-ret), 		\
+					ret,				\
+					(int) (fd)->fid.fclass);	\
+			fd = NULL;					\
+		}							\
 	} while (0)
 
 #define FT_CLOSEV_FID(fd, cnt)			\

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -113,6 +113,20 @@ static void setup_ep_fixture(void)
 		}
 	}
 
+	/* MSG endpoints require EQ to be bound to an endpoint */
+	if (fi->ep_attr->type == FI_EP_MSG) {
+		ret = fi_eq_open(fabric, &eq_attr, &eq, NULL);
+		if (ret) {
+			FT_PRINTERR("fi_eq_open", ret);
+			exit(EXIT_FAILURE);
+		}
+		ret = fi_ep_bind(ep, &eq->fid, 0);
+		if (ret) {
+			FT_PRINTERR("fi_ep_bind", ret);
+			exit(EXIT_FAILURE);
+		}
+	}
+
 	ret = fi_ep_bind(ep, &txcq->fid, FI_TRANSMIT);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
@@ -134,6 +148,7 @@ static void teardown_ep_fixture(void)
 	FT_CLOSE_FID(rxcq);
 	FT_CLOSE_FID(txcq);
 	FT_CLOSE_FID(domain);
+	FT_CLOSE_FID(eq);
 	FT_CLOSE_FID(fabric);
 }
 


### PR DESCRIPTION
@bturrubiates 