### PR TITLE
common: Update rma tests to check for FI_RX_CQ_DATA before posting a recv

### DIFF
--- a/benchmarks/benchmark_shared.c
+++ b/benchmarks/benchmark_shared.c
@@ -265,7 +265,15 @@ int bandwidth_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 			break;
 		case FT_RMA_WRITEDATA:
 			if (!opts.dst_addr) {
-				ret = ft_post_rx(ep, 0, &tx_ctx_arr[j]);
+				if (fi->rx_attr->mode & FI_RX_CQ_DATA)
+					ret = ft_post_rx(ep, 0, &tx_ctx_arr[j]);
+				else
+					/* Just increment the seq # instead of
+					 * posting recv so that we wait for
+					 * remote write completion on the next
+					 * iteration */
+					rx_seq++;
+
 			} else {
 				if (opts.transfer_size < fi->tx_attr->inject_size) {
 					ret = ft_post_rma_inject(FT_RMA_WRITEDATA,

--- a/common/shared.c
+++ b/common/shared.c
@@ -1294,7 +1294,15 @@ ssize_t ft_rma(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
 		return ret;
 
 	if (op == FT_RMA_WRITEDATA) {
-		ret = ft_rx(ep, 0);
+		if (fi->rx_attr->mode & FI_RX_CQ_DATA) {
+			ret = ft_rx(ep, 0);
+		} else {
+			ret = ft_get_rx_comp(rx_seq);
+			/* Just increment the seq # instead of posting recv so
+			 * that we wait for remote write completion on the next
+			 * iteration. */
+			rx_seq++;
+		}
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
Don't post recv on the recipient side of rma write with immediate data, if provider doesn't require FI_RX_CQ_DATA mode.