### PR TITLE
test_configs/sockets: quick.test simplification

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,6 +56,7 @@ nobase_dist_config_DATA = \
         test_configs/lat_bw.test \
         test_configs/sockets/all.test \
         test_configs/sockets/quick.test \
+	test_configs/sockets/complete.test \
         test_configs/udp/all.test \
         test_configs/udp/lat_bw.test \
         test_configs/udp/quick.test \

--- a/test_configs/sockets/complete.test
+++ b/test_configs/sockets/complete.test
@@ -24,9 +24,11 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -50,6 +52,7 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
 	],
 	eq_wait_obj: [
 		FI_WAIT_NONE,
@@ -62,6 +65,7 @@
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -86,6 +90,7 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
 	],
 	eq_wait_obj: [
 		FI_WAIT_NONE,
@@ -98,6 +103,7 @@
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -130,9 +136,11 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_RMA,
@@ -155,11 +163,33 @@
 		FT_FUNC_INJECT_ATOMIC,
 	],
 	op:[
+		FI_MIN,
+		FI_MAX,
 		FI_SUM,
 		FI_PROD,
+		FI_LOR,
+		FI_LAND,
+		FI_BOR,
+		FI_BAND,
+		FI_LXOR,
+		FI_BXOR,
+		FI_ATOMIC_WRITE,
 	],
 	datatype:[
 		FI_INT8,
+		FI_UINT8,
+		FI_INT16,
+		FI_UINT16,
+		FI_INT32,
+		FI_UINT32,
+		FI_INT64,
+		FI_UINT64,
+		FI_FLOAT,
+		FI_DOUBLE,
+		FI_LONG_DOUBLE,
+		FI_FLOAT_COMPLEX,
+		FI_DOUBLE_COMPLEX,
+		FI_LONG_DOUBLE_COMPLEX,
 	],
 	ep_type: [
 		FI_EP_MSG,
@@ -170,9 +200,11 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -195,6 +227,19 @@
 	],
 	datatype:[
 		FI_INT8,
+		FI_UINT8,
+		FI_INT16,
+		FI_UINT16,
+		FI_INT32,
+		FI_UINT32,
+		FI_INT64,
+		FI_UINT64,
+		FI_FLOAT,
+		FI_DOUBLE,
+		FI_LONG_DOUBLE,
+		FI_FLOAT_COMPLEX,
+		FI_DOUBLE_COMPLEX,
+		FI_LONG_DOUBLE_COMPLEX,
 	],
 	ep_type: [
 		FI_EP_MSG,
@@ -205,9 +250,11 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -227,9 +274,28 @@
 	],
 	op:[
 		FI_CSWAP,
+		FI_CSWAP_NE,
+		FI_CSWAP_LE,
+		FI_CSWAP_LT,
+		FI_CSWAP_GE,
+		FI_CSWAP_GT,
+		FI_MSWAP,
 	],
 	datatype:[
 		FI_INT8,
+		FI_UINT8,
+		FI_INT16,
+		FI_UINT16,
+		FI_INT32,
+		FI_UINT32,
+		FI_INT64,
+		FI_UINT64,
+		FI_FLOAT,
+		FI_DOUBLE,
+		FI_LONG_DOUBLE,
+		FI_FLOAT_COMPLEX,
+		FI_DOUBLE_COMPLEX,
+		FI_LONG_DOUBLE_COMPLEX,
 	],
 	ep_type: [
 		FI_EP_MSG,
@@ -240,9 +306,11 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
 	],
 	mode: [
 		FT_MODE_ALL,
+		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,


### PR DESCRIPTION
- simplify quick.test by removing tests (mostly atomic datatype/op combinations) to actually make the test "quick"
- move all combinations in old "quick.test" to new "complete.test" file that tracks all ubertest abilities and combinations

Signed-off-by: aingerson <alexia.ingerson@intel.com>

Fixes ofiwg/libfabric#3145