### PR TITLE
complex/fi_ubertest: add atomic testing

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -38,6 +38,7 @@
 #include <sys/wait.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <complex.h>
 
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
@@ -1087,6 +1088,42 @@ int size_to_count(int size)
 		return (opts.options & FT_OPT_BW) ? 2000 : 1000;
 	else
 		return (opts.options & FT_OPT_BW) ? 20000: 10000;
+}
+
+size_t datatype_to_size(enum fi_datatype datatype)
+{
+	switch (datatype) {
+	case FI_INT8:
+		return sizeof(int8_t);
+	case FI_UINT8:
+		return sizeof(uint8_t);
+	case FI_INT16:
+		return sizeof(int16_t);
+	case FI_UINT16:
+		return sizeof(uint16_t);
+	case FI_INT32:
+		return sizeof(int32_t);
+	case FI_UINT32:
+		return sizeof(uint32_t);
+	case FI_FLOAT:
+		return sizeof(float);
+	case FI_INT64:
+		return sizeof(int64_t);
+	case FI_UINT64:
+		return sizeof(uint64_t);
+	case FI_DOUBLE:
+		return sizeof(double);
+	case FI_FLOAT_COMPLEX:
+		return sizeof(float complex);
+	case FI_DOUBLE_COMPLEX:
+		return sizeof(double complex);
+	case FI_LONG_DOUBLE:
+		return sizeof(long double);
+	case FI_LONG_DOUBLE_COMPLEX:
+		return sizeof(long double complex);
+	default:
+		return 0;
+	}
 }
 
 void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len)

--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -90,6 +90,22 @@ struct ft_xcontrol {
 	uint64_t		remote_cq_data;
 };
 
+struct ft_atomic_control {
+	void			*res_buf;
+	struct fid_mr		*res_mr;
+	void			*res_memdesc;
+	void			*comp_buf;
+	struct fid_mr		*comp_mr;
+	void			*comp_memdesc;
+	struct fi_ioc		*ioc;
+	struct fi_ioc		*res_ioc;
+	struct fi_ioc		*comp_ioc;
+	enum fi_op		op;
+	enum fi_datatype	datatype;
+	size_t			count;
+	size_t			datatype_size;
+};
+
 struct ft_mr_control {
 	void			*buf;
 	struct fid_mr		*mr;
@@ -110,6 +126,7 @@ struct ft_control {
 extern struct ft_xcontrol ft_rx_ctrl, ft_tx_ctrl;
 extern struct ft_mr_control ft_mr_ctrl;
 extern struct ft_control ft_ctrl;
+extern struct ft_atomic_control ft_atom_ctrl;
 
 enum {
 	FT_MAX_CAPS		= 64,
@@ -151,6 +168,16 @@ enum ft_class_function {
 	FT_FUNC_INJECT_WRITE,
 	FT_FUNC_WRITEDATA,
 	FT_FUNC_INJECT_WRITEDATA,
+	FT_FUNC_ATOMIC,
+	FT_FUNC_ATOMICV,
+	FT_FUNC_ATOMICMSG,
+	FT_FUNC_INJECT_ATOMIC,
+	FT_FUNC_FETCH_ATOMIC,
+	FT_FUNC_FETCH_ATOMICV,
+	FT_FUNC_FETCH_ATOMICMSG,
+	FT_FUNC_COMPARE_ATOMIC,
+	FT_FUNC_COMPARE_ATOMICV,
+	FT_FUNC_COMPARE_ATOMICMSG,
 	FT_MAX_FUNCTIONS	
 };
 
@@ -162,6 +189,7 @@ struct ft_set {
 	char			prov_name[FI_NAME_MAX];
 	enum ft_test_type	test_type[FT_MAX_TEST];
 	enum ft_class_function	class_function[FT_MAX_FUNCTIONS];
+	enum fi_op		op[FI_ATOMIC_OP_LAST];
 	enum fi_ep_type		ep_type[FT_MAX_EP_TYPES];
 	enum fi_av_type		av_type[FT_MAX_AV_TYPES];
 	enum ft_comp_type	comp_type[FT_MAX_COMP];
@@ -180,6 +208,7 @@ struct ft_series {
 	int			cur_set;
 	int			cur_type;
 	int			cur_func;
+	int			cur_op;
 	int			cur_ep;
 	int			cur_av;
 	int			cur_comp;
@@ -194,6 +223,8 @@ struct ft_info {
 	int			test_index;
 	int			test_subindex;
 	enum ft_class_function	class_function;
+	enum fi_op		op;
+	enum fi_datatype	datatype;
 	uint64_t		test_flags;
 	uint64_t		caps;
 	uint64_t		mode;
@@ -241,6 +272,7 @@ int ft_open_passive();
 int ft_enable_comm();
 int ft_post_recv_bufs();
 void ft_format_iov(struct iovec *iov, size_t cnt, char *buf, size_t len);
+void ft_format_iocs(struct iovec *iov);
 void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt);
 
 int ft_recv_msg();

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -222,6 +222,12 @@ static struct key_t keys[] = {
 		.val_size = sizeof(((struct ft_set *)0)->cq_wait_obj) / FT_MAX_WAIT_OBJ,
 	},
 	{
+		.str = "op",
+		.offset = offsetof(struct ft_set, op),
+		.val_type = VAL_NUM,
+		.val_size = sizeof(((struct ft_set *)0)->op) / FI_ATOMIC_OP_LAST,
+	},
+	{
 		.str = "mode",
 		.offset = offsetof(struct ft_set, mode),
 		.val_type = VAL_NUM,
@@ -264,6 +270,18 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_READ, enum ft_class_function, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_READV, enum ft_class_function, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_READMSG, enum ft_class_function, buf);
+
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_ATOMIC, enum ft_class_function, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_ATOMICV, enum ft_class_function, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_ATOMICMSG, enum ft_class_function, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_INJECT_ATOMIC, enum ft_class_function, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_FETCH_ATOMIC, enum ft_class_function, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_FETCH_ATOMICV, enum ft_class_function, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_FETCH_ATOMICMSG, enum ft_class_function, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_COMPARE_ATOMIC, enum ft_class_function, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_COMPARE_ATOMICV, enum ft_class_function, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_COMPARE_ATOMICMSG, enum ft_class_function, buf);
+
 		FT_ERR("Unknown class_function");
 	} else if (!strncmp(key->str, "ep_type", strlen("ep_type"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_EP_MSG, enum fi_ep_type, buf);
@@ -287,6 +305,27 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FI_WAIT_FD, enum fi_wait_obj, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_WAIT_MUTEX_COND, enum fi_wait_obj, buf);
 		FT_ERR("Unknown (eq/cq)_wait_obj");
+	} else if (!strncmp(key->str, "op", strlen("atomic_op"))) {
+		TEST_ENUM_SET_N_RETURN(str, len, FI_MIN, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_MAX, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_SUM, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_PROD, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_LOR, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_LAND, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_BOR, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_BAND, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_LXOR, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_BXOR, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_ATOMIC_READ, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_ATOMIC_WRITE, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_CSWAP, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_CSWAP_NE, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_CSWAP_LE, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_CSWAP_LT, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_CSWAP_GE, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_CSWAP_GT, enum fi_op, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_MSWAP, enum fi_op, buf);
+		FT_ERR("Unknown op");
 	} else {
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_QUEUE, enum ft_comp_type, buf);
 		TEST_SET_N_RETURN(str, len, "FT_MODE_ALL", FT_MODE_ALL, uint64_t, buf);
@@ -575,6 +614,10 @@ void fts_next(struct ft_series *series)
 		return;
 	series->cur_func = 0;
 
+	if (set->op[++series->cur_op])
+		return;
+	series->cur_op = 0;
+
 	if (set->comp_type[++series->cur_comp])
 		return;
 	series->cur_comp = 0;
@@ -623,6 +666,7 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->test_type = set->test_type[series->cur_type];
 	info->test_index = series->test_index;
 	info->class_function = set->class_function[series->cur_func];
+	info->op = set->op[series->cur_op];
 	info->test_flags = set->test_flags;
 	info->caps = set->caps[series->cur_caps];
 	info->mode = (set->mode[series->cur_mode] == FT_MODE_NONE) ?

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -49,6 +49,7 @@ struct ft_info test_info;
 struct fi_info *fabric_info;
 struct ft_xcontrol ft_rx_ctrl, ft_tx_ctrl;
 struct ft_mr_control ft_mr_ctrl;
+struct ft_atomic_control ft_atom_ctrl;
 struct ft_control ft_ctrl;
 
 size_t recv_size, send_size;
@@ -120,6 +121,26 @@ static char *ft_class_func_str(enum ft_class_function enum_str)
 		return "writedata";
 	case FT_FUNC_INJECT_WRITEDATA:
 		return "inject_writedata";
+	case FT_FUNC_ATOMIC:
+		return "atomic";
+	case FT_FUNC_ATOMICV:
+		return "atomicv";
+	case FT_FUNC_ATOMICMSG:
+		return "atomic_msg";
+	case FT_FUNC_INJECT_ATOMIC:
+		return "inject_atomic";
+	case FT_FUNC_FETCH_ATOMIC:
+		return "fetch_atomic";
+	case FT_FUNC_FETCH_ATOMICV:
+		return "fetch_atomicv";
+	case FT_FUNC_FETCH_ATOMICMSG:
+		return "fetch_atomicmsg";
+	case FT_FUNC_COMPARE_ATOMIC:
+		return "compare_atomic";
+	case FT_FUNC_COMPARE_ATOMICV:
+		return "compare_atomicv";
+	case FT_FUNC_COMPARE_ATOMICMSG:
+		return "compare_atomicmsg";
 	default:
 		return "func_unspec";
 	}
@@ -147,7 +168,12 @@ static void ft_show_test_info(void)
 {
 	printf("[%s,", test_info.prov_name);
 	printf(" %s,", ft_test_type_str(test_info.test_type));
-	printf(" %s,", ft_class_func_str(test_info.class_function));
+	if (test_info.class_function >= FT_FUNC_ATOMIC) {
+		printf(" %s (%s),", ft_class_func_str(test_info.class_function),
+			fi_tostr(&test_info.op, FI_TYPE_ATOMIC_OP));
+	} else {
+		printf(" %s,", ft_class_func_str(test_info.class_function));
+	}
 	printf(" %s,", fi_tostr(&test_info.ep_type, FI_TYPE_EP_TYPE));
 	printf(" %s,", fi_tostr(&test_info.av_type, FI_TYPE_AV_TYPE));
 	printf(" eq_%s,", ft_wait_obj_str(test_info.eq_wait_obj));

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -304,6 +304,152 @@ static int ft_post_send_rma(void)
 	return ret;
 }
 
+int ft_post_send_atomic(void)
+{
+	int ret, i;
+	struct fi_msg_atomic msg;
+	struct fi_rma_ioc rma_iov;
+	size_t iov_count = ft_ctrl.iov_array[ft_tx_ctrl.iov_iter];
+
+	switch (test_info.class_function) {
+	case FT_FUNC_ATOMICV:
+		ft_format_iocs(ft_tx_ctrl.iov);
+		ft_send_retry(ret, fi_atomicv, ft_tx_ctrl.ep, ft_atom_ctrl.ioc,
+			ft_tx_ctrl.iov_desc, iov_count, ft_tx_ctrl.addr,
+			0, ft_mr_ctrl.mr_key, ft_atom_ctrl.datatype,
+			ft_atom_ctrl.op,  NULL);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
+		ft_tx_ctrl.credits--;
+		break;
+	case FT_FUNC_ATOMICMSG:
+		ft_format_iocs(ft_tx_ctrl.iov);
+		msg.msg_iov = ft_atom_ctrl.ioc;
+		msg.desc = ft_tx_ctrl.iov_desc;
+		msg.iov_count = iov_count;
+		msg.addr = ft_tx_ctrl.addr;
+		msg.context = NULL;
+		msg.data = 0;
+		msg.op = ft_atom_ctrl.op;
+		msg.datatype = ft_atom_ctrl.datatype;
+
+		rma_iov.addr = 0;
+		rma_iov.key = ft_mr_ctrl.mr_key;
+
+		for (i = 0, rma_iov.count = 0; i < msg.iov_count; i++)
+			rma_iov.count += ft_atom_ctrl.ioc[i].count;
+
+		msg.rma_iov = &rma_iov;
+		msg.rma_iov_count = 1;
+		ft_send_retry(ret, fi_atomicmsg, ft_tx_ctrl.ep, &msg, 0);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
+		ft_tx_ctrl.credits--;
+		break;
+	case FT_FUNC_FETCH_ATOMIC:
+		ft_send_retry(ret, fi_fetch_atomic, ft_tx_ctrl.ep,
+			ft_tx_ctrl.buf, ft_atom_ctrl.count, ft_tx_ctrl.memdesc,
+			ft_atom_ctrl.res_buf, ft_atom_ctrl.res_memdesc,
+			ft_tx_ctrl.addr, 0, ft_mr_ctrl.mr_key,
+			ft_atom_ctrl.datatype, ft_atom_ctrl.op, NULL);
+		ft_tx_ctrl.credits--;
+		break;
+	case FT_FUNC_FETCH_ATOMICV:
+		ft_format_iocs(ft_tx_ctrl.iov);
+		ft_send_retry(ret, fi_fetch_atomicv, ft_tx_ctrl.ep,
+			ft_atom_ctrl.ioc, ft_tx_ctrl.iov_desc, iov_count,
+			ft_atom_ctrl.res_ioc, ft_atom_ctrl.res_memdesc, iov_count,
+			ft_tx_ctrl.addr, 0, ft_mr_ctrl.mr_key,
+			ft_atom_ctrl.datatype, ft_atom_ctrl.op,  NULL);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
+		ft_tx_ctrl.credits--;
+		break;
+	case FT_FUNC_FETCH_ATOMICMSG:
+		ft_format_iocs(ft_tx_ctrl.iov);
+		msg.msg_iov = ft_atom_ctrl.ioc;
+		msg.desc = ft_tx_ctrl.iov_desc;
+		msg.iov_count = iov_count;
+		msg.addr = ft_tx_ctrl.addr;
+		msg.context = NULL;
+		msg.data = 0;
+		msg.op = ft_atom_ctrl.op;
+		msg.datatype = ft_atom_ctrl.datatype;
+
+		rma_iov.addr = 0;
+		rma_iov.key = ft_mr_ctrl.mr_key;
+
+		for (i = 0, rma_iov.count = 0; i < msg.iov_count; i++)
+			rma_iov.count += ft_atom_ctrl.ioc[i].count;
+
+		msg.rma_iov = &rma_iov;
+		msg.rma_iov_count = 1;
+
+		ft_send_retry(ret, fi_fetch_atomicmsg, ft_tx_ctrl.ep, &msg,
+			ft_atom_ctrl.res_ioc, ft_atom_ctrl.res_memdesc,
+			iov_count, 0);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
+		ft_tx_ctrl.credits--;
+		break;
+	case FT_FUNC_COMPARE_ATOMIC:
+		ft_send_retry(ret, fi_compare_atomic, ft_tx_ctrl.ep,
+			ft_tx_ctrl.buf, ft_atom_ctrl.count, ft_tx_ctrl.memdesc,
+			ft_atom_ctrl.comp_buf, ft_atom_ctrl.comp_memdesc,
+			ft_atom_ctrl.res_buf, ft_atom_ctrl.res_memdesc,
+			ft_tx_ctrl.addr, 0, ft_mr_ctrl.mr_key,
+			ft_atom_ctrl.datatype, ft_atom_ctrl.op, NULL);
+		ft_tx_ctrl.credits--;
+		break;
+	case FT_FUNC_COMPARE_ATOMICV:
+		ft_format_iocs(ft_tx_ctrl.iov);
+		ft_send_retry(ret, fi_compare_atomicv, ft_tx_ctrl.ep,
+			ft_atom_ctrl.ioc, ft_tx_ctrl.iov_desc, iov_count,
+			ft_atom_ctrl.comp_ioc, ft_atom_ctrl.comp_memdesc, iov_count,
+			ft_atom_ctrl.res_ioc, ft_atom_ctrl.res_memdesc,
+			iov_count, ft_tx_ctrl.addr, 0, ft_mr_ctrl.mr_key,
+			ft_atom_ctrl.datatype, ft_atom_ctrl.op,  NULL);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
+		ft_tx_ctrl.credits--;
+		break;
+	case FT_FUNC_COMPARE_ATOMICMSG:
+		ft_format_iocs(ft_tx_ctrl.iov);
+		msg.msg_iov = ft_atom_ctrl.ioc;
+		msg.desc = ft_tx_ctrl.iov_desc;
+		msg.iov_count = iov_count;
+		msg.addr = ft_tx_ctrl.addr;
+		msg.context = NULL;
+		msg.data = 0;
+		msg.op = ft_atom_ctrl.op;
+		msg.datatype = ft_atom_ctrl.datatype;
+
+		rma_iov.addr = 0;
+		rma_iov.key = ft_mr_ctrl.mr_key;
+
+		for (i = 0, rma_iov.count = 0; i < msg.iov_count; i++)
+			rma_iov.count += ft_atom_ctrl.ioc[i].count;
+
+		msg.rma_iov = &rma_iov;
+		msg.rma_iov_count = 1;
+
+		ft_send_retry(ret, fi_compare_atomicmsg, ft_tx_ctrl.ep, &msg,
+			ft_atom_ctrl.comp_ioc, ft_atom_ctrl.comp_memdesc, iov_count,
+			ft_atom_ctrl.res_ioc, ft_atom_ctrl.res_memdesc,
+			iov_count, 0);
+		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
+		ft_tx_ctrl.credits--;
+		break;
+	case FT_FUNC_INJECT_ATOMIC:
+		ft_send_retry(ret, fi_inject_atomic, ft_tx_ctrl.ep,
+			ft_tx_ctrl.buf, ft_atom_ctrl.count, ft_tx_ctrl.addr, 0,
+			ft_mr_ctrl.mr_key, ft_atom_ctrl.datatype, ft_atom_ctrl.op);
+		break;
+	default:
+		ft_send_retry(ret, fi_atomic, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
+				ft_atom_ctrl.count, ft_tx_ctrl.memdesc,
+				ft_tx_ctrl.addr, 0, ft_mr_ctrl.mr_key,
+				ft_atom_ctrl.datatype, ft_atom_ctrl.op, NULL);
+		ft_tx_ctrl.credits--;
+	}
+	return ret;
+}
+
 int ft_send_rma(void)
 {
 	int ret;
@@ -313,8 +459,12 @@ int ft_send_rma(void)
 		if (ret)
 			return ret;
 	}
-	
-	ret = ft_post_send_rma();
+
+	if (test_info.caps & FI_ATOMIC)
+		ret = ft_post_send_atomic();
+	else 	
+		ret = ft_post_send_rma();
+
 	if (ret) {
 		FT_PRINTERR("send_rma", ret);
 		return ret;

--- a/include/shared.h
+++ b/include/shared.h
@@ -230,7 +230,7 @@ int ft_read_addr_opts(char **node, char **service, struct fi_info *hints,
 char *size_str(char str[FT_STR_LEN], long long size);
 char *cnt_str(char str[FT_STR_LEN], long long cnt);
 int size_to_count(int size);
-
+size_t datatype_to_size(enum fi_datatype datatype);
 
 #define FT_PRINTERR(call, retv) \
 	do { fprintf(stderr, call "(): %s:%d, ret=%d (%s)\n", __FILE__, __LINE__, \

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -30,7 +30,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
-#include <complex.h>
 
 #include <rdma/fi_errno.h>
 #include <rdma/fi_atomic.h>
@@ -92,27 +91,6 @@ static enum fi_op get_fi_op(char *op) {
 	else {
 		fprintf(stderr, "Not a valid atomic operation\n");
 		return FI_ATOMIC_OP_LAST;
-	}
-}
-
-static inline size_t datatype_to_size(enum fi_datatype datatype)
-{
-        switch (datatype) {
-	case FI_INT8:   return sizeof(int8_t);
-	case FI_UINT8:  return sizeof(uint8_t);
-	case FI_INT16:  return sizeof(int16_t);
-	case FI_UINT16: return sizeof(uint16_t);
-	case FI_INT32:  return sizeof(int32_t);
-	case FI_UINT32: return sizeof(uint32_t);
-	case FI_FLOAT:  return sizeof(float);
-	case FI_INT64:  return sizeof(int64_t);
-	case FI_UINT64: return sizeof(uint64_t);
-	case FI_DOUBLE: return sizeof(double);
-	case FI_FLOAT_COMPLEX: return sizeof(float complex);
-	case FI_DOUBLE_COMPLEX: return sizeof(double complex);
-	case FI_LONG_DOUBLE: return sizeof(long double);
-	case FI_LONG_DOUBLE_COMPLEX: return sizeof(long double complex);
-	default:        return 0;
 	}
 }
 

--- a/test_configs/sockets/quick.test
+++ b/test_configs/sockets/quick.test
@@ -138,3 +138,127 @@
 	],
 	test_flags: FT_FLAG_QUICKTEST
 },
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_ATOMIC,
+		FT_FUNC_ATOMICV,
+		FT_FUNC_ATOMICMSG,
+		FT_FUNC_INJECT_ATOMIC,
+	],
+	op:[
+		FI_MIN,
+		FI_MAX,
+		FI_SUM,
+		FI_PROD,
+		FI_LOR,
+		FI_LAND,
+		FI_BOR,
+		FI_BAND,
+		FI_LXOR,
+		FI_BXOR,
+		FI_ATOMIC_WRITE,
+	],
+	ep_type: [
+		FI_EP_MSG,
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	caps: [
+		FT_CAP_ATOMIC,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_FETCH_ATOMIC,
+		FT_FUNC_FETCH_ATOMICV,
+		FT_FUNC_FETCH_ATOMICMSG,
+	],
+	op:[
+		FI_MIN,
+		FI_MAX,
+		FI_SUM,
+		FI_PROD,
+		FI_LOR,
+		FI_LAND,
+		FI_BOR,
+		FI_BAND,
+		FI_LXOR,
+		FI_BXOR,
+		FI_ATOMIC_READ,
+		FI_ATOMIC_WRITE,
+	],
+	ep_type: [
+		FI_EP_MSG,
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	caps: [
+		FT_CAP_ATOMIC,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_COMPARE_ATOMIC,
+		FT_FUNC_COMPARE_ATOMICV,
+		FT_FUNC_COMPARE_ATOMICMSG,
+	],
+	op:[
+		FI_CSWAP,
+		FI_CSWAP_NE,
+		FI_CSWAP_LE,
+		FI_CSWAP_LT,
+		FI_CSWAP_GE,
+		FI_CSWAP_GT,
+		FI_MSWAP,
+	],
+	ep_type: [
+		FI_EP_MSG,
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	caps: [
+		FT_CAP_ATOMIC,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},


### PR DESCRIPTION
Enable atomic testing in ubertest, including all functions, operations, and datatypes.

Signed-off-by: aingerson <alexia.ingerson@intel.com>