### PR TITLE
Add support to correctly progress CQ for inject operations

### DIFF
--- a/benchmarks/rma_bw.c
+++ b/benchmarks/rma_bw.c
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
 
 	hints->caps = FI_MSG | FI_RMA;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
-	hints->mode = FI_LOCAL_MR | FI_RX_CQ_DATA;
+	hints->mode = FI_CONTEXT | FI_LOCAL_MR | FI_RX_CQ_DATA;
 
 	ret = run();
 

--- a/common/shared.c
+++ b/common/shared.c
@@ -1151,6 +1151,8 @@ void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len)
 				return ret;					\
 			}							\
 										\
+			if (fi->domain_attr->data_progress == FI_PROGRESS_AUTO)	\
+				continue;					\
 			timeout_save = timeout;					\
 			timeout = 0;						\
 			rc = comp_fn(seq);					\


### PR DESCRIPTION
- 	Add missing FI_CONTEXT support in rma tests
-	common: Skip progressing if the provider supports auto progress
-	common: Add a function to progress the CQ for inject operations 