### PR TITLE
Fixed problem with CQ/EQ error reading in fabtests

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1454,6 +1454,7 @@ int ft_cq_readerr(struct fid_cq *cq)
 	struct fi_cq_err_entry cq_err;
 	int ret;
 
+	memset(&cq_err, 0, sizeof(cq_err));
 	ret = fi_cq_readerr(cq, &cq_err, 0);
 	if (ret < 0) {
 		FT_PRINTERR("fi_cq_readerr", ret);
@@ -1469,6 +1470,7 @@ void eq_readerr(struct fid_eq *eq, const char *eq_str)
 	struct fi_eq_err_entry eq_err;
 	int rd;
 
+	memset(&eq_err, 0, sizeof(eq_err));
 	rd = fi_eq_readerr(eq, &eq_err, 0);
 	if (rd != sizeof(eq_err)) {
 		FT_PRINTERR("fi_eq_readerr", rd);

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -74,6 +74,7 @@ int ft_eq_readerr(void)
 	struct fi_eq_err_entry err;
 	ssize_t ret;
 
+	memset(&err, 0, sizeof(err));
 	ret = fi_eq_readerr(eq, &err, 0);
 	if (ret != sizeof(err)) {
 		FT_PRINTERR("fi_eq_readerr", ret);

--- a/simple/cm_data.c
+++ b/simple/cm_data.c
@@ -290,6 +290,7 @@ static int client_expect_reject(size_t paramlen)
 		return ret;
 	}
 
+	memset(&err_entry, 0, sizeof(err_entry));
 	ret = fi_eq_readerr(eq, &err_entry, 0);
 	if (ret != sizeof(err_entry)) {
 		FT_EQ_ERR(eq, err_entry, NULL, 0);

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -60,6 +60,7 @@ check_eq_readerr(struct fid_eq *eq, fid_t fid, void *context, int index)
 	int ret;
 	struct fi_eq_err_entry err_entry;
 
+	memset(&err_entry, 0, sizeof(err_entry));
 	ret = fi_eq_readerr(eq, &err_entry, 0);
 	if (ret != sizeof(err_entry)) {
 		sprintf(err_buf, "fi_eq_readerr ret = %d, %s", ret,


### PR DESCRIPTION
Fixed problem with CQ/EQ error reading, if passes fi_[cq|eq]_err_entry that is statically
allocated variable and not memset'ed by zero.

After implementation of CQ/EQ application's error buffer (if err_data_size of
fi_[cq|eq]_err_entry is not a zero, provider will use APP's buffer as much as
it's possible). In case of statically allocated structure, garbage contains
in its fields (err_data_size isn't a zero, but some positive value), provider
will fill error informatiuon to buffer that is not actually provided by
application (i.e. write/read unitialized and invalid buffer). This behavior
leads to crash of process.

Solution is just to memset fi_[cq|eq]_err_entry variables by zero to avoid
mentioned above behavior. Since test are not expected to provide some its own
buffer for error reporting, it should be enough (the old behavior is used in
this case)

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>