### PR TITLE
complex/fi_ubertest: add cntr_wait_obj

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -87,7 +87,6 @@ struct ft_xcontrol {
 	uint8_t			seqno;
 	uint64_t		total_comp;
 	enum fi_cq_format	cq_format;
-	enum fi_wait_obj	comp_wait;  /* must be NONE */
 	uint64_t		remote_cq_data;
 	struct fi_context	*ctx;
 	int			curr_ctx;
@@ -235,6 +234,7 @@ struct ft_set {
 	enum ft_comp_type	comp_type[FT_MAX_COMP];
 	enum fi_wait_obj	eq_wait_obj[FT_MAX_WAIT_OBJ];
 	enum fi_wait_obj	cq_wait_obj[FT_MAX_WAIT_OBJ];
+	enum fi_wait_obj	cntr_wait_obj[FT_MAX_WAIT_OBJ];
 	uint64_t		mode[FT_MAX_PROV_MODES];
 	uint64_t		test_class[FT_MAX_CLASS];
 	uint64_t		constant_caps[FT_MAX_CAPS];
@@ -256,6 +256,7 @@ struct ft_series {
 	int			cur_comp;
 	int			cur_eq_wait_obj;
 	int			cur_cq_wait_obj;
+	int			cur_cntr_wait_obj;
 	int			cur_mode;
 	int			cur_class;
 };
@@ -277,6 +278,7 @@ struct ft_info {
 	enum ft_comp_type	comp_type;
 	enum fi_wait_obj	eq_wait_obj;
 	enum fi_wait_obj	cq_wait_obj;
+	enum fi_wait_obj	cntr_wait_obj;
 	uint32_t		protocol;
 	uint32_t		protocol_version;
 	char			node[FI_NAME_MAX];

--- a/complex/ft_comp.c
+++ b/complex/ft_comp.c
@@ -52,17 +52,26 @@ static size_t comp_entry_size[] = {
 
 static int ft_open_cntrs(void)
 {
+	struct fi_cntr_attr attr;
 	int ret;
 
 	if (!txcntr) {
-		ret = ft_cntr_open(&txcntr);
-		if (ret)
+		memset(&attr, 0, sizeof attr);
+		attr.wait_obj = test_info.cntr_wait_obj;
+		ret = fi_cntr_open(domain, &attr, &txcntr, &txcntr);
+		if (ret) {
+			FT_PRINTERR("fi_cntr_open", ret);
 			return ret;
+		}
 	}
 	if (!rxcntr) {
-		ret = ft_cntr_open(&rxcntr);
-		if (ret)
+		memset(&attr, 0, sizeof attr);
+		attr.wait_obj = test_info.cntr_wait_obj;
+		ret = fi_cntr_open(domain, &attr, &rxcntr, &rxcntr);
+		if (ret) {
+			FT_PRINTERR("fi_cntr_open", ret);
 			return ret;
+		}
 	}
 	return 0;
 }
@@ -75,7 +84,7 @@ static int ft_open_cqs(void)
 	if (!txcq) {
 		memset(&attr, 0, sizeof attr);
 		attr.format = ft_tx_ctrl.cq_format;
-		attr.wait_obj = ft_tx_ctrl.comp_wait;
+		attr.wait_obj = test_info.cq_wait_obj;
 		attr.size = ft_tx_ctrl.max_credits;
 
 		ret = fi_cq_open(domain, &attr, &txcq, NULL);
@@ -88,7 +97,7 @@ static int ft_open_cqs(void)
 	if (!rxcq) {
 		memset(&attr, 0, sizeof attr);
 		attr.format = ft_rx_ctrl.cq_format;
-		attr.wait_obj = ft_rx_ctrl.comp_wait;
+		attr.wait_obj = test_info.cq_wait_obj;
 		attr.size = ft_rx_ctrl.max_credits;
 
 		ret = fi_cq_open(domain, &attr, &rxcq, NULL);

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -222,6 +222,12 @@ static struct key_t keys[] = {
 		.val_size = sizeof(((struct ft_set *)0)->cq_wait_obj) / FT_MAX_WAIT_OBJ,
 	},
 	{
+		.str = "cntr_wait_obj",
+		.offset = offsetof(struct ft_set, cntr_wait_obj),
+		.val_type = VAL_NUM,
+		.val_size = sizeof(((struct ft_set *)0)->cntr_wait_obj) / FT_MAX_WAIT_OBJ,
+	},
+	{
 		.str = "op",
 		.offset = offsetof(struct ft_set, op),
 		.val_type = VAL_NUM,
@@ -319,12 +325,13 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_SET_N_RETURN(str, len, "FT_CAP_ATOMIC", FT_CAP_ATOMIC, uint64_t, buf);
 		FT_ERR("Unknown test class");
 	} else if (!strncmp(key->str, "eq_wait_obj", strlen("eq_wait_obj")) ||
-		!strncmp(key->str, "cq_wait_obj", strlen("cq_wait_obj"))) {
+		!strncmp(key->str, "cq_wait_obj", strlen("cq_wait_obj")) ||
+		!strncmp(key->str, "cntr_wait_obj", strlen("cntr_wait_obj"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_WAIT_NONE, enum fi_wait_obj, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_WAIT_UNSPEC, enum fi_wait_obj, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_WAIT_FD, enum fi_wait_obj, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_WAIT_MUTEX_COND, enum fi_wait_obj, buf);
-		FT_ERR("Unknown (eq/cq)_wait_obj");
+		FT_ERR("Unknown wait_obj");
 	} else if (!strncmp(key->str, "op", strlen("op"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MIN, enum fi_op, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MAX, enum fi_op, buf);
@@ -633,6 +640,7 @@ void fts_start(struct ft_series *series, int index)
 	series->cur_comp = 0;
 	series->cur_eq_wait_obj = 0;
 	series->cur_cq_wait_obj = 0;
+	series->cur_cntr_wait_obj = 0;
 	series->cur_mode = 0;
 	series->cur_class = 0;
 
@@ -703,6 +711,10 @@ void fts_next(struct ft_series *series)
 		return;
 	series->cur_cq_wait_obj = 0;
 
+	if (set->cntr_wait_obj[++series->cur_cntr_wait_obj])
+		return;
+	series->cur_cntr_wait_obj = 0;
+
 	if (set->ep_type[series->cur_ep] == FI_EP_RDM ||
 	    set->ep_type[series->cur_ep] == FI_EP_DGRAM) {
 		if (set->av_type[++series->cur_av])
@@ -765,7 +777,7 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->av_type = set->av_type[series->cur_av];
 	info->comp_type = set->comp_type[series->cur_comp];
 	info->eq_wait_obj = set->eq_wait_obj[series->cur_eq_wait_obj];
-	info->cq_wait_obj = set->cq_wait_obj[series->cur_cq_wait_obj];
+	info->cntr_wait_obj = set->cntr_wait_obj[series->cur_cntr_wait_obj];
 
 	if (set->node[0])
 		strncpy(info->node, set->node, sizeof(info->node) - 1);

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -198,6 +198,7 @@ static void ft_show_test_info(void)
 	printf(" %s,", fi_tostr(&test_info.av_type, FI_TYPE_AV_TYPE));
 	printf(" eq_%s,", ft_wait_obj_str(test_info.eq_wait_obj));
 	printf(" cq_%s,", ft_wait_obj_str(test_info.cq_wait_obj));
+	printf(" cntr_%s,", ft_wait_obj_str(test_info.cq_wait_obj));
 	printf(" %s,", ft_comp_type_str(test_info.comp_type));
 	printf(" [%s],", fi_tostr(&test_info.mode, FI_TYPE_MODE));
 	printf(" [%s]]\n", fi_tostr(&test_info.caps, FI_TYPE_CAPS));

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -47,7 +47,6 @@ static int ft_init_xcontrol(struct ft_xcontrol *ctrl)
 	memset(ctrl, 0, sizeof *ctrl);
 	ctrl->credits = FT_DEFAULT_CREDITS;
 	ctrl->max_credits =  FT_DEFAULT_CREDITS;
-	ctrl->comp_wait = test_info.cq_wait_obj;
 
 	ctrl->iov = calloc(ft_ctrl.iov_array[ft_ctrl.iov_cnt - 1], sizeof *ctrl->iov);
 	ctrl->iov_desc = calloc(ft_ctrl.iov_array[ft_ctrl.iov_cnt - 1],

--- a/test_configs/sockets/complete.test
+++ b/test_configs/sockets/complete.test
@@ -60,9 +60,6 @@
 		FI_WAIT_FD,
 		FI_WAIT_MUTEX_COND,
 	],
-	cq_wait_obj: [
-		FI_WAIT_NONE,
-	],
 	mode: [
 		FT_MODE_ALL,
 		FT_MODE_NONE,
@@ -90,12 +87,48 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-		FT_COMP_CNTR,
 	],
 	eq_wait_obj: [
 		FI_WAIT_NONE,
 	],
 	cq_wait_obj: [
+		FI_WAIT_NONE,
+		FI_WAIT_UNSPEC,
+		FI_WAIT_FD,
+		FI_WAIT_MUTEX_COND,
+	],
+	mode: [
+		FT_MODE_ALL,
+		FT_MODE_NONE,
+	],
+	test_class: [
+		FT_CAP_MSG,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+	],
+	ep_type: [
+		FI_EP_MSG,
+		FI_EP_DGRAM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_CNTR,
+	],
+	eq_wait_obj: [
+		FI_WAIT_NONE,
+	],
+	cntr_wait_obj: [
 		FI_WAIT_NONE,
 		FI_WAIT_UNSPEC,
 		FI_WAIT_FD,


### PR DESCRIPTION
- clarify use of wait object for both CQs and counters

Signed-off-by: aingerson <alexia.ingerson@intel.com>