### PR TITLE
Use the new prefix for utility provider names

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -285,4 +285,4 @@ dist-hook: fabtests.spec
 test:
 	./scripts/runfabtests.sh -vvv
 	./scripts/runfabtests.sh -vvv udp
-	./scripts/runfabtests.sh -vvv ofi-rxm
+	./scripts/runfabtests.sh -vvv ofi_rxm


### PR DESCRIPTION
https://github.com/ofiwg/libfabric/pull/3122 changed the utility provider name prefix from "ofi-" to "ofi_". Update the test to reflect the same.