### PR TITLE
Updates to getinfo unit test

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -2165,3 +2165,50 @@ void ft_sock_shutdown(int fd)
 	close(fd);
 }
 
+static int ft_has_util_prefix(const char *str)
+{
+	return !strncasecmp(str, OFI_UTIL_PREFIX, strlen(OFI_UTIL_PREFIX));
+}
+
+const char *ft_util_name(const char *str, size_t *len)
+{
+	char *delim;
+
+	delim = strchr(str, OFI_NAME_DELIM);
+	if (delim) {
+		if (ft_has_util_prefix(delim + 1)) {
+			*len = strlen(delim + 1);
+			return delim + 1;
+		} else if (ft_has_util_prefix(str)) {
+			*len = delim - str;
+			return str;
+		}
+	} else if (ft_has_util_prefix(str)) {
+		*len = strlen(str);
+		return str;
+	}
+	*len = 0;
+	return NULL;
+}
+
+const char *ft_core_name(const char *str, size_t *len)
+{
+	char *delim;
+
+	delim = strchr(str, OFI_NAME_DELIM);
+	if (delim) {
+		if (!ft_has_util_prefix(delim + 1)) {
+			*len = strlen(delim + 1);
+			return delim + 1;
+		} else if (!ft_has_util_prefix(str)) {
+			*len = delim - str;
+			return str;
+		}
+	} else if (!ft_has_util_prefix(str)) {
+		*len = strlen(str);
+		return str;
+	}
+	*len = 0;
+	return NULL;
+
+}

--- a/include/shared.h
+++ b/include/shared.h
@@ -58,6 +58,8 @@ extern "C" {
 #include "freebsd/osd.h"
 #endif
 
+#define OFI_UTIL_PREFIX "ofi-"
+#define OFI_NAME_DELIM ';'
 
 /* exit codes must be 0-255 */
 static inline int ft_exit_code(int ret)
@@ -359,6 +361,8 @@ uint64_t ft_info_to_mr_access(struct fi_info *info);
 int ft_alloc_bit_combo(uint64_t fixed, uint64_t opt, uint64_t **combos, int *len);
 void ft_free_bit_combo(uint64_t *combo);
 int ft_cntr_open(struct fid_cntr **cntr);
+const char *ft_util_name(const char *str, size_t *len);
+const char *ft_core_name(const char *str, size_t *len);
 
 #define FT_PROCESS_QUEUE_ERR(readerr, rd, queue, fn, str)	\
 	do {							\

--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -41,6 +41,9 @@
 #include "shared.h"
 #include "unit_common.h"
 
+#define TEST_ENTRY_GETINFO(name) TEST_ENTRY(getinfo_ ## name,\
+					    getinfo_ ## name ## _desc)
+
 typedef int (*ft_getinfo_init)(struct fi_info *);
 typedef int (*ft_getinfo_check)(void *);
 
@@ -132,10 +135,10 @@ out:
 	return ret;
 }
 
-#define getinfo_test(num, desc, node, service, flags, hints, init, check,	\
+#define getinfo_test(name, num, desc, node, service, flags, hints, init, check,	\
 		ret_exp)							\
-char *getinfo ## num ## _desc = desc;						\
-static int getinfo ## num(void)							\
+char *getinfo_ ## name ## num ## _desc = desc;					\
+static int getinfo_ ## name ## num(void)					\
 {										\
 	int ret, testret = FAIL;						\
 	ret = getinfo_unit_test(node, service, flags, hints, init, check,	\
@@ -159,47 +162,47 @@ fail:										\
  */
 
 /* 1.1 Source address only tests */
-getinfo_test(1, "Test with no node, service, flags or hints",
+getinfo_test(no_hints, 1, "Test with no node, service, flags or hints",
 		NULL, NULL, 0, NULL, NULL, check_srcaddr, 0)
-getinfo_test(2, "Test with node, no service, FI_SOURCE flag and no hints",
+getinfo_test(no_hints, 2, "Test with node, no service, FI_SOURCE flag and no hints",
 		opts.src_addr ? opts.src_addr : "localhost", NULL, FI_SOURCE,
 		NULL, NULL, check_srcaddr, 0)
-getinfo_test(3, "Test with service, FI_SOURCE flag and no node or hints",
+getinfo_test(no_hints, 3, "Test with service, FI_SOURCE flag and no node or hints",
 		 NULL, opts.src_port, FI_SOURCE, NULL, NULL,
 		 check_srcaddr, 0)	// TODO should we check for wildcard addr?
-getinfo_test(4, "Test with node, service, FI_SOURCE flags and no hints",
+getinfo_test(no_hints, 4, "Test with node, service, FI_SOURCE flags and no hints",
 		opts.src_addr ? opts.src_addr : "localhost", opts.src_port,
 		FI_SOURCE, NULL, NULL, check_srcaddr, 0)
 
 /* 1.2 Source and destination address tests */
-getinfo_test(5, "Test with node, service and no hints",
+getinfo_test(no_hints, 5, "Test with node, service and no hints",
 		opts.dst_addr ? opts.dst_addr : "localhost", opts.dst_port,
 		0, NULL, NULL, check_src_dest_addr, 0)
 
 /* 2. Test with hints */
 /* 2.1 Source address only tests */
-getinfo_test(6, "Test with no node, service, or flags",
+getinfo_test(src, 1, "Test with no node, service, or flags",
 		NULL, NULL, 0, hints, NULL, check_srcaddr, 0)
-getinfo_test(7, "Test with node, no service, FI_SOURCE flag",
+getinfo_test(src, 2, "Test with node, no service, FI_SOURCE flag",
 		opts.src_addr ? opts.src_addr : "localhost", NULL, FI_SOURCE,
 		hints, NULL, check_srcaddr, 0)
-getinfo_test(8, "Test with service, FI_SOURCE flag and no node",
+getinfo_test(src, 3, "Test with service, FI_SOURCE flag and no node",
 		 NULL, opts.src_port, FI_SOURCE, hints, NULL,
 		 check_srcaddr, 0)	// TODO should we check for wildcard addr?
-getinfo_test(9, "Test with node, service, FI_SOURCE flags",
+getinfo_test(src, 4, "Test with node, service, FI_SOURCE flags",
 		opts.src_addr ? opts.src_addr : "localhost", opts.src_port,
 		FI_SOURCE, hints, NULL, check_srcaddr, 0)
 
 /* 2.2 Source and destination address tests */
-getinfo_test(10, "Test with node, service",
+getinfo_test(src_dest, 1, "Test with node, service",
 		opts.dst_addr ? opts.dst_addr : "localhost", opts.dst_port,
 		0, hints, NULL, check_src_dest_addr, 0)
 
-getinfo_test(11, "Test API version",
+getinfo_test(src_dest, 2, "Test API version",
 		NULL, NULL, 0, hints, NULL, check_api_version ,0)
 
 /* Negative tests */
-getinfo_test(12, "Test with non-existent domain name",
+getinfo_test(neg, 1, "Test with non-existent domain name",
 		NULL, NULL, 0, hints, invalid_dom, NULL, -FI_ENODATA)
 
 static void usage(void)
@@ -229,22 +232,22 @@ int main(int argc, char **argv)
 	int op;
 
 	struct test_entry no_hint_tests[] = {
-		TEST_ENTRY(getinfo1, getinfo1_desc),
-		TEST_ENTRY(getinfo2, getinfo2_desc),
-		TEST_ENTRY(getinfo3, getinfo3_desc),
-		TEST_ENTRY(getinfo4, getinfo4_desc),
-		TEST_ENTRY(getinfo5, getinfo5_desc),
+		TEST_ENTRY_GETINFO(no_hints1),
+		TEST_ENTRY_GETINFO(no_hints2),
+		TEST_ENTRY_GETINFO(no_hints3),
+		TEST_ENTRY_GETINFO(no_hints4),
+		TEST_ENTRY_GETINFO(no_hints5),
 		{ NULL, "" }
 	};
 
 	struct test_entry hint_tests[] = {
-		TEST_ENTRY(getinfo6, getinfo6_desc),
-		TEST_ENTRY(getinfo7, getinfo7_desc),
-		TEST_ENTRY(getinfo8, getinfo8_desc),
-		TEST_ENTRY(getinfo9, getinfo9_desc),
-		TEST_ENTRY(getinfo10, getinfo10_desc),
-		TEST_ENTRY(getinfo11, getinfo11_desc),
-		TEST_ENTRY(getinfo12, getinfo12_desc),
+		TEST_ENTRY_GETINFO(src1),
+		TEST_ENTRY_GETINFO(src2),
+		TEST_ENTRY_GETINFO(src3),
+		TEST_ENTRY_GETINFO(src4),
+		TEST_ENTRY_GETINFO(src_dest1),
+		TEST_ENTRY_GETINFO(src_dest2),
+		TEST_ENTRY_GETINFO(neg1),
 		{ NULL, "" }
 	};
 


### PR DESCRIPTION
- 	unit: Add short names to getinfo tests
- 	unit: Add a getinfo unit test for testing utility providers
- Also fix setting FI_PROVIDER env variable. If the user passed an utility
provider for prov_name we shouldn't filter out core providers unless a
core provider is also specified

The getinfo unit test for utility providers would fail until https://github.com/ofiwg/libfabric/issues/2892 is fixed.