### PR TITLE
osd/windows: Improve clock_gettime for Windows

### DIFF
--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -343,8 +343,8 @@ static int sread_event(int timeout, uint64_t flags)
 	int ret;
 
 	ft_start();
-
 	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), timeout, flags);
+	ft_stop();
 	if (ret != sizeof(entry)) {
 		sprintf(err_buf, "fi_eq_sread returned %d, %s", ret,
 				fi_strerror(-ret));
@@ -352,8 +352,6 @@ static int sread_event(int timeout, uint64_t flags)
 	}
 
 	/* check timeout accuracy */
-	ft_stop();
-
 	elapsed = get_elapsed(&start, &end, MILLI);
 	if (elapsed > (int) (timeout * 1.25)) {
 		sprintf(err_buf, "fi_eq_sread slept %d ms, expected %d",
@@ -470,13 +468,13 @@ eq_wait_fd_sread()
 	/* timed sread on empty EQ, 2s timeout */
 	ft_start();
 	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), 2000, 0);
+	ft_stop();
 	if (ret != -FI_EAGAIN) {
 		sprintf(err_buf, "fi_eq_read of empty EQ returned %d", ret);
 		goto fail;
 	}
 
 	/* check timeout accuracy */
-	ft_stop();
 	elapsed = get_elapsed(&start, &end, MILLI);
 	if (elapsed < 1500 || elapsed > 2500) {
 		sprintf(err_buf, "fi_eq_sread slept %d ms, expected 2000",
@@ -493,18 +491,18 @@ eq_wait_fd_sread()
 		goto fail;
 	}
 
-	/* timed sread on EQ with event, 2s timeout */
-	ft_start();
 	event = ~0;
 	memset(&entry, 0, sizeof(entry));
+	/* timed sread on EQ with event, 2s timeout */
+	ft_start();
 	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), 2000, 0);
+	ft_stop();
 	if (ret != sizeof(entry)) {
 		sprintf(err_buf, "fi_eq_read ret=%d, %s", ret, fi_strerror(-ret));
 		goto fail;
 	}
 
 	/* check that no undue waiting occurred */
-	ft_stop();
 	elapsed = get_elapsed(&start, &end, MILLI);
 	if (elapsed > 5) {
 		sprintf(err_buf, "fi_eq_sread slept %d ms, expected immediate return",


### PR DESCRIPTION
Some tests with time checking fail from time to time

Improve clock_gettime realization for Windows to make it more accuracy

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>