### PR TITLE
streaming/rdm_atomic: change return check to run all ops

### DIFF
--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -337,8 +337,10 @@ static int run_ops(void)
 
 	for (op_type = FI_MIN; op_type < FI_ATOMIC_OP_LAST; op_type++) {
 		ret = run_op();
-		if (ret != -FI_ENOSYS && ret != -FI_EOPNOTSUPP)
+		if (ret && ret != -FI_ENOSYS && ret != -FI_EOPNOTSUPP) {
+			FT_PRINTERR("run_op", ret);
 			return ret;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Test will return if last datatype tested returns in success, skipping the rest of the tests. Change so that test only returns on actual error.

Signed-off-by: aingerson <alexia.ingerson@intel.com>