### PR TITLE
configure.ac: bump to v1.4.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 dnl
-dnl Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2016-2017 Cisco Systems, Inc.  All rights reserved.
 dnl
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT([fabtests], [1.5.0a1], [ofiwg@lists.openfabrics.org])
+AC_INIT([fabtests], [1.4.1], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)


### PR DESCRIPTION
To match the libfabric v1.4.1 release.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>