### PR TITLE
win/ci: added config file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,21 @@
+image: Visual Studio 2015
+
+build:
+  project: fabtests.sln
+
+configuration:
+  - Debug
+  - Release
+
+install:
+  - cd ..
+  - git clone https://github.com/ofiwg/libfabric
+  - cd libfabric
+  - ps: .appveyor.ps1 -Verbose
+  - msbuild libfabric.sln
+  - set PATH=%CD%\x64\%CONFIGURATION%;%PATH%
+  - cd ..\fabtests
+
+test_script:
+  - set PATH=%CD%\x64\%CONFIGURATION%;%PATH%
+  - scripts\runfabtests.cmd


### PR DESCRIPTION
Added `.appveyor.yml` to support Windows testing of libfabric in fabtests repository

#### Steps for repository administrator to enable AppVeyor:
1. Sign in on https://ci.appveyor.com
2. click **NEW PROJECT** -> hover on **fabtests** -> click **ADD**
3. fabtests -> click **SETTINGS** -> **General**:
a) set **'Build version format'** to: `{build}`
b) set **'Custom configuration .yml file name'** to: `.appveyor.yml`
c) check **'Skip branches without appveyor.yml'**: `on`
4. Merge the PR. New build will start automatically.