### PR TITLE
Convert all exit codes to range 0-255

### DIFF
--- a/benchmarks/dgram_pingpong.c
+++ b/benchmarks/dgram_pingpong.c
@@ -124,5 +124,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/benchmarks/msg_bw.c
+++ b/benchmarks/msg_bw.c
@@ -114,5 +114,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/benchmarks/msg_pingpong.c
+++ b/benchmarks/msg_pingpong.c
@@ -110,5 +110,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/benchmarks/rdm_cntr_pingpong.c
+++ b/benchmarks/rdm_cntr_pingpong.c
@@ -103,5 +103,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/benchmarks/rdm_pingpong.c
+++ b/benchmarks/rdm_pingpong.c
@@ -100,5 +100,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/benchmarks/rdm_tagged_bw.c
+++ b/benchmarks/rdm_tagged_bw.c
@@ -107,5 +107,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/benchmarks/rdm_tagged_pingpong.c
+++ b/benchmarks/rdm_tagged_pingpong.c
@@ -101,5 +101,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -505,5 +505,5 @@ out:
 	if (opts.dst_addr)
 		fts_close(series);
 	ft_free();
-	return ret;
+	return ft_exit_code(ret);
 }

--- a/include/shared.h
+++ b/include/shared.h
@@ -34,6 +34,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <stdlib.h>
 #include <inttypes.h>
 #include <netinet/tcp.h>
 #include <sys/uio.h>
@@ -56,6 +57,13 @@ extern "C" {
 #include "freebsd/osd.h"
 #endif
 
+
+/* exit codes must be 0-255 */
+static inline int ft_exit_code(int ret)
+{
+	int absret = ret < 0 ? -ret : ret;
+	return absret > 255 ? EXIT_FAILURE : absret;
+}
 
 #define ft_foreach_info(fi, info) \
 	for (fi = info; fi; fi = fi->next)

--- a/ported/libibverbs/rc_pingpong.c
+++ b/ported/libibverbs/rc_pingpong.c
@@ -670,5 +670,5 @@ err2:
 		rc = ret;
 err1:
 	fi_freeinfo(fi);
-	return rc;
+	return ft_exit_code(rc);
 }

--- a/ported/librdmacm/cmatose.c
+++ b/ported/librdmacm/cmatose.c
@@ -569,5 +569,5 @@ int main(int argc, char **argv)
 
 out:
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/cm_data.c
+++ b/simple/cm_data.c
@@ -480,5 +480,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -147,5 +147,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/dgram.c
+++ b/simple/dgram.c
@@ -79,5 +79,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -186,5 +186,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/msg.c
+++ b/simple/msg.c
@@ -91,5 +91,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
 
 	ft_free_res();
 	close(epfd);
-	return -ret;
+	return ft_exit_code(ret);
 }
 
 #else
@@ -234,6 +234,6 @@ int main(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-	return FI_ENODATA;
+	return ft_exit_code(FI_ENODATA);
 }
 #endif

--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -475,5 +475,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -241,5 +241,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/rdm.c
+++ b/simple/rdm.c
@@ -79,5 +79,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -118,5 +118,5 @@ int main(int argc, char **argv)
 	ret = run_test();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/rdm_rma_trigger.c
+++ b/simple/rdm_rma_trigger.c
@@ -148,5 +148,5 @@ int main(int argc, char **argv)
 	ret = run_test();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/rdm_shared_av.c
+++ b/simple/rdm_shared_av.c
@@ -203,5 +203,5 @@ int main(int argc, char **argv)
 
 	ft_free_res();
 
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -164,5 +164,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -385,5 +385,5 @@ int main(int argc, char **argv)
 	/* Closes the scalable ep that was allocated in the test */
 	FT_CLOSE_FID(sep);
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/simple/shared_ctx.c
+++ b/simple/shared_ctx.c
@@ -690,5 +690,5 @@ int main(int argc, char **argv)
 	free(addr_array);
 	free(ep_array);
 	free(fi_dup);
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/streaming/msg.c
+++ b/streaming/msg.c
@@ -132,5 +132,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -142,5 +142,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -522,5 +522,5 @@ int main(int argc, char **argv)
 
 	free_res();
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -334,5 +334,5 @@ int main(int argc, char **argv)
 
 	free_res();
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -134,5 +134,5 @@ int main(int argc, char **argv)
 	ret = run();
 
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -948,7 +948,7 @@ struct test_entry test_array_good[] = {
 struct test_entry test_array_bad[] = {
 	TEST_ENTRY(av_bad_sync, "Test sync AV insert of bad address"),
 	TEST_ENTRY(av_goodbad_vector_sync,
-			"Test sync AV inset of 1 good and 1 bad address"),
+			"Test sync AV insert of 1 good and 1 bad address"),
 	TEST_ENTRY(av_goodbad_vector_async,
 			"Test async AV insert with good and bad address"),
 	TEST_ENTRY(av_goodbad_2vector_async, "Test async AV insert with two vectors:"

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -1084,5 +1084,5 @@ int main(int argc, char **argv)
 
 err:
 	ft_free_res();
-	return ret ? -ret : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+	return ret ? ft_exit_code(ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/cq_test.c
+++ b/unit/cq_test.c
@@ -199,5 +199,5 @@ int main(int argc, char **argv)
 
 err:
 	ft_free_res();
-	return ret ? -ret : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+	return ret ? ft_exit_code(ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -128,5 +128,5 @@ int main(int argc, char **argv)
 	free(domain_vec);
 out:
 	ft_free_res();
-	return -ret;
+	return ft_exit_code(ret);
 }

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -602,5 +602,5 @@ int main(int argc, char **argv)
 
 err:
 	ft_free_res();
-	return ret ? -ret : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+	return ret ? ft_exit_code(ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
adds function to ensure all exit codes are in range.  If we later decide to limit which exit codes to use (say only 0-2), we only need to update a single function to update all tests.