### PR TITLE
Fix coverity issues in fabtests

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -279,7 +279,7 @@ int ft_alloc_bit_combo(uint64_t fixed, uint64_t opt,
 	num_flags = 0;
 	for_each_bit(opt, i) {
 		if (bit_isset(opt, i))
-			flags[num_flags++] = 1 << i;
+			flags[num_flags++] = 1ULL << i;
 	}
 
 	for (index = 0; index < (*len); index++) {

--- a/unit/cntr_test.c
+++ b/unit/cntr_test.c
@@ -166,7 +166,9 @@ int main(int argc, char **argv)
 	if (!fi->domain_attr->cntr_cnt)
 		goto out;
 
-	ft_open_fabric_res();
+	ret = ft_open_fabric_res();
+	if (ret)
+		goto out;
 
 	printf("Testing CNTRS on fabric %s\n", fi->fabric_attr->name);
 


### PR DESCRIPTION
The following issues are fixed:
- Unintentional integer overflow
- Unchecked return value
- Bad bit shift operation

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>