### PR TITLE
Specify cntr wait type in pingpong test

### DIFF
--- a/benchmarks/rdm_cntr_pingpong.c
+++ b/benchmarks/rdm_cntr_pingpong.c
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
 
 	opts = INIT_OPTS;
 	opts.options = FT_OPT_RX_CNTR | FT_OPT_TX_CNTR;
+	opts.comp_method = FT_COMP_SREAD;
 
 	hints = fi_allocinfo();
 	if (!hints)


### PR DESCRIPTION
Currently the rdm_cntr_pingpong test does not
specify a FT_WAIT_TYPE when setting up. According
to the man page, fi_cntr_wait can only be used when
configured with a wait_object. This change adds
FT_COMP_SREAD, which maps to FI_WAIT_UNSPEC under
the covers so that the test can use fi_cntr_wait without
getting stuck in an infinite loop.

Signed-off-by: James Shimek <jshimek@cray.com>