### PR TITLE
add FI_CLAIM and FI_DISCARD simple tests

### DIFF
--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -31,95 +31,187 @@
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
+#include <unistd.h>
 
 #include <rdma/fi_errno.h>
 #include <rdma/fi_tagged.h>
 
 #include <shared.h>
 
-static int tagged_peek(uint64_t tag)
+static int wait_for_send_comp(int count)
 {
+	int ret, completions = 0;
 	struct fi_cq_tagged_entry comp;
-	struct fi_msg_tagged msg;
+
+	do {
+		ret = fi_cq_sread(txcq, &comp, 1, NULL, -1);
+		if (ret != 1) {
+			FT_PRINTERR("fi_cq_sread", ret);
+			return ret;
+		}
+		completions++;
+	} while (completions < count);
+
+	return 0;
+}
+
+static int tag_queue_op(uint64_t tag, int recv, uint64_t flags)
+{
 	int ret;
+	struct fi_cq_tagged_entry comp;
+	struct fi_msg_tagged msg = {0};
+	struct fi_cq_err_entry cq_err;
+	struct iovec iov;
+	struct fi_context ctx;
 
-	memset(&msg, 0, sizeof msg);
+	if (recv) {
+		iov.iov_base = buf;
+		iov.iov_len = rx_size;
+		msg.msg_iov = &iov;
+		msg.desc = fi_mr_desc(mr);
+		msg.iov_count = 1;
+		msg.addr = remote_fi_addr;
+	}
 	msg.tag = tag;
-	msg.context = &rx_ctx;
+	msg.context = &ctx;
 
-	ret = fi_trecvmsg(ep, &msg, FI_PEEK);
+	ret = fi_trecvmsg(ep, &msg, flags);
 	if (ret) {
-		FT_PRINTERR("FI_PEEK", ret);
+		FT_PRINTERR("fi_trecvmsg", ret);
 		return ret;
 	}
 
 	ret = fi_cq_sread(rxcq, &comp, 1, NULL, -1);
 	if (ret != 1) {
-		if (ret == -FI_EAVAIL)
-			ret = ft_cq_readerr(rxcq);
-		else
+		if (ret == -FI_EAVAIL) {
+			ret = fi_cq_readerr(rxcq, &cq_err, 0);
+			if (ret < 0)
+				FT_PRINTERR("fi_cq_readerr", ret);
+			else
+				ret = -cq_err.err;
+		} else {
 			FT_PRINTERR("fi_cq_sread", ret);
+		}
 	}
 	return ret;
 }
 
 static int run(void)
 {
-	int ret;
+	int i, ret;
 
 	ret = ft_init_fabric();
 	if (ret)
 		return ret;
 
+	if (!(tx_ctx_arr = calloc(5, sizeof *tx_ctx_arr)))
+		return -FI_ENOMEM;
+
 	if (opts.dst_addr) {
 		printf("Searching for a bad msg\n");
-		ret = tagged_peek(0xbad);
+		ret = tag_queue_op(0xbad, 0, FI_PEEK);
 		if (ret != -FI_ENOMSG) {
 			FT_PRINTERR("FI_PEEK", ret);
 			return ret;
 		}
 
-		printf("Synchronizing with sender..\n");
-		ret = ft_sync();
-		if (ret)
+		printf("Searching for a bad msg with claim\n");
+		ret = tag_queue_op(0xbad, 0, FI_PEEK | FI_CLAIM);
+		if (ret != -FI_ENOMSG) {
+			FT_PRINTERR("FI_PEEK", ret);
 			return ret;
+		}
 
-		printf("Searching for a good msg\n");
-		ret = tagged_peek(0x900d);
+		printf("Retrieving fifth message\n");
+		ret = tag_queue_op(0x900d+4, 1, 0);
+		if (ret != 1) {
+			FT_PRINTERR("Receive after peek", ret);
+			return ret;
+		}
+		printf("Messages 1-4 should be in unexpected queue\n");
+
+		printf("Searching for first msg\n");
+		ret = tag_queue_op(0x900d, 0, FI_PEEK);
 		if (ret != 1) {
 			FT_PRINTERR("FI_PEEK", ret);
 			return ret;
 		}
 
-		printf("Receiving msg\n");
-		ret = fi_trecv(ep, buf, rx_size, fi_mr_desc(mr), remote_fi_addr,
-				0x900d, 0, &rx_ctx);
-		if (ret) {
-			FT_PRINTERR("fi_trecv", ret);
+		printf("Receiving first msg\n");
+		ret = tag_queue_op(0x900d, 1, 0);
+		if (ret != 1) {
+			FT_PRINTERR("Receive after peek", ret);
 			return ret;
 		}
 
-		printf("Completing recv\n");
-		ret = ft_get_rx_comp(++rx_seq);
+		printf("Searching for second msg to claim\n");
+		ret = tag_queue_op(0x900d+1, 0, FI_PEEK | FI_CLAIM);
+		if (ret != 1) {
+			FT_PRINTERR("FI_PEEK | FI_CLAIM", ret);
+			return ret;
+		}
+
+		printf("Receiving second msg\n");
+		ret = tag_queue_op(0x900d+1, 1, FI_CLAIM);
+		if (ret != 1) {
+			FT_PRINTERR("FI_CLAIM", ret);
+			return ret;
+		}
+
+		printf("Searching for third msg to peek and discard\n");
+		ret = tag_queue_op(0x900d+2, 0, FI_PEEK | FI_DISCARD);
+		if (ret != 1) {
+			FT_PRINTERR("FI_PEEK | FI_DISCARD", ret);
+			return ret;
+		}
+
+		printf("Checking to see if third msg was discarded\n");
+		ret = tag_queue_op(0x900d+2, 0, FI_PEEK);
+		if (ret != -FI_ENOMSG) {
+			FT_PRINTERR("FI_PEEK", ret);
+			return ret;
+		}
+
+		printf("Searching for fourth msg to claim and discard\n");
+		ret = tag_queue_op(0x900d+3, 0, FI_PEEK | FI_CLAIM);
+		if (ret != 1) {
+			FT_PRINTERR("FI_DISCARD", ret);
+			return ret;
+		}
+
+		printf("Discarding fourth msg\n");
+		ret = tag_queue_op(0x900d+3, 0, FI_CLAIM | FI_DISCARD);
+		if (ret != 1) {
+			FT_PRINTERR("FI_CLAIM", ret);
+			return ret;
+		}
+		/* sync with sender before ft_finalize, since we sent
+		 * and received messages outside of the sequence numbers
+		 * maintained by common code */
+		ret = fi_tsend(ep, tx_buf, 1, fi_mr_desc(mr),
+				remote_fi_addr, 0xabc, &tx_ctx_arr[0]);
 		if (ret)
 			return ret;
-
+		ret = wait_for_send_comp(1);
+		if (ret)
+			return ret;
 	} else {
-		printf("Sending tagged message\n");
-		ret = fi_tsend(ep, tx_buf, tx_size, fi_mr_desc(mr),
-				remote_fi_addr, 0x900d, &tx_ctx);
+		printf("Sending five tagged messages\n");
+		for(i = 0; i < 5; i++) {
+			ret = fi_tsend(ep, tx_buf, tx_size, fi_mr_desc(mr),
+					remote_fi_addr, 0x900d+i, &tx_ctx_arr[i]);
+			if (ret)
+				return ret;
+		}
+		printf("Waiting for messages to complete\n");
+		ret = wait_for_send_comp(5);
 		if (ret)
 			return ret;
-
-		printf("Synchronizing with receiver..\n");
-		ret = ft_sync();
-		if (ret)
+		ret = tag_queue_op(0xabc, 1, 0);
+		if (ret != 1) {
+			FT_PRINTERR("Receive sync", ret);
 			return ret;
-
-		printf("Getting send completion\n");
-		ret = ft_get_tx_comp(tx_seq + 1);
-		if (ret)
-			return ret;
+		}
 	}
 
 	ft_finalize();
@@ -140,15 +232,15 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	while ((op = getopt(argc, argv, "h" ADDR_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
-			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parsecsopts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints);
 			break;
 		case '?':
 		case 'h':
-			ft_usage(argv[0], "An RDM client-server example that uses tagged search.\n");
+			ft_csusage(argv[0], "An RDM client-server example that uses tagged search.\n");
 			return EXIT_FAILURE;
 		}
 	}
@@ -157,6 +249,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->rx_attr->total_buffered_recv = 1024;
+	hints->tx_attr->msg_order = FI_ORDER_SAS;
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_TAGGED;
 	hints->mode = FI_CONTEXT | FI_LOCAL_MR;


### PR DESCRIPTION
I extended the tagged_peek test to include FI_CLAIM and FI_DISCARD flags testing as well.

Does this test look OK? Feedback?

This test has to do unexpected messaging, so it has some weird interactions with the common code, therefore there is a separate sync outside of the common code before the call to ft_finalize().

Also, the receive function has to use a different struct fi_context than rx_ctx since rx_ctx is global and is posted as a receive buffer for the next ft_sync().

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>