### PR TITLE
options: Make provider/domain/fabric name and src/dest port consistent

### DIFF
--- a/benchmarks/benchmark_shared.c
+++ b/benchmarks/benchmark_shared.c
@@ -48,7 +48,7 @@ void ft_parse_benchmark_opts(int op, char *optarg)
 	case 'v':
 		opts.options |= FT_OPT_VERIFY_DATA;
 		break;
-	case 'P':
+	case 'k':
 		hints->mode |= FI_MSG_PREFIX;
 		break;
 	case 'j':
@@ -65,7 +65,7 @@ void ft_parse_benchmark_opts(int op, char *optarg)
 void ft_benchmark_usage(void)
 {
 	FT_PRINT_OPTS_USAGE("-v", "enables data_integrity checks");
-	FT_PRINT_OPTS_USAGE("-P", "enable prefix mode");
+	FT_PRINT_OPTS_USAGE("-k", "enable prefix mode");
 	FT_PRINT_OPTS_USAGE("-j", "maximum inject message size");
 	FT_PRINT_OPTS_USAGE("-W", "window size* (for bandwidth tests)\n\n"
 			"* The following condition is required to have at least "

--- a/benchmarks/benchmark_shared.h
+++ b/benchmarks/benchmark_shared.h
@@ -40,7 +40,7 @@ extern "C" {
 
 #include <stdbool.h>
 
-#define BENCHMARK_OPTS "vPj:W:"
+#define BENCHMARK_OPTS "vkj:W:"
 #define FT_BENCHMARK_MAX_MSG_SIZE (test_size[TEST_CNT - 1].size)
 
 void ft_parse_benchmark_opts(int op, char *optarg);

--- a/common/shared.c
+++ b/common/shared.c
@@ -1628,10 +1628,10 @@ void ft_usage(char *name, char *desc)
 		fprintf(stderr, "\n%s\n", desc);
 
 	fprintf(stderr, "\nOptions:\n");
-	FT_PRINT_OPTS_USAGE("-n <domain>", "domain name");
-	FT_PRINT_OPTS_USAGE("-b <src_port>", "non default source port number");
-	FT_PRINT_OPTS_USAGE("-p <dst_port>", "non default destination port number");
-	FT_PRINT_OPTS_USAGE("-f <provider>", "specific provider name eg sockets, verbs");
+	FT_PRINT_OPTS_USAGE("-d <domain>", "domain name");
+	FT_PRINT_OPTS_USAGE("-B <src_port>", "non default source port number");
+	FT_PRINT_OPTS_USAGE("-P <dst_port>", "non default destination port number");
+	FT_PRINT_OPTS_USAGE("-p <provider>", "specific provider name eg sockets, verbs");
 	FT_PRINT_OPTS_USAGE("-s <address>", "source address");
 	FT_PRINT_OPTS_USAGE("-e <ep_type>", "Endpoint type: msg|rdm|dgram (default:rdm)");
 	FT_PRINT_OPTS_USAGE("", "Only the following tests support this option for now:");
@@ -1661,7 +1661,7 @@ void ft_csusage(char *name, char *desc)
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints)
 {
 	switch (op) {
-	case 'n':
+	case 'd':
 		if (!hints->domain_attr) {
 			hints->domain_attr = malloc(sizeof *(hints->domain_attr));
 			if (!hints->domain_attr) {
@@ -1671,7 +1671,7 @@ void ft_parseinfo(int op, char *optarg, struct fi_info *hints)
 		}
 		hints->domain_attr->name = strdup(optarg);
 		break;
-	case 'f':
+	case 'p':
 		if (!hints->fabric_attr) {
 			hints->fabric_attr = malloc(sizeof *(hints->fabric_attr));
 			if (!hints->fabric_attr) {
@@ -1702,10 +1702,10 @@ void ft_parse_addr_opts(int op, char *optarg, struct ft_opts *opts)
 	case 's':
 		opts->src_addr = optarg;
 		break;
-	case 'b':
+	case 'B':
 		opts->src_port = optarg;
 		break;
-	case 'p':
+	case 'P':
 		opts->dst_port = optarg;
 		break;
 	default:

--- a/common/shared.c
+++ b/common/shared.c
@@ -1661,6 +1661,16 @@ void ft_csusage(char *name, char *desc)
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints)
 {
 	switch (op) {
+	case 'f':
+		if (!hints->fabric_attr) {
+			hints->fabric_attr = malloc(sizeof *(hints->fabric_attr));
+			if (!hints->fabric_attr) {
+				perror("malloc");
+				exit(EXIT_FAILURE);
+			}
+		}
+		hints->fabric_attr->name = strdup(optarg);
+		break;
 	case 'd':
 		if (!hints->domain_attr) {
 			hints->domain_attr = malloc(sizeof *(hints->domain_attr));

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -380,13 +380,13 @@ static void ft_fw_usage(char *program)
 	FT_PRINT_OPTS_USAGE("-x", "exit after test run");
 	fprintf(stderr, "\nClient only options:\n");
 	FT_PRINT_OPTS_USAGE("-u <test_config_file>", "config file path (Either config file path or both provider and test config name are required)");
-	FT_PRINT_OPTS_USAGE("-f <provider_name>", " provider name");
+	FT_PRINT_OPTS_USAGE("-p <provider_name>", " provider name");
 	FT_PRINT_OPTS_USAGE("-t <test_config_name>", "test config name");
 	FT_PRINT_OPTS_USAGE("-y <start_test_index>", "");
 	FT_PRINT_OPTS_USAGE("-z <end_test_index>", "");
 	FT_PRINT_OPTS_USAGE("-s <address>", "source address");
-	FT_PRINT_OPTS_USAGE("-b <src_port>", "non default source port number");
-	FT_PRINT_OPTS_USAGE("-p <dst_port>", "non default destination port number"
+	FT_PRINT_OPTS_USAGE("-B <src_port>", "non default source port number");
+	FT_PRINT_OPTS_USAGE("-P <dst_port>", "non default destination port number"
 		       " (config file service parameter will override this)");
 }
 
@@ -406,12 +406,12 @@ int main(int argc, char **argv)
 	opts = INIT_OPTS;
 	int ret, op;
 
-	while ((op = getopt(argc, argv, "f:u:t:q:xy:z:h" ADDR_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "p:u:t:q:xy:z:h" ADDR_OPTS)) != -1) {
 		switch (op) {
 		case 'u':
 			filename = strdup(optarg);
 			break;
-		case 'f':
+		case 'p':
 			provname = strdup(optarg);
 			break;
 		case 't':

--- a/include/shared.h
+++ b/include/shared.h
@@ -186,8 +186,8 @@ extern int ft_parent_proc;
 extern int ft_socket_pair[2];
 extern int sock;
 extern int listen_sock;
-#define ADDR_OPTS "b:p:s:a:"
-#define INFO_OPTS "n:f:e:"
+#define ADDR_OPTS "B:P:s:a:"
+#define INFO_OPTS "d:p:e:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
 
 extern char default_port[8];

--- a/man/fabtests.7.md
+++ b/man/fabtests.7.md
@@ -91,16 +91,16 @@ These are comprehensive latency and bandwidth tests that can handle a variety of
 
 The common options for most of the tests are listed below. Individual tests may have additional options.
 
-*-f <provider_name>*
+*-p <provider_name>*
 : The name of the underlying fabric provider e.g. sockets, verbs, psm etc. If the provider name is not provided, the test will pick one from the list of the available providers it finds by fi_getinfo call.
 
-*-n <domain>*
+*-d <domain>*
 : The name of the the specific domain to be used.
 
-*-b <src_port>*
+*-B <src_port>*
 : The non-default source port number of the endpoint.
 
-*-p <dest_port>*
+*-P <dest_port>*
 : The non-default destination port number of the endpoint.
 
 *-s <src_addr>*
@@ -128,15 +128,15 @@ The common options for most of the tests are listed below. Individual tests may 
 
 ## A simple example
 
-	run server: <test_name> -f <provider_name> -s <source_addr>
-		e.g.	fi_msg_rma -f sockets -s 192.168.0.123
-	run client: <test_name> <server_addr> -f <provider_name>
-		e.g.	fi_msg_rma 192.168.0.123 -f sockets
+	run server: <test_name> -p <provider_name> -s <source_addr>
+		e.g.	fi_msg_rma -p sockets -s 192.168.0.123
+	run client: <test_name> <server_addr> -p <provider_name>
+		e.g.	fi_msg_rma 192.168.0.123 -p sockets
 
 ## An example with various options
 
-	run server: fi_rdm_atomic -f psm -s 192.168.0.123 -I 1000 -S 1024
-	run client: fi_rdm_atomic 192.168.0.123 -f psm -I 1000 -S 1024
+	run server: fi_rdm_atomic -p psm -s 192.168.0.123 -I 1000 -S 1024
+	run client: fi_rdm_atomic 192.168.0.123 -p psm -I 1000 -S 1024
 
 This will run "fi_rdm_atomic" for all atomic operations with
 

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -125,8 +125,8 @@ short_tests=(
 standard_tests=(
 	"msg_pingpong"
 	"msg_pingpong -v"
-	"msg_pingpong -P"
-	"msg_pingpong -P -v"
+	"msg_pingpong -k"
+	"msg_pingpong -k -v"
 	"msg_bw"
 	"rma_bw -e msg -o write"
 	"rma_bw -e msg -o read"
@@ -143,8 +143,8 @@ standard_tests=(
 	"rdm_multi_recv"
 	"rdm_pingpong"
 	"rdm_pingpong -v"
-	"rdm_pingpong -P"
-	"rdm_pingpong -P -v"
+	"rdm_pingpong -k"
+	"rdm_pingpong -k -v"
 	"rdm_rma -o write"
 	"rdm_rma -o read"
 	"rdm_rma -o writedata"
@@ -152,13 +152,13 @@ standard_tests=(
 	"rdm_tagged_bw"
 	"dgram_pingpong"
 	"dgram_pingpong -v"
-	"dgram_pingpong -P"
-	"dgram_pingpong -P -v"
+	"dgram_pingpong -k"
+	"dgram_pingpong -k -v"
 	"rc_pingpong"
 )
 
 unit_tests=(
-	"av_test -d GOOD_ADDR -n 1 -s SERVER_ADDR"
+	"av_test -g GOOD_ADDR -n 1 -s SERVER_ADDR"
 	"dom_test -n 2"
 	"eq_test"
 	"cq_test"
@@ -260,7 +260,7 @@ function unit_test {
 	local test=$1
 	local is_neg=$2
 	local ret1=0
-	local test_exe=$(echo "fi_${test} -f $PROV" | \
+	local test_exe=$(echo "fi_${test} -p $PROV" | \
 	    sed -e "s/GOOD_ADDR/$GOOD_ADDR/g" -e "s/SERVER_ADDR/${S_INTERFACE}/g")
 	local start_time
 	local end_time
@@ -311,7 +311,7 @@ function cs_test {
 	local test=$1
 	local ret1=0
 	local ret2=0
-	local test_exe="fi_${test} -f ${PROV}"
+	local test_exe="fi_${test} -p ${PROV}"
 	local start_time
 	local end_time
 	local test_time
@@ -383,7 +383,7 @@ function complex_test {
 	p1=$!
 	sleep 1
 
-	c_cmd="${BIN_PATH}${test_exe} -s $C_INTERFACE -f ${PROV} -t $config $S_INTERFACE"
+	c_cmd="${BIN_PATH}${test_exe} -s $C_INTERFACE -p ${PROV} -t $config $S_INTERFACE"
 	FI_LOG_LEVEL=error ${CLIENT_CMD} "$c_cmd" &> $c_outp &
 	p2=$!
 

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -997,13 +997,13 @@ int main(int argc, char **argv)
 	int failed;
 
 	opts = INIT_OPTS;
-        opts.options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE;
 
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "p:g:G:n:f:s:h")) != -1) {
+	while ((op = getopt(argc, argv, "f:p:g:G:n:s:h")) != -1) {
 		switch (op) {
 		case 'g':
 			good_address = optarg;
@@ -1011,24 +1011,17 @@ int main(int argc, char **argv)
 		case 'G':
 			bad_address = optarg;
 			break;
-		case 'f':
-			free(hints->fabric_attr->name);
-			hints->fabric_attr->name = strdup(optarg);
-			break;
 		case 'n':
 			num_good_addr = atoi(optarg);
-			break;
-		case 'p':
-			free(hints->fabric_attr->prov_name);
-			hints->fabric_attr->prov_name = strdup(optarg);
 			break;
 		case 's':
 			opts.src_addr = optarg;
 			break;
-		case 'h':
-			usage();
-			return EXIT_SUCCESS;
 		default:
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
 			usage();
 			return EXIT_FAILURE;
 

--- a/unit/common.c
+++ b/unit/common.c
@@ -45,7 +45,7 @@ void ft_unit_usage(char *name, char *desc)
 
 	fprintf(stderr, "\nOptions:\n");
 	FT_PRINT_OPTS_USAGE("-f <fabric_name>", "specific fabric to use");
-	FT_PRINT_OPTS_USAGE("-p <provider>", "specific provider name eg sockets, verbs");
+	FT_PRINT_OPTS_USAGE("-p <provider_name>", "specific provider name eg sockets, verbs");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
 }
 

--- a/unit/common.c
+++ b/unit/common.c
@@ -44,8 +44,8 @@ void ft_unit_usage(char *name, char *desc)
 		fprintf(stderr, "\n%s\n", desc);
 
 	fprintf(stderr, "\nOptions:\n");
-	FT_PRINT_OPTS_USAGE("-a <fabric_name>", "specific fabric to use");
-	FT_PRINT_OPTS_USAGE("-f <provider>", "specific provider name eg sockets, verbs");
+	FT_PRINT_OPTS_USAGE("-f <fabric_name>", "specific fabric to use");
+	FT_PRINT_OPTS_USAGE("-p <provider>", "specific provider name eg sockets, verbs");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
 }
 

--- a/unit/cq_test.c
+++ b/unit/cq_test.c
@@ -174,18 +174,11 @@ int main(int argc, char **argv)
 
 	while ((op = getopt(argc, argv, "f:p:h")) != -1) {
 		switch (op) {
-		case 'f':
-			free(hints->fabric_attr->name);
-			hints->fabric_attr->name = strdup(optarg);
-			break;
-		case 'p':
-			free(hints->fabric_attr->prov_name);
-			hints->fabric_attr->prov_name = strdup(optarg);
-			break;
-		case 'h':
-			usage();
-			return EXIT_SUCCESS;
 		default:
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
 			usage();
 			return EXIT_FAILURE;
 		}

--- a/unit/cq_test.c
+++ b/unit/cq_test.c
@@ -172,13 +172,13 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:a:h")) != -1) {
+	while ((op = getopt(argc, argv, "f:p:h")) != -1) {
 		switch (op) {
-		case 'a':
+		case 'f':
 			free(hints->fabric_attr->name);
 			hints->fabric_attr->name = strdup(optarg);
 			break;
-		case 'f':
+		case 'p':
 			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -82,10 +82,6 @@ int main(int argc, char **argv)
 
 	while ((op = getopt(argc, argv, "f:p:n:h")) != -1) {
 		switch (op) {
-		case 'f':
-			free(hints->fabric_attr->name);
-			hints->fabric_attr->name = strdup(optarg);
-			break;
 		case 'n':
 			errno = 0;
 			num_domains = strtol(optarg, &ptr, 10);
@@ -95,14 +91,11 @@ int main(int argc, char **argv)
 				goto out;
 			}
 			break;
-		case 'p':
-			free(hints->fabric_attr->prov_name);
-			hints->fabric_attr->prov_name = strdup(optarg);
-			break;
-		case 'h':
-			usage();
-			return EXIT_SUCCESS;
 		default:
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
 			usage();
 			return EXIT_FAILURE;
 		}

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -80,9 +80,9 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:a:n:h")) != -1) {
+	while ((op = getopt(argc, argv, "f:p:n:h")) != -1) {
 		switch (op) {
-		case 'a':
+		case 'f':
 			free(hints->fabric_attr->name);
 			hints->fabric_attr->name = strdup(optarg);
 			break;
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
 				goto out;
 			}
 			break;
-		case 'f':
+		case 'p':
 			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -571,13 +571,13 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:a:h")) != -1) {
+	while ((op = getopt(argc, argv, "f:p:h")) != -1) {
 		switch (op) {
-		case 'a':
+		case 'f':
 			free(hints->fabric_attr->name);
 			hints->fabric_attr->name = strdup(optarg);
 			break;
-		case 'f':
+		case 'p':
 			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -573,18 +573,11 @@ int main(int argc, char **argv)
 
 	while ((op = getopt(argc, argv, "f:p:h")) != -1) {
 		switch (op) {
-		case 'f':
-			free(hints->fabric_attr->name);
-			hints->fabric_attr->name = strdup(optarg);
-			break;
-		case 'p':
-			free(hints->fabric_attr->prov_name);
-			hints->fabric_attr->prov_name = strdup(optarg);
-			break;
-		case 'h':
-			usage();
-			return EXIT_SUCCESS;
 		default:
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
 			usage();
 			return EXIT_FAILURE;
 		}

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -301,13 +301,13 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:a:h")) != -1) {
+	while ((op = getopt(argc, argv, "f:p:h")) != -1) {
 		switch (op) {
-		case 'a':
+		case 'f':
 			free(hints->fabric_attr->name);
 			hints->fabric_attr->name = strdup(optarg);
 			break;
-		case 'f':
+		case 'p':
 			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
 			break;

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -303,18 +303,11 @@ int main(int argc, char **argv)
 
 	while ((op = getopt(argc, argv, "f:p:h")) != -1) {
 		switch (op) {
-		case 'f':
-			free(hints->fabric_attr->name);
-			hints->fabric_attr->name = strdup(optarg);
-			break;
-		case 'p':
-			free(hints->fabric_attr->prov_name);
-			hints->fabric_attr->prov_name = strdup(optarg);
-			break;
-		case 'h':
-			usage();
-			return EXIT_SUCCESS;
 		default:
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
 			usage();
 			return EXIT_FAILURE;
 		}


### PR DESCRIPTION
- Make provider name, domain name, fabric name, src port and dest port consistent in all the tests according to the discussion in #561
- Change ```runfabtests.sh``` is updated to use the modified options 
- Update manpage
- Use ft_parseinfo in unit tests to resolve options
```
New Usage:
-f fabric name
-d domain name
-p provider name
-B src port
-P dest port
```
@a-ilango
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>