### PR TITLE
complex: Fix coverity issue - Unused value of ret after ft_send_rma()

### DIFF
--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -648,6 +648,8 @@ static int ft_bw_atomic(void)
 
 			for (i = 0; i < ft_ctrl.xfer_iter; i++) {
 				ret = ft_send_rma();
+				if (ret)
+					return ret;
 			}
 		}
 		ret = ft_send_msg();


### PR DESCRIPTION

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>