### PR TITLE
shared: Fix check_atomic_attr call

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1381,12 +1381,13 @@ ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, struct fid_ep *ep, size_t siz
 	return 0;
 }
 
-static int check_atomic_attr(enum fi_op op, enum fi_datatype datatype)
+static int check_atomic_attr(enum fi_op op, enum fi_datatype datatype,
+			     uint64_t flags)
 {
 	struct fi_atomic_attr attr;
 	int ret;
 
-	ret = fi_query_atomic(domain, datatype, op, &attr, 0);
+	ret = fi_query_atomic(domain, datatype, op, &attr, flags);
 	if (ret) {
 		FT_PRINTERR("fi_query_atomic", ret);
 		return ret;
@@ -1409,7 +1410,7 @@ int check_base_atomic_op(struct fid_ep *endpoint, enum fi_op op,
 	if (ret)
 		return ret;
 
-	return check_atomic_attr(op, datatype);
+	return check_atomic_attr(op, datatype, 0);
 }
 
 int check_fetch_atomic_op(struct fid_ep *endpoint, enum fi_op op,
@@ -1421,7 +1422,7 @@ int check_fetch_atomic_op(struct fid_ep *endpoint, enum fi_op op,
 	if (ret)
 		return ret;
 
-	return check_atomic_attr(op, datatype);
+	return check_atomic_attr(op, datatype, FI_FETCH_ATOMIC);
 }
 
 int check_compare_atomic_op(struct fid_ep *endpoint, enum fi_op op,
@@ -1433,7 +1434,7 @@ int check_compare_atomic_op(struct fid_ep *endpoint, enum fi_op op,
 	if (ret)
 		return ret;
 
-	return check_atomic_attr(op, datatype);
+	return check_atomic_attr(op, datatype, FI_COMPARE_ATOMIC);
 }
 
 ssize_t ft_post_rx(struct fid_ep *ep, size_t size, struct fi_context* ctx)


### PR DESCRIPTION
The call to fi_query_atomic should specify the correct set
of flags (FI_FETCH_ATOMIC, FI_COMPARE_ATOMIC) in order to
validate if atomic fetch and atomic compare operatons are
supported.  Otherwise, the check defaults to base atomic
operations.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>