### PR TITLE
shared ctx test: do not open unnecessary ep

### DIFF
--- a/simple/shared_ctx.c
+++ b/simple/shared_ctx.c
@@ -129,7 +129,7 @@ static int alloc_ep_res(struct fi_info *fi)
 {
 	int ret;
 
-	ret = ft_alloc_active_res(fi);
+	ret = ft_alloc_ep_res(fi);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
ft_alloc_active_res() opens an unnecessary endpoint with the same
port number as the first endpoint in the array of endpoints
which are subsequently bound to a shared TX context.  The sockets
provider somehow doesn't care if two endpoints with the same
address are opened (maybe the collision is only detected at
fi_enable), but for the GNI provider it is not allowed to
open two endpoints with the same ip addr/port.

To avoid this call ft_alloc_ep_res() instead.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>