### PR TITLE
Fix opts and usage

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1618,6 +1618,13 @@ void show_perf_mr(int tsize, int iters, struct timespec *start,
 	printf(" }\n");
 }
 
+void ft_addr_usage()
+{
+	FT_PRINT_OPTS_USAGE("-B <src_port>", "non default source port number");
+	FT_PRINT_OPTS_USAGE("-P <dst_port>", "non default destination port number");
+	FT_PRINT_OPTS_USAGE("-s <address>", "source address");
+}
+
 void ft_usage(char *name, char *desc)
 {
 	fprintf(stderr, "Usage:\n");
@@ -1628,11 +1635,9 @@ void ft_usage(char *name, char *desc)
 		fprintf(stderr, "\n%s\n", desc);
 
 	fprintf(stderr, "\nOptions:\n");
+	ft_addr_usage();
 	FT_PRINT_OPTS_USAGE("-d <domain>", "domain name");
-	FT_PRINT_OPTS_USAGE("-B <src_port>", "non default source port number");
-	FT_PRINT_OPTS_USAGE("-P <dst_port>", "non default destination port number");
 	FT_PRINT_OPTS_USAGE("-p <provider>", "specific provider name eg sockets, verbs");
-	FT_PRINT_OPTS_USAGE("-s <address>", "source address");
 	FT_PRINT_OPTS_USAGE("-e <ep_type>", "Endpoint type: msg|rdm|dgram (default:rdm)");
 	FT_PRINT_OPTS_USAGE("", "Only the following tests support this option for now:");
 	FT_PRINT_OPTS_USAGE("", "fi_rma_bw");

--- a/include/shared.h
+++ b/include/shared.h
@@ -174,6 +174,7 @@ void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
 void ft_parse_addr_opts(int op, char *optarg, struct ft_opts *opts);
 void ft_parsecsopts(int op, char *optarg, struct ft_opts *opts);
 int ft_parse_rma_opts(int op, char *optarg, struct ft_opts *opts);
+void ft_addr_usage();
 void ft_usage(char *name, char *desc);
 void ft_csusage(char *name, char *desc);
 void ft_fill_buf(void *buf, int size);
@@ -192,7 +193,8 @@ extern int ft_socket_pair[2];
 extern int sock;
 extern int listen_sock;
 #define ADDR_OPTS "B:P:s:a:"
-#define INFO_OPTS "d:p:e:"
+#define FAB_OPTS "f:d:p:"
+#define INFO_OPTS FAB_OPTS "e:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
 
 extern char default_port[8];

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1008,7 +1008,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:p:g:G:n:s:h")) != -1) {
+	while ((op = getopt(argc, argv, FAB_OPTS "g:G:n:s:h")) != -1) {
 		switch (op) {
 		case 'g':
 			good_address = optarg;

--- a/unit/common.c
+++ b/unit/common.c
@@ -45,6 +45,7 @@ void ft_unit_usage(char *name, char *desc)
 
 	fprintf(stderr, "\nOptions:\n");
 	FT_PRINT_OPTS_USAGE("-f <fabric_name>", "specific fabric to use");
+	FT_PRINT_OPTS_USAGE("-d <domain>", "domain name");
 	FT_PRINT_OPTS_USAGE("-p <provider_name>", "specific provider name eg sockets, verbs");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
 }

--- a/unit/cq_test.c
+++ b/unit/cq_test.c
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:p:h")) != -1) {
+	while ((op = getopt(argc, argv, FAB_OPTS "h")) != -1) {
 		switch (op) {
 		default:
 			ft_parseinfo(op, optarg, hints);

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:p:n:h")) != -1) {
+	while ((op = getopt(argc, argv, FAB_OPTS "n:h")) != -1) {
 		switch (op) {
 		case 'n':
 			errno = 0;

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -571,7 +571,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:p:h")) != -1) {
+	while ((op = getopt(argc, argv, FAB_OPTS "h")) != -1) {
 		switch (op) {
 		default:
 			ft_parseinfo(op, optarg, hints);

--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -175,6 +175,8 @@ getinfo_test(6, "Test with non-existent domain name",
 static void usage(void)
 {
 	ft_unit_usage("getinfo_test", "Unit tests for fi_getinfo");
+	FT_PRINT_OPTS_USAGE("-e <ep_type>", "Endpoint type: msg|rdm|dgram (default:rdm)");
+	ft_addr_usage();
 }
 
 int main(int argc, char **argv)
@@ -198,7 +200,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, ADDR_OPTS "p:h")) != -1) {
+	while ((op = getopt(argc, argv, ADDR_OPTS INFO_OPTS "h")) != -1) {
 		switch (op) {
 		default:
 			ft_parse_addr_opts(op, optarg, &opts);

--- a/unit/size_left_test.c
+++ b/unit/size_left_test.c
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "f:p:h")) != -1) {
+	while ((op = getopt(argc, argv, FAB_OPTS "h")) != -1) {
 		switch (op) {
 		default:
 			ft_parseinfo(op, optarg, hints);


### PR DESCRIPTION
- Add a common function to print addr opts usage.
- Add fabric option to INFO_OPTS macro.
  All files that use this macro call ft_parseinfo. So we should
  be good.
- Define new FAB_OPTS macro.
- Allow some unit tests to make use of domain name option.
- Fix opts in fi_getinfo test.

This should fix #572 