### PR TITLE
shared.h: Add back socket headers for common code

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -36,6 +36,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/wait.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -35,6 +35,8 @@
 #include <getopt.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
 #include <rdma/fi_errno.h>
 #include <rdma/fi_endpoint.h>

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -36,6 +36,8 @@
 #include <getopt.h>
 #include <string.h>
 #include <netdb.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
 #include <rdma/fi_errno.h>
 


### PR DESCRIPTION
Add back socket headers removed in 87e9d2ff. Builds on Linux must be
including these indirectly, but FreeBSd currently fails.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>