### PR TITLE
Disable clock_gettime workaround for OSX version 10.12.

### DIFF
--- a/common/osx/osd.c
+++ b/common/osx/osd.c
@@ -32,6 +32,8 @@
 
 #include "osx/osd.h"
 
+#if HAVE_CLOCK_GETTIME == 0
+
 // clock_gettime() does not exist on OS X.  Instead, simply use
 // gettimeofday(), which is apparently fairly efficient on OS X (i.e.,
 // ignore the clk_id that is passed in and always return the system
@@ -47,3 +49,5 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 
 	return retval;
 }
+
+#endif

--- a/configure.ac
+++ b/configure.ac
@@ -108,5 +108,15 @@ AC_CHECK_FUNC([epoll_create1], [have_epoll=1], [have_epoll=0])
 AC_DEFINE_UNQUOTED([HAVE_EPOLL], [$have_epoll],
 		   [Defined to 1 if Linux epoll is available])
 
+have_clock_gettime=0
+AC_SEARCH_LIBS([clock_gettime],[rt],
+		[have_clock_gettime=1],
+		[AC_CHECK_FUNCS([host_get_clock_service],
+			[have_host_get_clock_service=1],
+			[AC_MSG_ERROR([clock_gettime or host_get_clock_service
+			 not found.])])])
+
+AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
+		   [Define to 1 if clock_gettime is available.])
 AC_CONFIG_FILES([Makefile fabtests.spec])
 AC_OUTPUT

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -36,6 +36,13 @@
 #include <sys/time.h>
 #include <time.h>
 
+#include <AvailabilityMacros.h>
+#ifndef MAC_OS_X_VERSION_10_12
+#define MAC_OS_X_VERSION_10_12 101200
+#endif
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12
+
 #define CLOCK_REALTIME 0
 #define CLOCK_REALTIME_COARSE 0
 #define CLOCK_MONOTONIC 0
@@ -50,6 +57,8 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp);
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif
 
 #endif // FABTESTS_OSX_OSD_H

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -36,12 +36,9 @@
 #include <sys/time.h>
 #include <time.h>
 
-#include <AvailabilityMacros.h>
-#ifndef MAC_OS_X_VERSION_10_12
-#define MAC_OS_X_VERSION_10_12 101200
-#endif
+#include "config.h"
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12
+#if HAVE_CLOCK_GETTIME == 0
 
 #define CLOCK_REALTIME 0
 #define CLOCK_REALTIME_COARSE 0


### PR DESCRIPTION
OSX has clock_gettime() starting from version 10.12. The workaround
breaks the build on OSX 10.12. The patch checks the version of current
OSX and disables the workaround if the version is greater or equal to
10.12.

Signed-off-by: Yanfei Guo yguo@anl.gov
