### PR TITLE
README.md: indicate that version-matched pairs are best

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,38 @@
 
 # fabtests
 
-Fabtests provides a set of examples that uses [libfabric](http://libfabric.org)
--- a high-performance fabric software library.
+Fabtests provides a set of examples that uses
+[libfabric](http://libfabric.org) -- a high-performance fabric
+software library.
+
+## Notes
+
+Note that the fabtests suite is released paired with a specific
+version of libfabric.  For example, libfabric v1.4 and fabtests v1.4
+were released together.
+
+Using these paired versions is the best way to test a given version of
+libfabric.  Using version-mismatched libfabric/fabtests pairs may
+produce unexpected results.
 
 ## Building fabtests
 
 Distribution tarballs are available from the Github
 [releases](https://github.com/ofiwg/fabtests/releases) tab.
 
-If you are building Fabtests from a developer Git clone, you must first run the
-`autogen.sh` script. This will invoke the GNU Autotools to bootstrap Fabtests'
-configuration and build mechanisms. If you are building Fabtests from an
-official distribution tarball, there is no need to run `autogen.sh`; Fabtests
-distribution tarballs are already bootstrapped for you.
+If you are building Fabtests from a developer Git clone, you must
+first run the `autogen.sh` script. This will invoke the GNU Autotools
+to bootstrap Fabtests' configuration and build mechanisms. If you are
+building Fabtests from an official distribution tarball, there is no
+need to run `autogen.sh`; Fabtests distribution tarballs are already
+bootstrapped for you.
 
-Fabtests relies on being able to find an installed version of Libfabric. In
-some cases, Libfabric may be in default compiler / linker search paths, and you
-don't need to tell Fabtests where to find it. In other cases, you may need to
-tell Fabtests where to find the installed Libfabric's header and library files
-using the `--with-libfabric=<directory>` option, described below.
+Fabtests relies on being able to find an installed version of
+Libfabric. In some cases, Libfabric may be in default compiler /
+linker search paths, and you don't need to tell Fabtests where to find
+it. In other cases, you may need to tell Fabtests where to find the
+installed Libfabric's header and library files using the
+`--with-libfabric=<directory>` option, described below.
 
 ### Configure options
 
@@ -65,7 +78,8 @@ $ ./configure --with-libfabric=/opt/libfabric --prefix=/opt/fabtests && make -j 
 ```
 
 This will tell the Fabtests to look for Libfabric libraries in the
-`/opt/libfabric` tree, and to install the Fabtests in the `/opt/fabtests` tree.
+`/opt/libfabric` tree, and to install the Fabtests in the
+`/opt/fabtests` tree.
 
 Alternatively:
 
@@ -73,6 +87,7 @@ Alternatively:
 $ ./configure --prefix=/opt/fabtests && make -j 32 && sudo make install
 ```
 
-Tells the Fabtests that it should be able to find the Libfabric header files
-and libraries in default compiler / linker search paths (configure will abort
-if it is not able to find them), and to install Fabtests in `/opt/fabtests`.
+Tells the Fabtests that it should be able to find the Libfabric header
+files and libraries in default compiler / linker search paths
+(configure will abort if it is not able to find them), and to install
+Fabtests in `/opt/fabtests`.


### PR DESCRIPTION
YMMV if you use libfabric vX with fabtests vY.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>