### PR TITLE
Updates for FreeBSD

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1901,6 +1901,7 @@ int ft_sock_listen(char *service)
 
 	memset(&hints, 0, sizeof hints);
 	hints.ai_flags = AI_PASSIVE;
+	hints.ai_family = AF_INET;
 
 	ret = getaddrinfo(NULL, service, &hints, &ai);
 	if (ret) {

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -60,7 +60,11 @@ declare -i skip_count=0
 declare -i pass_count=0
 declare -i fail_count=0
 
-declare -ri FI_ENODATA=$(python -c 'import errno; print(errno.ENODATA)')
+if [[ "$(uname)" == "FreeBSD" ]]; then
+    declare -ri FI_ENODATA=$(python -c 'import errno; print(errno.ENOMSG)')
+else
+    declare -ri FI_ENODATA=$(python -c 'import errno; print(errno.ENODATA)')
+fi
 declare -ri FI_ENOSYS=$(python -c 'import errno; print(errno.ENOSYS)')
 
 neg_unit_tests=(


### PR DESCRIPTION
- runfabtests: Set FI_ENODATA correctly for FreeBSD
- common: Set socket family in ft_socket_listen