### PR TITLE
complex/fi_ubertest: psm/psm2 suppport

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,7 +61,9 @@ nobase_dist_config_DATA = \
         test_configs/verbs/all.test \
         test_configs/verbs/quick.test \
 	test_configs/usnic/all.test \
-	test_configs/usnic/quick.test
+	test_configs/usnic/quick.test \
+	test_configs/psm/all.test \
+	test_configs/psm2/all.test
 
 noinst_LTLIBRARIES = libfabtests.la
 libfabtests_la_SOURCES = \

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -669,7 +669,7 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->class_function = set->class_function[series->cur_func];
 	info->op = set->op[series->cur_op];
 	info->test_flags = set->test_flags;
-	info->caps = set->caps[series->cur_caps];
+	info->caps = set->caps[series->cur_caps] | FT_CAP_MSG;
 	info->mode = (set->mode[series->cur_mode] == FT_MODE_NONE) ?
 			0 : set->mode[series->cur_mode];
 	info->ep_type = set->ep_type[series->cur_ep];

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -669,7 +669,9 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->class_function = set->class_function[series->cur_func];
 	info->op = set->op[series->cur_op];
 	info->test_flags = set->test_flags;
-	info->caps = set->caps[series->cur_caps] | FT_CAP_MSG;
+	info->caps = set->caps[series->cur_caps];
+	if (info->caps & (FT_CAP_RMA | FT_CAP_ATOMIC))
+		info->caps |= FT_CAP_MSG;
 	info->mode = (set->mode[series->cur_mode] == FT_MODE_NONE) ?
 			0 : set->mode[series->cur_mode];
 	info->ep_type = set->ep_type[series->cur_ep];

--- a/complex/ft_endpoint.c
+++ b/complex/ft_endpoint.c
@@ -88,10 +88,12 @@ int ft_open_active(void)
 	ft_rx_ctrl.ep = ep;
 	ft_tx_ctrl.ep = ep;
 
-	ret = fi_ep_bind(ep, &eq->fid, 0);
-	if (ret) {
-		FT_PRINTERR("fi_ep_bind", ret);
-		return ret;
+	if (test_info.ep_type == FI_EP_MSG) {
+		ret = fi_ep_bind(ep, &eq->fid, 0);
+		if (ret) {
+			FT_PRINTERR("fi_ep_bind", ret);
+			return ret;
+		}
 	}
 
 	ret = ft_bind_comp(ep, FI_TRANSMIT | FI_RECV);

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -33,6 +33,7 @@
 #include <time.h>
 #include <netdb.h>
 #include <unistd.h>
+#include <sys/wait.h>
 
 #include <limits.h>
 #include <shared.h>
@@ -282,8 +283,7 @@ static int ft_fw_process_list(struct fi_info *hints, struct fi_info *info)
 		ret = ft_sock_send(sock, &result, sizeof result);
 		if (result) {
 			FT_PRINTERR("ft_run_test", result);
-		}
-		else if (ret) {
+		} else if (ret) {
 			FT_PRINTERR("ft_sock_send", ret);
 			return ret;
 		}
@@ -295,14 +295,53 @@ static int ft_fw_process_list(struct fi_info *hints, struct fi_info *info)
 		return ret;
 	}
 
+	if (subindex == 1)
+		return -FI_ENODATA;
+
 	return 0;
 }
 
-static int ft_fw_server(void)
+static int ft_server_child()
 {
 	struct fi_info *hints, *info;
 	int ret;
 
+	hints = fi_allocinfo();
+	if (!hints)
+		return -FI_ENOMEM;
+
+	ft_fw_convert_info(hints, &test_info);
+	printf("Starting test %d:\n", test_info.test_index);
+
+	ret = fi_getinfo(FT_FIVERSION, ft_strptr(test_info.node),
+			 ft_strptr(test_info.service), FI_SOURCE,
+			 hints, &info);
+	if (ret && ret != -FI_ENODATA) {
+		FT_PRINTERR("fi_getinfo", ret);
+	} else {
+		ret = ft_fw_process_list(hints, info);
+		if (ret != -FI_ENODATA)
+			fi_freeinfo(info);
+
+		if (ret) {
+			FT_PRINTERR("ft_fw_process_list", ret);
+			printf("Node: %s\nService: %s\n",
+				test_info.node, test_info.service);
+			printf("%s\n", fi_tostr(hints, FI_TYPE_INFO));
+		}
+	}
+	fi_freeinfo(hints);
+
+	printf("Ending test %d, result: %s\n", test_info.test_index,
+		fi_strerror(-ret));
+
+	return ret;
+}
+
+static int ft_fw_server(void)
+{
+	int ret;
+	pid_t pid;
 
 	do {
 		ret = ft_sock_recv(sock, &test_info, sizeof test_info);
@@ -317,66 +356,101 @@ static int ft_fw_server(void)
 		test_info.prov_name[sizeof(test_info.prov_name) - 1] = '\0';
 		test_info.fabric_name[sizeof(test_info.fabric_name) - 1] = '\0';
 
-		hints = fi_allocinfo();
-		if (!hints)
-			return -FI_ENOMEM;
-
-		ft_fw_convert_info(hints, &test_info);
-		printf("Starting test %d:\n", test_info.test_index);
-
-		ret = fi_getinfo(FT_FIVERSION, ft_strptr(test_info.node),
-				 ft_strptr(test_info.service), FI_SOURCE,
-				 hints, &info);
-		if (ret && ret != -FI_ENODATA) {
-			FT_PRINTERR("fi_getinfo", ret);
+		pid = fork();
+		if (!pid) {
+			ret = ft_server_child();
+			_exit(-ret);
 		} else {
-			/* fabric_info is replaced when connecting */
-			if (ret == -FI_ENODATA) {
-				info = NULL;
-				results[ft_fw_result_index(FI_ENODATA)]++;
-			}
-
-			ret = ft_fw_process_list(hints, info);
-
-			if (fabric_info != info)
-				fi_freeinfo(fabric_info);
-			fabric_info = NULL;
+			waitpid(pid, &ret, 0);
+			ret = WEXITSTATUS(ret);
 		}
-		fi_freeinfo(info);
 
-		if (ret) {
-			FT_PRINTERR("ft_fw_process_list", ret);
-			printf("Node: %s\nService: %s\n",
+		results[ft_fw_result_index(ret)]++;
+
+	} while (!ret || ret == FI_ENODATA);
+
+	return ret; 
+}
+
+static int ft_client_child(void)
+{
+	struct fi_info *hints, *info;
+	int ret, result, sresult;
+
+	result = -FI_ENODATA;
+	hints = fi_allocinfo();
+	if (!hints)
+		return -FI_ENOMEM;
+
+	ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
+	if (ret)
+		return ret;
+
+	ft_fw_convert_info(hints, &test_info);
+
+	printf("Starting test %d / %d:\n", test_info.test_index,
+		series->test_count);
+	while (!ft_nullstr(test_info.prov_name)) {
+		printf("Starting test %d-%d: ", test_info.test_index,
+			test_info.test_subindex);
+		ft_show_test_info();
+
+		result = fi_getinfo(FT_FIVERSION, ft_strptr(test_info.node),
+				 ft_strptr(test_info.service), 0, hints, &info);
+		if (result) {
+			FT_PRINTERR("fi_getinfo", result);
+		} else if (info->next) {
+			printf("fi_getinfo returned multiple matches\n");
+			ret = -FI_E2BIG;
+		} else {
+			fabric_info = info;
+			result = ft_run_test();
+			fi_freeinfo(info);
+		}
+
+		ret = ft_sock_recv(sock, &sresult, sizeof sresult);
+		if (result) {
+			FT_PRINTERR("ft_run_test", result);
+			fprintf(stderr, "Node: %s\nService: %s \n",
 				test_info.node, test_info.service);
-			printf("%s\n", fi_tostr(hints, FI_TYPE_INFO));
+			fprintf(stderr, "%s\n", fi_tostr(hints, FI_TYPE_INFO));
+			ret = result;
+			goto out;
+		} else if (ret) {
+			FT_PRINTERR("ft_sock_send", ret);
+			goto out;
+		} else if (sresult) {
+			ret = sresult;
+			goto out;
 		}
-		fi_freeinfo(hints);
 
-		printf("Ending test %d, result: %s\n", test_info.test_index,
-			fi_strerror(-ret));
-	} while (!ret);
+		ret = ft_sock_recv(sock, &test_info, sizeof test_info);
+		if (ret) {
+			FT_PRINTERR("ft_sock_recv", ret);
+			goto out;
+		}
+		ft_fw_convert_info(hints, &test_info);
+	}
 
+	printf("Ending test %d / %d, result: %s\n", test_info.test_index,
+		series->test_count, fi_strerror(-result));
+	ret = result;
+out:
+	fi_freeinfo(hints);
 	return ret;
 }
 
 static int ft_fw_client(void)
 {
-	struct fi_info *hints, *info;
-	int ret, result, sresult;
+	int ret, result;
+	pid_t pid;
 
-	hints = fi_allocinfo();
-	if (!hints)
-		return -FI_ENOMEM;
 
 	for (fts_start(series, test_start_index);
 	     !fts_end(series, test_end_index);
 	     fts_next(series)) {
 
 		fts_cur_info(series, &test_info);
-
-		ret = ft_getsrcaddr(opts.src_addr, opts.src_port, hints);
-		if (ret)
-			return ret;
 
 		ret = ft_sock_send(sock, &test_info, sizeof test_info);
 		if (ret) {
@@ -389,58 +463,18 @@ static int ft_fw_client(void)
 			FT_PRINTERR("ft_sock_recv", ret);
 			return ret;
 		}
-		ft_fw_convert_info(hints, &test_info);
 
-		printf("Starting test %d / %d:\n", test_info.test_index,
-			series->test_count);
-		while (!ft_nullstr(test_info.prov_name)) {
-			printf("Starting test %d-%d: ", test_info.test_index,
-				test_info.test_subindex);	
-			ft_show_test_info();
-
-			result = fi_getinfo(FT_FIVERSION, ft_strptr(test_info.node),
-					 ft_strptr(test_info.service), 0, hints, &info);
-			if (result) {
-				FT_PRINTERR("fi_getinfo", result);
-			} else if (info->next) {
-				printf("fi_getinfo returned multiple matches\n");
-				ret = -FI_E2BIG;
-			} else {
-				fabric_info = info;
-				result = ft_run_test();
-				fi_freeinfo(info);
-			}
-	
-			results[ft_fw_result_index(-result)]++;
-			ret = ft_sock_recv(sock, &sresult, sizeof sresult);
-			if (result) {
-				FT_PRINTERR("ft_run_test", result);
-				fprintf(stderr, "Node: %s\nService:	 %s \n",
-					test_info.node, test_info.service);
-				fprintf(stderr, "%s\n", fi_tostr(hints, FI_TYPE_INFO));
-				return result;
-			} else if (ret) {
-				FT_PRINTERR("ft_sock_send", ret);
-				return ret;
-			} else if (sresult) {
-				return sresult;
-			}
-
-			ret = ft_sock_recv(sock, &test_info, sizeof test_info);
-			if (ret) {
-				FT_PRINTERR("ft_sock_recv", ret);
-				return ret;
-			}
-			ft_fw_convert_info(hints, &test_info);
+		pid = fork();
+		if (!pid) {
+			result = ft_client_child();
+			_exit(-result);
+		} else {
+			waitpid(pid, &result, 0);
+			result = WEXITSTATUS(result);
 		}
-		if (!test_info.test_subindex)
-			results[ft_fw_result_index(FI_ENODATA)]++;
 
-		printf("Ending test %d / %d, result: %s\n", test_info.test_index,
-			series->test_count, fi_strerror(-result));
+		results[ft_fw_result_index(result)]++;
 	}
-
-	fi_freeinfo(hints);
 	return 0;
 }
 

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -317,9 +317,7 @@ int ft_get_ctx(struct ft_xcontrol *ctrl, struct fi_context **ctx)
 	int ret;
 
 	ctrl->curr_ctx++;
-	if (ctrl->curr_ctx < ctrl->max_credits) {
-		return 0;
-	} else {
+	if (ctrl->curr_ctx >= ctrl->max_credits) {
 		if (ctrl == &ft_tx_ctrl) {
 			while (ctrl->credits < ctrl->max_credits) {
 				ret = ft_comp_tx(FT_COMP_TO);
@@ -865,6 +863,14 @@ int ft_run_test()
 		if (ret) {
 			FT_PRINTERR("ft_open_active", ret);
 			goto cleanup;
+		}
+	}
+
+	if (!opts.dst_addr) {
+		ret = ft_sock_send(sock, &test_info, sizeof test_info);
+		if (ret) {
+			FT_PRINTERR("ft_sock_send", ret);
+			return ret;
 		}
 	}
 

--- a/test_configs/psm/all.test
+++ b/test_configs/psm/all.test
@@ -1,0 +1,62 @@
+{
+	prov_name: psm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM
+	],
+	av_type: [
+		FI_AV_TABLE
+		FI_AV_MAP,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	caps: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: psm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_WRITEMSG,
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+		FT_FUNC_READMSG,
+	],
+	ep_type: [
+		FI_EP_RDM
+	],
+	av_type: [
+		FI_AV_TABLE
+		FI_AV_MAP,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	caps: [
+		FT_CAP_RMA,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},

--- a/test_configs/psm2/all.test
+++ b/test_configs/psm2/all.test
@@ -1,0 +1,62 @@
+{
+	prov_name: psm2,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM
+	],
+	av_type: [
+		FI_AV_TABLE
+		FI_AV_MAP,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	caps: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: psm2,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_WRITEMSG,
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+		FT_FUNC_READMSG,
+	],
+	ep_type: [
+		FI_EP_RDM
+	],
+	av_type: [
+		FI_AV_TABLE
+		FI_AV_MAP,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	caps: [
+		FT_CAP_RMA,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},


### PR DESCRIPTION
Includes two patches to enable full psm support.

Connection switch:
- previously, client parsed config file and connected before server, causing an address resolution issue with psm providers
- patch switches connection so client connects only after server has connected

Process creation:
- psm2 does not strictly support opening multiple contexts within the same process, causing problems when running multiple tests
- to resolve this issue, this patch adds a fork during each iteration to ensure that every test is its own process, allowing the test to run any number of tests reliably

Adds psm and psm2 config files for testing.
These patches have been verified with sockets, psm, psm2, and verbs.