### PR TITLE
fi_rdm_rma: Leave FI_CONTEXT mode bit unset

### DIFF
--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_RMA;
-	hints->mode = FI_CONTEXT | FI_LOCAL_MR | FI_RX_CQ_DATA;
+	hints->mode = FI_LOCAL_MR | FI_RX_CQ_DATA;
 
 	ret = run();
 

--- a/unit/mr_test.c
+++ b/unit/mr_test.c
@@ -49,7 +49,7 @@ static char err_buf[512];
 static int mr_reg()
 {
 	int i;
-	int ret;
+	int ret = 0;
 	int testret;
 	struct fid_mr *mr;
 


### PR DESCRIPTION
Plus a bonus fix to a compiler warning