### PR TITLE
unit/fi_getinfo_test: Added MSG/RMA Ordering testing

### DIFF
--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -45,6 +45,7 @@
 					    getinfo_ ## name ## _desc)
 
 typedef int (*ft_getinfo_init)(struct fi_info *);
+typedef int (*ft_getinfo_test)(char *, char *, uint64_t, struct fi_info *, struct fi_info **);
 typedef int (*ft_getinfo_check)(void *);
 
 static char err_buf[512];
@@ -113,8 +114,280 @@ int invalid_dom(struct fi_info *hints)
 	return 0;
 }
 
+int validate_msg_ordering_bits(char *node, char *service, uint64_t flags,
+		struct fi_info *hints, struct fi_info **info)
+{
+	int i, ret;
+	uint64_t ordering_bits = (FI_ORDER_STRICT | FI_ORDER_DATA);
+	uint64_t *msg_order_combinations;
+	int cnt;
+
+	ret = ft_alloc_bit_combo(0, ordering_bits, &msg_order_combinations, &cnt);
+	if (ret) {
+		FT_UNIT_STRERR(err_buf, "ft_alloc_bit_combo failed", ret);
+		return ret;
+	}
+
+	/* test for what ordering support exists on this provider */
+	/* test ordering support in TX ATTRIBUTE */
+	for (i = 0; i < cnt; i++) {
+		hints->tx_attr->msg_order = msg_order_combinations[i];
+		ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, info);
+		if (ret && ret != -FI_ENODATA) {
+			FT_UNIT_STRERR(err_buf, "fi_getinfo failed", ret);
+			goto failed_getinfo;
+		}
+
+		ft_foreach_info(fi, *info) {
+			FT_DEBUG("\nTesting for fabric: %s, domain: %s, endpoint type: %d",
+					fi->fabric_attr->name, fi->domain_attr->name,
+					fi->ep_attr->type);
+			if (hints->tx_attr->msg_order) {
+				if (!(fi->tx_attr->msg_order & hints->tx_attr->msg_order)) {
+					ret = -FI_EOTHER;
+					fi_freeinfo(*info);
+					goto failed_getinfo;
+				}
+			}
+		}
+		fi_freeinfo(*info);
+	}
+
+	/* test ordering support in RX ATTRIBUTE */
+	for (i = 0; i < cnt; i++) {
+		hints->tx_attr->msg_order = 0;
+		hints->rx_attr->msg_order = msg_order_combinations[i];
+		ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, info);
+		if (ret && ret != -FI_ENODATA) {
+			FT_UNIT_STRERR(err_buf, "fi_getinfo failed", ret);
+			goto failed_getinfo;
+		}
+		ft_foreach_info(fi, *info) {
+			FT_DEBUG("\nTesting for fabric: %s, domain: %s, endpoint type: %d",
+					fi->fabric_attr->name, fi->domain_attr->name,
+					fi->ep_attr->type);
+			if (hints->rx_attr->msg_order) {
+				if (!(fi->rx_attr->msg_order & hints->rx_attr->msg_order)) {
+					ret = -FI_EOTHER;
+					fi_freeinfo(*info);
+					goto failed_getinfo;
+				}
+			}
+		}
+		fi_freeinfo(*info);
+	}
+
+	*info = NULL;
+	ft_free_bit_combo(msg_order_combinations);
+	return 0;
+
+failed_getinfo:
+	*info = NULL;
+	ft_free_bit_combo(msg_order_combinations);
+	return ret;
+}
+
+int init_valid_rma_RAW_ordering_no_set_size(struct fi_info *hints)
+{
+	hints->caps = FI_RMA;
+	hints->tx_attr->msg_order = FI_ORDER_RAW;
+	hints->rx_attr->msg_order = FI_ORDER_RAW;
+	hints->ep_attr->max_order_raw_size = 0;
+
+	return 0;
+}
+
+int init_valid_rma_RAW_ordering_set_size(struct fi_info *hints)
+{
+	int ret;
+	struct fi_info *fi;
+
+	hints->caps = FI_RMA;
+	hints->tx_attr->msg_order = FI_ORDER_RAW;
+	hints->rx_attr->msg_order = FI_ORDER_RAW;
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
+	if (ret) {
+		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
+		return ret;
+	}
+	if (fi->ep_attr->max_order_raw_size > 0)
+		hints->ep_attr->max_order_raw_size = fi->ep_attr->max_order_raw_size - 1;
+
+	fi_freeinfo(fi);
+
+	return 0;
+}
+
+int init_valid_rma_WAR_ordering_no_set_size(struct fi_info *hints)
+{
+	hints->caps = FI_RMA;
+	hints->tx_attr->msg_order = FI_ORDER_WAR;
+	hints->rx_attr->msg_order = FI_ORDER_WAR;
+	hints->ep_attr->max_order_war_size = 0;
+
+	return 0;
+}
+
+int init_valid_rma_WAR_ordering_set_size(struct fi_info *hints)
+{
+	int ret;
+	struct fi_info *fi;
+
+	hints->caps = FI_RMA;
+	hints->tx_attr->msg_order = FI_ORDER_WAR;
+	hints->rx_attr->msg_order = FI_ORDER_WAR;
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
+	if (ret) {
+		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
+		return ret;
+	}
+	if (fi->ep_attr->max_order_war_size > 0)
+		hints->ep_attr->max_order_war_size = fi->ep_attr->max_order_war_size - 1;
+
+	fi_freeinfo(fi);
+
+	return 0;
+}
+
+int init_valid_rma_WAW_ordering_no_set_size(struct fi_info *hints)
+{
+	hints->caps = FI_RMA;
+	hints->tx_attr->msg_order = FI_ORDER_WAW;
+	hints->rx_attr->msg_order = FI_ORDER_WAW;
+	hints->ep_attr->max_order_waw_size = 0;
+
+	return 0;
+}
+
+int init_valid_rma_WAW_ordering_set_size(struct fi_info *hints)
+{
+	int ret;
+	struct fi_info *fi;
+
+	hints->caps = FI_RMA;
+	hints->tx_attr->msg_order = FI_ORDER_WAW;
+	hints->rx_attr->msg_order = FI_ORDER_WAW;
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
+	if (ret) {
+		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
+		return ret;
+	}
+	if (fi->ep_attr->max_order_waw_size > 0)
+		hints->ep_attr->max_order_waw_size = fi->ep_attr->max_order_waw_size - 1;
+
+	fi_freeinfo(fi);
+
+	return 0;
+}
+
+static int check_valid_rma_ordering_sizes(void *arg)
+{
+	struct fi_info *info = arg;
+	if ((info->tx_attr->msg_order && FI_ORDER_RAW) ||
+			(info->rx_attr->msg_order && FI_ORDER_RAW)) {
+		if (info->ep_attr->max_order_raw_size <= 0)
+			return EXIT_FAILURE;
+		if (hints->ep_attr->max_order_raw_size) {
+			if (info->ep_attr->max_order_raw_size < hints->ep_attr->max_order_raw_size)
+				return EXIT_FAILURE;
+		}
+	}
+	if ((info->tx_attr->msg_order && FI_ORDER_WAR) ||
+			(info->rx_attr->msg_order && FI_ORDER_WAR)) {
+		if (info->ep_attr->max_order_war_size <= 0)
+			return EXIT_FAILURE;
+		if (hints->ep_attr->max_order_war_size) {
+			if (info->ep_attr->max_order_war_size < hints->ep_attr->max_order_war_size)
+				return EXIT_FAILURE;
+		}
+	}
+	if ((info->tx_attr->msg_order && FI_ORDER_WAW) ||
+			(info->rx_attr->msg_order && FI_ORDER_WAW)) {
+		if (info->ep_attr->max_order_waw_size <= 0)
+			return EXIT_FAILURE;
+		if (hints->ep_attr->max_order_waw_size) {
+			if (info->ep_attr->max_order_waw_size < hints->ep_attr->max_order_waw_size)
+				return EXIT_FAILURE;
+		}
+	}
+
+	return 0;
+}
+
+int init_invalid_rma_RAW_ordering_size(struct fi_info *hints)
+{
+	int ret;
+	struct fi_info *fi;
+
+	hints->caps |= FI_RMA;
+	hints->tx_attr->msg_order = FI_ORDER_RAW;
+	hints->rx_attr->msg_order = FI_ORDER_RAW;
+	hints->ep_attr->max_order_war_size = 0;
+	hints->ep_attr->max_order_waw_size = 0;
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
+	if (ret) {
+		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
+		return ret;
+	}
+
+	if (fi->ep_attr->max_order_raw_size)
+		hints->ep_attr->max_order_raw_size = fi->ep_attr->max_order_raw_size + 1;
+
+	fi_freeinfo(fi);
+
+	return 0;
+}
+
+int init_invalid_rma_WAR_ordering_size(struct fi_info *hints)
+{
+	int ret;
+	struct fi_info *fi;
+
+	hints->caps |= FI_RMA;
+	hints->tx_attr->msg_order = FI_ORDER_WAR;
+	hints->rx_attr->msg_order = FI_ORDER_WAR;
+	hints->ep_attr->max_order_raw_size = 0;
+	hints->ep_attr->max_order_waw_size = 0;
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
+	if (ret) {
+		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
+		return ret;
+	}
+
+	if (fi->ep_attr->max_order_war_size)
+		hints->ep_attr->max_order_war_size = fi->ep_attr->max_order_war_size + 1;
+
+	fi_freeinfo(fi);
+
+	return 0;
+}
+
+int init_invalid_rma_WAW_ordering_size(struct fi_info *hints)
+{
+	int ret;
+	struct fi_info *fi;
+
+	hints->caps |= FI_RMA;
+	hints->tx_attr->msg_order = FI_ORDER_WAW;
+	hints->rx_attr->msg_order = FI_ORDER_WAW;
+	hints->ep_attr->max_order_raw_size = 0;
+	hints->ep_attr->max_order_war_size = 0;
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
+	if (ret) {
+		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
+		return ret;
+	}
+
+	if (fi->ep_attr->max_order_waw_size)
+		hints->ep_attr->max_order_waw_size = fi->ep_attr->max_order_waw_size + 1;
+
+	fi_freeinfo(fi);
+
+	return 0;
+}
+
 static int getinfo_unit_test(char *node, char *service, uint64_t flags,
-		struct fi_info *hints, ft_getinfo_init init,
+		struct fi_info *hints, ft_getinfo_init init, ft_getinfo_test test,
 		ft_getinfo_check check, int ret_exp)
 {
 	struct fi_info *info, *fi;
@@ -126,13 +399,19 @@ static int getinfo_unit_test(char *node, char *service, uint64_t flags,
 			return ret;
 	}
 
-	ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &info);
+	if (test)
+		ret = test(node, service, flags, hints, &info);
+	else
+		ret = fi_getinfo(FT_FIVERSION, node, service, flags, hints, &info);
 	if (ret) {
 		if (ret == ret_exp)
 			return 0;
 		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
 		return ret;
 	}
+
+	if (!info)
+		return ret;
 
 	if (!check)
 		goto out;
@@ -150,13 +429,13 @@ out:
 	return ret;
 }
 
-#define getinfo_test(name, num, desc, node, service, flags, hints, init, check,	\
+#define getinfo_test(name, num, desc, node, service, flags, hints, init, test, check,	\
 		ret_exp)							\
 char *getinfo_ ## name ## num ## _desc = desc;					\
 static int getinfo_ ## name ## num(void)					\
 {										\
 	int ret, testret = FAIL;						\
-	ret = getinfo_unit_test(node, service, flags, hints, init, check,	\
+	ret = getinfo_unit_test(node, service, flags, hints, init, test, check,	\
 			ret_exp);						\
 	if (ret)								\
 		goto fail;							\
@@ -178,51 +457,74 @@ fail:										\
 
 /* 1.1 Source address only tests */
 getinfo_test(no_hints, 1, "Test with no node, service, flags or hints",
-		NULL, NULL, 0, NULL, NULL, check_srcaddr, 0)
+		NULL, NULL, 0, NULL, NULL, NULL, check_srcaddr, 0)
 getinfo_test(no_hints, 2, "Test with node, no service, FI_SOURCE flag and no hints",
 		opts.src_addr ? opts.src_addr : "localhost", NULL, FI_SOURCE,
-		NULL, NULL, check_srcaddr, 0)
+		NULL, NULL, NULL, check_srcaddr, 0)
 getinfo_test(no_hints, 3, "Test with service, FI_SOURCE flag and no node or hints",
 		 NULL, opts.src_port, FI_SOURCE, NULL, NULL,
-		 check_srcaddr, 0)	// TODO should we check for wildcard addr?
+		 NULL, check_srcaddr, 0)	// TODO should we check for wildcard addr?
 getinfo_test(no_hints, 4, "Test with node, service, FI_SOURCE flags and no hints",
 		opts.src_addr ? opts.src_addr : "localhost", opts.src_port,
-		FI_SOURCE, NULL, NULL, check_srcaddr, 0)
+		FI_SOURCE, NULL, NULL, NULL, check_srcaddr, 0)
 
 /* 1.2 Source and destination address tests */
 getinfo_test(no_hints, 5, "Test with node, service and no hints",
 		opts.dst_addr ? opts.dst_addr : "localhost", opts.dst_port,
-		0, NULL, NULL, check_src_dest_addr, 0)
+		0, NULL, NULL, NULL, check_src_dest_addr, 0)
 
 /* 2. Test with hints */
 /* 2.1 Source address only tests */
 getinfo_test(src, 1, "Test with no node, service, or flags",
-		NULL, NULL, 0, hints, NULL, check_srcaddr, 0)
+		NULL, NULL, 0, hints, NULL, NULL, check_srcaddr, 0)
 getinfo_test(src, 2, "Test with node, no service, FI_SOURCE flag",
 		opts.src_addr ? opts.src_addr : "localhost", NULL, FI_SOURCE,
-		hints, NULL, check_srcaddr, 0)
+		hints, NULL, NULL, check_srcaddr, 0)
 getinfo_test(src, 3, "Test with service, FI_SOURCE flag and no node",
 		 NULL, opts.src_port, FI_SOURCE, hints, NULL,
-		 check_srcaddr, 0)	// TODO should we check for wildcard addr?
+		 NULL, check_srcaddr, 0)	// TODO should we check for wildcard addr?
 getinfo_test(src, 4, "Test with node, service, FI_SOURCE flags",
 		opts.src_addr ? opts.src_addr : "localhost", opts.src_port,
-		FI_SOURCE, hints, NULL, check_srcaddr, 0)
+		FI_SOURCE, hints, NULL, NULL, check_srcaddr, 0)
 
 /* 2.2 Source and destination address tests */
 getinfo_test(src_dest, 1, "Test with node, service",
 		opts.dst_addr ? opts.dst_addr : "localhost", opts.dst_port,
-		0, hints, NULL, check_src_dest_addr, 0)
+		0, hints, NULL, NULL, check_src_dest_addr, 0)
 
 getinfo_test(src_dest, 2, "Test API version",
-		NULL, NULL, 0, hints, NULL, check_api_version ,0)
+		NULL, NULL, 0, hints, NULL, NULL, check_api_version , 0)
 
 /* Negative tests */
 getinfo_test(neg, 1, "Test with non-existent domain name",
-		NULL, NULL, 0, hints, invalid_dom, NULL, -FI_ENODATA)
+		NULL, NULL, 0, hints, invalid_dom, NULL, NULL, -FI_ENODATA)
 
 /* Utility provider tests */
 getinfo_test(util, 1, "Test if we get utility provider when requested",
-		NULL, NULL, 0, hints, NULL, check_util_prov, 0)
+		NULL, NULL, 0, hints, NULL, NULL, check_util_prov, 0)
+
+/* Message Ordering Tests */
+getinfo_test(ordering, 1, "Test msg ordering bits supported are set",
+		NULL, NULL, 0, hints, NULL, validate_msg_ordering_bits, NULL, 0)
+getinfo_test(ordering, 2, "Test rma RAW ordering size is set",
+		NULL, NULL, 0, hints, init_valid_rma_RAW_ordering_no_set_size, NULL, check_valid_rma_ordering_sizes, 0)
+getinfo_test(ordering, 3, "Test rma RAW ordering size is set to hints",
+		NULL, NULL, 0, hints, init_valid_rma_RAW_ordering_set_size, NULL, check_valid_rma_ordering_sizes, 0)
+getinfo_test(ordering, 4, "Test rma WAR ordering size is set",
+		NULL, NULL, 0, hints, init_valid_rma_WAR_ordering_no_set_size, NULL, check_valid_rma_ordering_sizes, 0)
+getinfo_test(ordering, 5, "Test rma WAR ordering size is set to hints",
+		NULL, NULL, 0, hints, init_valid_rma_WAR_ordering_set_size, NULL, check_valid_rma_ordering_sizes, 0)
+getinfo_test(ordering, 6, "Test rma WAW ordering size is set",
+		NULL, NULL, 0, hints, init_valid_rma_WAW_ordering_no_set_size, NULL, check_valid_rma_ordering_sizes, 0)
+getinfo_test(ordering, 7, "Test rma WAW ordering size is set to hints",
+		NULL, NULL, 0, hints, init_valid_rma_WAW_ordering_set_size, NULL, check_valid_rma_ordering_sizes, 0)
+getinfo_test(ordering, 8, "Test invalid rma RAW ordering size",
+		NULL, NULL, 0, hints, init_invalid_rma_RAW_ordering_size, NULL, NULL, -FI_ENODATA)
+getinfo_test(ordering, 9, "Test invalid rma WAR ordering size",
+		NULL, NULL, 0, hints, init_invalid_rma_WAR_ordering_size, NULL, NULL, -FI_ENODATA)
+getinfo_test(ordering, 10, "Test invalid rma WAW ordering size",
+		NULL, NULL, 0, hints, init_invalid_rma_WAW_ordering_size, NULL, NULL, -FI_ENODATA)
+
 
 
 static void usage(void)
@@ -281,6 +583,16 @@ int main(int argc, char **argv)
 		TEST_ENTRY_GETINFO(src4),
 		TEST_ENTRY_GETINFO(src_dest1),
 		TEST_ENTRY_GETINFO(src_dest2),
+		TEST_ENTRY_GETINFO(ordering1),
+		TEST_ENTRY_GETINFO(ordering2),
+		TEST_ENTRY_GETINFO(ordering3),
+		TEST_ENTRY_GETINFO(ordering4),
+		TEST_ENTRY_GETINFO(ordering5),
+		TEST_ENTRY_GETINFO(ordering6),
+		TEST_ENTRY_GETINFO(ordering7),
+		TEST_ENTRY_GETINFO(ordering8),
+		TEST_ENTRY_GETINFO(ordering9),
+		TEST_ENTRY_GETINFO(ordering10),
 		/* This test has to be last getinfo unit test to be run until we
 		 * find a way to reset hints->domain_attr->name*/
 		TEST_ENTRY_GETINFO(neg1),


### PR DESCRIPTION
  unit/getinfo_test
    - Added test to validate that a provider sets the supported msg_ordering bits
    - Added tests to validate that a provider allows valid RMA ordering sizes
    - Added tests to validate that a provider checks invalid RMA ordering sizes

Signed-off-by: Neil R Spruit <neil.r.spruit@intel.com>