### PR TITLE
Fix macOS Sierra build.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,7 +69,10 @@ libfabtests_la_SOURCES = \
 
 if MACOS
 libfabtests_la_SOURCES += include/osx/osd.h
+
+if !HAVE_CLOCK_GETTIME
 libfabtests_la_SOURCES += common/osx/osd.c
+endif
 endif
 
 simple_fi_msg_sockets_SOURCES = \

--- a/common/osx/osd.c
+++ b/common/osx/osd.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -31,11 +32,14 @@
  */
 
 #include "osx/osd.h"
+#include "config.h"
 
-// clock_gettime() does not exist on OS X.  Instead, simply use
-// gettimeofday(), which is apparently fairly efficient on OS X (i.e.,
-// ignore the clk_id that is passed in and always return the system
-// clock time).
+/* clock_gettime() does not exist on OS X before the mac OS Sierra release. If
+ * the symbol is not already defined, then define a workaround using
+ * gettimeofday. Ignore the clk_id that is passed in and always return the
+ * system clock time.
+ */
+#if !HAVE_CLOCK_GETTIME
 int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 	int retval;
 	struct timeval tv;
@@ -47,3 +51,4 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 
 	return retval;
 }
+#endif

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,16 @@ AM_PROG_CC_C_O
 
 LT_INIT
 
+have_clock_gettime=0
+
+AC_SEARCH_LIBS([clock_gettime],[rt],
+	       [have_clock_gettime=1],
+	       [])
+
+AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
+		   [Define to 1 if clock_gettime is available.])
+AM_CONDITIONAL(HAVE_CLOCK_GETTIME, [test $have_clock_gettime -eq 1])
+
 AC_ARG_WITH([libfabric],
             AC_HELP_STRING([--with-libfabric], [Use non-default libfabric location - default NO]),
             [AS_IF([test -d $withval/lib64], [fab_libdir="lib64"], [fab_libdir="lib"])

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -36,6 +36,7 @@
 #include <sys/time.h>
 #include <time.h>
 
+#if !HAVE_CLOCK_GETTIME
 #define CLOCK_REALTIME 0
 #define CLOCK_REALTIME_COARSE 0
 #define CLOCK_MONOTONIC 0
@@ -51,5 +52,6 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp);
 #ifdef __cplusplus
 }
 #endif
+#endif // !HAVE_CLOCK_GETTIME
 
 #endif // FABTESTS_OSX_OSD_H


### PR DESCRIPTION
The workaround for clock_gettime is only necessary when the function is
not already available. macOS sierra includes an implementation of
clock_gettime in libc.

- Only define implementations if HAVE_CLOCK_GETTIME is 0.
- Add AM_CONDITIONAL to define whether HAVE_CLOCK_GETTIME is defined.
  This will be used to determine whether to compile the osx/osd.c file.

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>