### PR TITLE
ubertest: Fix coverity issues for mixed enum values

### DIFF
--- a/complex/ft_comp.c
+++ b/complex/ft_comp.c
@@ -54,8 +54,6 @@ static int ft_open_cntrs(void)
 {
 	int ret;
 
-	opts.comp_method = test_info.cq_wait_obj;
-
 	if (!txcntr) {
 		ret = ft_cntr_open(&txcntr);
 		if (ret)

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -278,7 +278,7 @@ static int ft_fw_result_index(int fi_errno)
 
 static int ft_fw_process_list(struct fi_info *hints, struct fi_info *info)
 {
-	int ret, subindex, result;
+	int ret, subindex, result = 0;
 	size_t len;
 
 	for (subindex = 1, fabric_info = info; fabric_info;
@@ -309,6 +309,7 @@ static int ft_fw_process_list(struct fi_info *hints, struct fi_info *info)
 			return ret;
 		}
 	}
+
 	test_info.prov_name[0] = '\0';
 	ret = ft_sock_send(sock, &test_info, sizeof test_info);
 	if (ret) {

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -393,7 +393,7 @@ static int ft_check_verify_cnt()
 
 static int ft_pingpong_rma(void)
 {
-	int ret, i;
+	int ret = 0, i;
 	size_t count;
 
 	if (test_info.test_class & FI_ATOMIC) {


### PR DESCRIPTION
Plus uninitialized variables.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>