### PR TITLE
complex/fi_ubertest: add FI_CONTEXT

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -88,6 +88,8 @@ struct ft_xcontrol {
 	enum fi_cq_format	cq_format;
 	enum fi_wait_obj	comp_wait;  /* must be NONE */
 	uint64_t		remote_cq_data;
+	struct fi_context	*ctx;
+	int			curr_ctx;
 };
 
 struct ft_atomic_control {
@@ -274,6 +276,7 @@ int ft_post_recv_bufs();
 void ft_format_iov(struct iovec *iov, size_t cnt, char *buf, size_t len);
 void ft_format_iocs(struct iovec *iov);
 void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt);
+int ft_get_ctx(struct ft_xcontrol *ctrl, struct fi_context **ctx);
 
 int ft_recv_msg();
 int ft_send_msg();

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -38,7 +38,7 @@
 #define FT_CAP_RMA	FI_RMA | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE
 #define FT_CAP_ATOMIC	FI_ATOMICS | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE
 
-#define FT_MODE_ALL	/*FI_CONTEXT |*/ FI_LOCAL_MR /*| FI_MSG_PREFIX*/
+#define FT_MODE_ALL	FI_CONTEXT | FI_LOCAL_MR /*| FI_MSG_PREFIX*/
 #define FT_MODE_NONE	~0ULL
 
 struct key_t {
@@ -329,6 +329,7 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 	} else {
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_QUEUE, enum ft_comp_type, buf);
 		TEST_SET_N_RETURN(str, len, "FT_MODE_ALL", FT_MODE_ALL, uint64_t, buf);
+		TEST_SET_N_RETURN(str, len, "FT_MODE_NONE", FT_MODE_NONE, uint64_t, buf);
 		TEST_SET_N_RETURN(str, len, "FT_FLAG_QUICKTEST", FT_FLAG_QUICKTEST, uint64_t, buf);
 		FT_ERR("Unknown comp_type/mode/test_flags");
 	}

--- a/test_configs/sockets/quick.test
+++ b/test_configs/sockets/quick.test
@@ -26,6 +26,7 @@
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	caps: [
 		FT_CAP_MSG,
@@ -61,6 +62,7 @@
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	caps: [
 		FT_CAP_MSG,
@@ -97,6 +99,7 @@
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	caps: [
 		FT_CAP_MSG,
@@ -132,6 +135,7 @@
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	caps: [
 		FT_CAP_RMA,
@@ -175,6 +179,7 @@
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	caps: [
 		FT_CAP_ATOMIC,
@@ -218,6 +223,7 @@
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	caps: [
 		FT_CAP_ATOMIC,
@@ -256,6 +262,7 @@
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	caps: [
 		FT_CAP_ATOMIC,


### PR DESCRIPTION
Enhancements to mode bit testing, specifically addition of FI_CONTEXT support

Signed-off-by: aingerson <alexia.ingerson@intel.com>