### PR TITLE
dgram_waitset.c: Fix a race condition.

### DIFF
--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under the BSD license below:
  *
@@ -83,6 +83,13 @@ static int send_recv()
 {
 	struct fi_cq_entry comp;
 	int ret;
+
+	ret = fi_recv(ep, rx_buf, rx_size + ft_rx_prefix_size(), fi_mr_desc(mr),
+		      0, &rx_ctx);
+	if (ret)
+		return ret;
+
+	ft_sync();
 
 	fprintf(stdout, "Posting a send...\n");
 	ret = ft_post_tx(ep, remote_fi_addr, tx_size, &tx_ctx);


### PR DESCRIPTION
Before this change, the receive for the message was posted by the client
as the final step of the initialization process. The server can
sometimes finish initialization and post the send containing the
message before the client has completed posting a receive buffer. Post
an extra receive buffer to handle the message and synchronize to allow
the client to complete posting the buffer.

Signed-off-by: Ben Turrubiates \<bturrubi@cisco.com\>