### PR TITLE
osd.h: add <config.h>

### DIFF
--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -33,6 +33,8 @@
 #ifndef _FABTESTS_OSX_OSD_H_
 #define _FABTESTS_OSX_OSD_H_
 
+#include <config.h>
+
 #include <sys/time.h>
 #include <time.h>
 


### PR DESCRIPTION
Need <config.h> to get the definition of HAVE_CLOCK_GETTIME.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>