### PR TITLE
simple/msg_sockets: use only IPv4 addresses

### DIFF
--- a/simple/msg_sockets.c
+++ b/simple/msg_sockets.c
@@ -317,6 +317,7 @@ static int setup_handle(void)
 
 	memset(&aihints, 0, sizeof aihints);
 	aihints.ai_flags = AI_PASSIVE;
+	aihints.ai_family = AF_INET;
 	ret = getaddrinfo(opts.src_addr, opts.src_port, &aihints, &ai);
 	if (ret == EAI_SYSTEM) {
 		FT_ERR("getaddrinfo for %s:%s: %s",


### PR DESCRIPTION
- If source address provided as domain name, the first address in ai list may be IPv6.
- In this case subsequent fi_getinfo will return -120.

PR:https://github.com/ofiwg/libfabric/pull/3024 adds debug log message when such error occurs.