### PR TITLE
The reproduction of "prov/socket segfaults in sock_ep_connect() when …

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1660,6 +1660,7 @@ void ft_csusage(char *name, char *desc)
 	FT_PRINT_OPTS_USAGE("-m", "machine readable output");
 	FT_PRINT_OPTS_USAGE("-t <type>", "completion type [queue, counter]");
 	FT_PRINT_OPTS_USAGE("-c <method>", "completion method [spin, sread, fd]");
+	FT_PRINT_OPTS_USAGE("-u", "set destination addr:port in fi_connect only");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
 
 	return;
@@ -1771,6 +1772,9 @@ void ft_parsecsopts(int op, char *optarg, struct ft_opts *opts)
 		break;
 	case 'l':
 		opts->options |= FT_OPT_ALIGN;
+		break;
+	case 'u':
+		opts->dest_mode = FT_DEST_ADDR_ONLY_IN_FI_CONN;
 		break;
 	default:
 		/* let getopt handle unknown opts*/

--- a/include/shared.h
+++ b/include/shared.h
@@ -123,6 +123,11 @@ enum ft_rma_opcodes {
 	FT_RMA_WRITEDATA,
 };
 
+enum ft_dest_addr_mode {
+	FT_DEST_ADDR_IN_FI_INFO = 0,
+	FT_DEST_ADDR_ONLY_IN_FI_CONN = 1
+};
+
 struct ft_opts {
 	int iterations;
 	int warmup_iterations;
@@ -140,6 +145,7 @@ struct ft_opts {
 	enum ft_rma_opcodes rma_op;
 	int argc;
 	char **argv;
+	enum ft_dest_addr_mode dest_mode;
 };
 
 extern struct fi_info *fi_pep, *fi, *hints;
@@ -200,7 +206,7 @@ extern int listen_sock;
 #define ADDR_OPTS "B:P:s:a:"
 #define FAB_OPTS "f:d:p:"
 #define INFO_OPTS FAB_OPTS "e:"
-#define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
+#define CS_OPTS ADDR_OPTS "I:S:mc:t:w:lu"
 
 extern char default_port[8];
 

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -81,6 +81,7 @@ simple_tests=(
 	"msg"
 	"msg_epoll"
 	"msg_sockets"
+	"msg_sockets -u"
 	"poll -t queue"
 	"poll -t counter"
 	"rdm"


### PR DESCRIPTION
The reproduction of "prov/socket segfaults in sock_ep_connect() when it tries to dereference dest_addr" issue
https://github.com/ofiwg/libfabric/issues/2676

fi_msg_sockets: Add new test case that covers Issue #2676
Invokes fi_send when no connect is established and no destination addres:port
pair is passed to fi_info

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>