### PR TITLE
fixed potential issue in FT_PRINTERR macro

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -231,7 +231,7 @@ int size_to_count(int size);
 
 #define FT_PRINTERR(call, retv) \
 	do { fprintf(stderr, call "(): %s:%d, ret=%d (%s)\n", __FILE__, __LINE__, \
-			(int) retv, fi_strerror((int) -retv)); } while (0)
+			(int) (retv), fi_strerror((int) -(retv))); } while (0)
 
 #define FT_LOG(level, fmt, ...) \
 	do { fprintf(stderr, "[%s] fabtests:%s:%d: " fmt "\n", level, __FILE__, \


### PR DESCRIPTION
- parameter retv in macro was not wrapped by () which may cause
  unpredicted behavior in some cases

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>