### PR TITLE
unit/getinfo: Manual merge of updates to getinfo test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,7 @@ bin_PROGRAMS = \
 	unit/fi_eq_test \
 	unit/fi_cq_test \
 	unit/fi_mr_test \
+	unit/fi_cntr_test \
 	unit/fi_av_test \
 	unit/fi_dom_test \
 	unit/fi_getinfo_test \
@@ -218,6 +219,11 @@ unit_fi_mr_test_SOURCES = \
 	unit/mr_test.c \
 	unit/common.c
 unit_fi_mr_test_LDADD = libfabtests.la
+
+unit_fi_cntr_test_SOURCES = \
+	unit/cntr_test.c \
+	unit/common.c
+unit_fi_cntr_test_LDADD = libfabtests.la
 
 unit_fi_av_test_SOURCES = \
 	unit/av_test.c \

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -447,7 +447,6 @@ int main(int argc, char **argv)
 	}
 
 	opts.dst_addr = (optind == argc - 1) ? argv[optind] : NULL;
-
 	if (opts.dst_addr) {
 		if (!opts.dst_port)
 			opts.dst_port = default_port;

--- a/include/shared.h
+++ b/include/shared.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel Corporation.  All rights reserved.
  * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under the BSD license below:
@@ -355,6 +355,9 @@ void show_perf_mr(int tsize, int iters, struct timespec *start,
 int send_recv_greeting(struct fid_ep *ep);
 int check_recv_msg(const char *message);
 uint64_t ft_info_to_mr_access(struct fi_info *info);
+int ft_alloc_bit_combo(uint64_t fixed, uint64_t opt, uint64_t **combos, int *len);
+void ft_free_bit_combo(uint64_t *combo);
+int ft_cntr_open(struct fid_cntr **cntr);
 
 #define FT_PROCESS_QUEUE_ERR(readerr, rd, queue, fn, str)	\
 	do {							\

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #
+# Copyright (c) 2017, Intel Corporation.  All rights reserved.
 # Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.
 # Copyright (c) 2016, Cray, Inc. All rights reserved.
 #
@@ -170,6 +171,7 @@ unit_tests=(
 	"eq_test"
 	"cq_test"
 	"mr_test"
+	"cntr_test"
 )
 
 complex_tests=(

--- a/unit/cntr_test.c
+++ b/unit/cntr_test.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2013-2017 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2014-2016 Cisco Systems, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#include <rdma/fi_errno.h>
+
+#include "unit_common.h"
+#include "shared.h"
+
+static char err_buf[512];
+
+static int cntr_open_close()
+{
+	int i, opened;
+	int ret = 0;
+	int testret = FAIL;
+	struct fid_cntr **cntrs = calloc(fi->domain_attr->cntr_cnt,
+					 sizeof(struct fid_cntr *));
+	if (!cntrs) {
+		perror("calloc");
+		return -FI_ENOMEM;
+	}
+
+	for (opened = 0; opened < fi->domain_attr->cntr_cnt; opened++) {
+		ret = ft_cntr_open(&cntrs[opened]);
+		if (ret) {
+			FT_PRINTERR("fi_cntr_open", ret);
+			break;
+		}
+	}
+
+	for (i = 0; i < opened; i++) {
+		ret = fi_close(&(cntrs[i])->fid);
+		if (ret) {
+			FT_PRINTERR("fi_cntr_close", ret);
+			goto fail;
+		}
+	}
+	if (opened == fi->domain_attr->cntr_cnt)
+		testret = PASS;
+
+fail:
+	free(cntrs);
+	return TEST_RET_VAL(ret, testret);
+}
+
+struct test_entry test_array[] = {
+	TEST_ENTRY(cntr_open_close, "Test open/close counters to limit"),
+	{ NULL, "" }
+};
+
+static void usage(void)
+{
+	ft_unit_usage("cntr_test", "Unit test for counter (cntr)");
+}
+
+int main(int argc, char **argv)
+{
+	int op, ret;
+	int failed = 0;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt(argc, argv, FAB_OPTS "h")) != -1) {
+		switch (op) {
+		default:
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
+			usage();
+			return EXIT_FAILURE;
+		}
+	}
+
+	hints->mode = ~0;
+	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		goto out;
+	}
+
+	if (!fi->domain_attr->cntr_cnt)
+		goto out;
+
+	ft_open_fabric_res();
+
+	printf("Testing CNTRS on fabric %s\n", fi->fabric_attr->name);
+
+	failed = run_tests(test_array, err_buf);
+	if (failed > 0)
+		printf("Summary: %d tests failed\n", failed);
+	else
+		printf("Summary: all tests passed\n");
+
+out:
+	ft_free_res();
+	return ret ? ft_exit_code(ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -61,13 +61,13 @@ static int check_addr(void *addr, size_t addrlen, char *str)
 
 static int check_srcaddr(void *arg)
 {
-	struct fi_info *info = (struct fi_info *)arg;
+	struct fi_info *info = arg;
 	return check_addr(info->src_addr, info->src_addrlen, "source");
 }
 
 static int check_src_dest_addr(void *arg)
 {
-	struct fi_info *info = (struct fi_info *)arg;
+	struct fi_info *info = arg;
 	int ret;
 
 	ret = check_addr(info->src_addr, info->src_addrlen, "source");
@@ -75,6 +75,12 @@ static int check_src_dest_addr(void *arg)
 		return ret;
 
 	return check_addr(info->dest_addr, info->dest_addrlen, "destination");
+}
+
+static int check_api_version(void *arg)
+{
+	struct fi_info *info = arg;
+	return info->fabric_attr->api_version != FT_FIVERSION;
 }
 
 int invalid_dom(struct fi_info *hints)
@@ -186,8 +192,11 @@ getinfo_test(10, "Test with node, service",
 		opts.dst_addr ? opts.dst_addr : "localhost", opts.dst_port,
 		0, hints, NULL, check_src_dest_addr, 0)
 
+getinfo_test(11, "Test API version",
+		NULL, NULL, 0, hints, NULL, check_api_version ,0)
+
 /* Negative tests */
-getinfo_test(11, "Test with non-existent domain name",
+getinfo_test(12, "Test with non-existent domain name",
 		NULL, NULL, 0, hints, invalid_dom, NULL, -FI_ENODATA)
 
 static void usage(void)
@@ -214,6 +223,7 @@ int main(int argc, char **argv)
 		TEST_ENTRY(getinfo9, getinfo9_desc),
 		TEST_ENTRY(getinfo10, getinfo10_desc),
 		TEST_ENTRY(getinfo11, getinfo11_desc),
+		TEST_ENTRY(getinfo12, getinfo12_desc),
 		{ NULL, "" }
 	};
 


### PR DESCRIPTION
Cleaned up end of line white space.  Copied getenv() results, since a putenv() call can modify the returned buffer.