### PR TITLE
common: Fix null pointer dereference of txcq (found by coverity).

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1151,7 +1151,7 @@ static int ft_inject_progress(uint64_t total)
 		if (ret > 0)
 			tx_cq_cntr++;
 	} else if (txcntr) {
-		ret = fi_cntr_wait(txcntr, total, 0);
+		return fi_cntr_wait(txcntr, total, 0);
 	} else {
 		return -FI_ENOCQ;
 	}


### PR DESCRIPTION
Return after fi_cntr_wait. No need to check for any errors. The caller
would handle those.