### PR TITLE
rdm_atomic: Fix print statement

### DIFF
--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -124,9 +124,9 @@ static int check_base_atomic_op(enum fi_op op, enum fi_datatype datatype)
 
 	ret = fi_atomicvalid(ep, datatype, op, count);
 	if (ret) {
-		fprintf(stderr, "Provider doesn't support %s "
-			"base atomic operation on %s\n",
-			fi_tostr(&op, FI_TYPE_ATOMIC_OP),
+		fprintf(stderr, "Provider doesn't support %s ",
+			fi_tostr(&op, FI_TYPE_ATOMIC_OP));
+		fprintf(stderr, "base atomic operation on %s\n",
 			fi_tostr(&datatype, FI_TYPE_ATOMIC_TYPE));
 		return ret;
 	}


### PR DESCRIPTION
fi_tostr returns a static string that gets overwritten by
multiple calls to it.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>