### PR TITLE
Multi Memory Region, Multi Domain, Multi Endpoint, Recv Cancel, & Unexpected_msg FT

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ bin_PROGRAMS = \
 	simple/fi_rdm_shared_av \
 	simple/fi_cm_data \
 	simple/fi_multi_mr \
+	simple/fi_rdm_multi_domain \
 	streaming/fi_msg_rma \
 	streaming/fi_rdm_atomic \
 	streaming/fi_rdm_multi_recv \
@@ -162,6 +163,10 @@ simple_fi_poll_LDADD = libfabtests.la
 simple_fi_multi_mr_SOURCES = \
 	simple/multi_mr.c
 simple_fi_multi_mr_LDADD = libfabtests.la
+
+simple_fi_rdm_multi_domain_SOURCES = \
+	simple/rdm_multi_domain.c
+simple_fi_rdm_multi_domain_LDADD = libfabtests.la
 
 streaming_fi_msg_rma_SOURCES = \
 	streaming/msg_rma.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ bin_PROGRAMS = \
 	simple/fi_msg_epoll \
 	simple/fi_rdm_shared_av \
 	simple/fi_cm_data \
+	simple/fi_multi_mr \
 	streaming/fi_msg_rma \
 	streaming/fi_rdm_atomic \
 	streaming/fi_rdm_multi_recv \
@@ -157,6 +158,10 @@ simple_fi_shared_ctx_LDADD = libfabtests.la
 simple_fi_poll_SOURCES = \
 	simple/poll.c
 simple_fi_poll_LDADD = libfabtests.la
+
+simple_fi_multi_mr_SOURCES = \
+	simple/multi_mr.c
+simple_fi_multi_mr_LDADD = libfabtests.la
 
 streaming_fi_msg_rma_SOURCES = \
 	streaming/msg_rma.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,7 @@ bin_PROGRAMS = \
 	simple/fi_cm_data \
 	simple/fi_multi_mr \
 	simple/fi_rdm_multi_domain \
+	simple/fi_multi_ep \
 	streaming/fi_msg_rma \
 	streaming/fi_rdm_atomic \
 	streaming/fi_rdm_multi_recv \
@@ -159,6 +160,10 @@ simple_fi_shared_ctx_LDADD = libfabtests.la
 simple_fi_poll_SOURCES = \
 	simple/poll.c
 simple_fi_poll_LDADD = libfabtests.la
+
+simple_fi_multi_ep_SOURCES = \
+	simple/multi_ep.c
+simple_fi_multi_ep_LDADD = libfabtests.la
 
 simple_fi_multi_mr_SOURCES = \
 	simple/multi_mr.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@ bin_PROGRAMS = \
 	simple/fi_rdm_multi_domain \
 	simple/fi_multi_ep \
 	simple/fi_recv_cancel \
+	simple/fi_unexpected_msg \
 	streaming/fi_msg_rma \
 	streaming/fi_rdm_atomic \
 	streaming/fi_rdm_multi_recv \
@@ -169,6 +170,10 @@ simple_fi_multi_ep_LDADD = libfabtests.la
 simple_fi_multi_mr_SOURCES = \
 	simple/multi_mr.c
 simple_fi_multi_mr_LDADD = libfabtests.la
+
+simple_fi_unexpected_msg_SOURCES = \
+	simple/unexpected_msg.c
+simple_fi_unexpected_msg_LDADD = libfabtests.la
 
 simple_fi_rdm_multi_domain_SOURCES = \
 	simple/rdm_multi_domain.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ bin_PROGRAMS = \
 	simple/fi_multi_mr \
 	simple/fi_rdm_multi_domain \
 	simple/fi_multi_ep \
+	simple/fi_recv_cancel \
 	streaming/fi_msg_rma \
 	streaming/fi_rdm_atomic \
 	streaming/fi_rdm_multi_recv \
@@ -172,6 +173,10 @@ simple_fi_multi_mr_LDADD = libfabtests.la
 simple_fi_rdm_multi_domain_SOURCES = \
 	simple/rdm_multi_domain.c
 simple_fi_rdm_multi_domain_LDADD = libfabtests.la
+
+simple_fi_recv_cancel_SOURCES = \
+	simple/recv_cancel.c
+simple_fi_recv_cancel_LDADD = libfabtests.la
 
 streaming_fi_msg_rma_SOURCES = \
 	streaming/msg_rma.c

--- a/common/shared.c
+++ b/common/shared.c
@@ -71,6 +71,7 @@ uint64_t remote_cq_data = 0;
 uint64_t tx_seq, rx_seq, tx_cq_cntr, rx_cq_cntr;
 int ft_skip_mr = 0;
 int (*ft_mr_alloc_func)(void);
+uint64_t ft_tag = 0;
 int ft_parent_proc = 0;
 pid_t ft_child_pid = 0;
 int ft_socket_pair[2];
@@ -1374,7 +1375,7 @@ ssize_t ft_post_tx(struct fid_ep *ep, fi_addr_t fi_addr, size_t size, struct fi_
 	if (hints->caps & FI_TAGGED) {
 		FT_POST(fi_tsend, ft_get_tx_comp, tx_seq, "transmit", ep,
 				tx_buf, size + ft_tx_prefix_size(), fi_mr_desc(mr),
-				fi_addr, tx_seq, ctx);
+				fi_addr, ft_tag ? ft_tag : tx_seq, ctx);
 	} else {
 		FT_POST(fi_send, ft_get_tx_comp, tx_seq, "transmit", ep,
 				tx_buf,	size + ft_tx_prefix_size(), fi_mr_desc(mr),
@@ -1571,7 +1572,7 @@ ssize_t ft_post_rx(struct fid_ep *ep, size_t size, struct fi_context* ctx)
 	if (hints->caps & FI_TAGGED) {
 		FT_POST(fi_trecv, ft_get_rx_comp, rx_seq, "receive", ep, rx_buf,
 				MAX(size, FT_MAX_CTRL_MSG) + ft_rx_prefix_size(),
-				fi_mr_desc(mr), 0, rx_seq, 0, ctx);
+				fi_mr_desc(mr), 0, ft_tag ? ft_tag : rx_seq, 0, ctx);
 	} else {
 		FT_POST(fi_recv, ft_get_rx_comp, rx_seq, "receive", ep, rx_buf,
 				MAX(size, FT_MAX_CTRL_MSG) + ft_rx_prefix_size(),
@@ -2066,6 +2067,7 @@ void ft_usage(char *name, char *desc)
 	FT_PRINT_OPTS_USAGE("", "fi_shared_ctx");
 	FT_PRINT_OPTS_USAGE("", "fi_multi_mr");
 	FT_PRINT_OPTS_USAGE("", "fi_multi_ep");
+	FT_PRINT_OPTS_USAGE("", "fi_recv_cancel");
 	FT_PRINT_OPTS_USAGE("-a <address vector name>", "name of address vector");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
 

--- a/common/shared.c
+++ b/common/shared.c
@@ -2068,6 +2068,7 @@ void ft_usage(char *name, char *desc)
 	FT_PRINT_OPTS_USAGE("", "fi_multi_mr");
 	FT_PRINT_OPTS_USAGE("", "fi_multi_ep");
 	FT_PRINT_OPTS_USAGE("", "fi_recv_cancel");
+	FT_PRINT_OPTS_USAGE("", "fi_unexpected_msg");
 	FT_PRINT_OPTS_USAGE("-a <address vector name>", "name of address vector");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -186,6 +186,7 @@ void ft_csusage(char *name, char *desc);
 
 void ft_fill_buf(void *buf, int size);
 int ft_check_buf(void *buf, int size);
+int ft_check_opts(uint64_t flags);
 uint64_t ft_init_cq_data(struct fi_info *info);
 int ft_sock_listen(char *service);
 int ft_sock_connect(char *node, char *service);
@@ -195,6 +196,7 @@ int ft_sock_recv(int fd, void *msg, size_t len);
 int ft_sock_sync(int value);
 void ft_sock_shutdown(int fd);
 extern int ft_skip_mr;
+extern int (*ft_mr_alloc_func)(void);
 extern int ft_parent_proc;
 extern int ft_socket_pair[2];
 extern int sock;

--- a/include/shared.h
+++ b/include/shared.h
@@ -129,6 +129,7 @@ struct ft_opts {
 	int transfer_size;
 	int window_size;
 	int av_size;
+	int verbose;
 	char *src_port;
 	char *dst_port;
 	char *src_addr;
@@ -199,6 +200,7 @@ int ft_sock_sync(int value);
 void ft_sock_shutdown(int fd);
 extern int ft_skip_mr;
 extern int (*ft_mr_alloc_func)(void);
+extern uint64_t ft_tag;
 extern int ft_parent_proc;
 extern int ft_socket_pair[2];
 extern int sock;
@@ -217,6 +219,7 @@ extern char default_port[8];
 		.transfer_size = 1024, \
 		.window_size = 64, \
 		.av_size = 1, \
+		.verbose = 0, \
 		.sizes_enabled = FT_DEFAULT_SIZE, \
 		.rma_op = FT_RMA_WRITE, \
 		.argc = argc, .argv = argv \

--- a/include/shared.h
+++ b/include/shared.h
@@ -128,6 +128,7 @@ struct ft_opts {
 	int warmup_iterations;
 	int transfer_size;
 	int window_size;
+	int av_size;
 	char *src_port;
 	char *dst_port;
 	char *src_addr;
@@ -215,6 +216,7 @@ extern char default_port[8];
 		.warmup_iterations = 10, \
 		.transfer_size = 1024, \
 		.window_size = 64, \
+		.av_size = 1, \
 		.sizes_enabled = FT_DEFAULT_SIZE, \
 		.rma_op = FT_RMA_WRITE, \
 		.argc = argc, .argv = argv \
@@ -303,9 +305,19 @@ int ft_init_fabric();
 int ft_start_server();
 int ft_server_connect();
 int ft_client_connect();
+int ft_init_fabric_cm(void);
+int ft_complete_connect(struct fid_ep *ep, struct fid_eq *eq);
+int ft_retrieve_conn_req(struct fid_eq *eq, struct fi_info **fi);
+int ft_accept_connection(struct fid_ep *ep, struct fid_eq *eq);
+int ft_connect_ep(struct fid_ep *ep,
+		struct fid_eq *eq, fi_addr_t *remote_addr);
 int ft_alloc_ep_res(struct fi_info *fi);
 int ft_alloc_active_res(struct fi_info *fi);
 int ft_init_ep(void);
+int ft_setup_ep(struct fid_ep *ep, struct fid_eq *eq,
+		struct fid_av *av, struct fid_cq *txcq,
+		struct fid_cq *rxcq, struct fid_cntr *txcntr,
+		struct fid_cntr *rxcntr, bool post_initial_recv);
 int ft_init_alias_ep(uint64_t flags);
 int ft_av_insert(struct fid_av *av, void *addr, size_t count, fi_addr_t *fi_addr,
 		uint64_t flags, void *context);

--- a/include/shared.h
+++ b/include/shared.h
@@ -38,6 +38,7 @@
 #include <inttypes.h>
 #include <netinet/tcp.h>
 #include <sys/uio.h>
+#include <stdbool.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_rma.h>
@@ -310,6 +311,10 @@ int ft_av_insert(struct fid_av *av, void *addr, size_t count, fi_addr_t *fi_addr
 		uint64_t flags, void *context);
 int ft_init_av(void);
 int ft_join_mc(void);
+int ft_init_av_dst_addr(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
+		fi_addr_t *remote_addr);
+int ft_init_av_addr(struct fid_av *av, struct fid_ep *ep,
+		fi_addr_t *addr);
 int ft_exchange_keys(struct fi_rma_iov *peer_iov);
 void ft_free_res();
 void init_test(struct ft_opts *opts, char *test_name, size_t test_name_len);

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -103,6 +103,7 @@ simple_tests=(
 	"rdm_shared_av"
 	"multi_mr -e msg -V"
 	"multi_mr -e rdm -V"
+	"rdm_multi_domain -V"
 )
 
 short_tests=(

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -104,6 +104,9 @@ simple_tests=(
 	"multi_mr -e msg -V"
 	"multi_mr -e rdm -V"
 	"rdm_multi_domain -V"
+	"multi_ep -e msg"
+	"multi_ep -e rdm"
+	"multi_ep -e dgram"
 )
 
 short_tests=(

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -101,6 +101,8 @@ simple_tests=(
 	"scalable_ep"
 	"cmatose"
 	"rdm_shared_av"
+	"multi_mr -e msg -V"
+	"multi_mr -e rdm -V"
 )
 
 short_tests=(

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -108,6 +108,12 @@ simple_tests=(
 	"multi_ep -e rdm"
 	"multi_ep -e dgram"
 	"recv_cancel -e rdm -V"
+	"unexpected_msg -e msg -i 10"
+	"unexpected_msg -e rdm -i 10"
+	"unexpected_msg -e dgram -i 10"
+	"unexpected_msg -e msg -S -i 10"
+	"unexpected_msg -e rdm -S -i 10"
+	"unexpected_msg -e dgram -S -i 10"
 )
 
 short_tests=(

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -107,6 +107,7 @@ simple_tests=(
 	"multi_ep -e msg"
 	"multi_ep -e rdm"
 	"multi_ep -e dgram"
+	"recv_cancel -e rdm -V"
 )
 
 short_tests=(

--- a/simple/multi_ep.c
+++ b/simple/multi_ep.c
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <time.h>
+#include <netdb.h>
+#include <unistd.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_cm.h>
+
+#define FT_FIVERSION FI_VERSION(1, 5)
+#include "shared.h"
+
+int num_eps;
+static struct fid_ep **eps;
+static fi_addr_t *remote_addr;
+
+static int alloc_multi_ep_res()
+{
+	eps = calloc(num_eps, sizeof(*eps));
+	if (!eps)
+		return -FI_ENOMEM;
+
+	remote_addr = calloc(num_eps, sizeof(*remote_addr));
+	if (!remote_addr)
+		return -FI_ENOMEM;
+
+	return 0;
+}
+
+static void free_ep_res()
+{
+	int i;
+
+	for (i = 0; i < num_eps; i++)
+		FT_CLOSE_FID(eps[i]);
+	free(eps);
+	free(remote_addr);
+}
+
+static int multi_ep_pingpong(void)
+{
+	int i, ret = 0;
+	int *send_bufs[num_eps];
+	int *recv_bufs[num_eps];
+	struct fi_context recv_ctx[num_eps];
+	struct fi_context send_ctx[num_eps];
+	int *rx_buf_ptr;
+	int *buffers;
+
+	buffers = calloc(num_eps * 2, opts.transfer_size);
+	if (!buffers)
+		return -FI_ENOMEM;
+
+	rx_buf_ptr = buffers + (opts.transfer_size * num_eps);
+	for (i = 0; i < num_eps; i++) {
+		send_bufs[i] = (int *)((uintptr_t)buffers + opts.transfer_size * i);
+		recv_bufs[i] = (int *)((uintptr_t)rx_buf_ptr + opts.transfer_size * i);
+	}
+
+	for (i = 0; i < num_eps; i++) {
+		rx_buf = (char *)recv_bufs[i];
+		ret = ft_post_rx(eps[i], opts.transfer_size, &recv_ctx[i]);
+		if (ret)
+			goto cleanup_and_close;
+	}
+
+	for (i = 0; i < num_eps; i++) {
+		if (ft_check_opts(FT_OPT_VERIFY_DATA))
+			ft_fill_buf((char *)send_bufs[i], opts.transfer_size);
+
+		tx_buf = (char *)send_bufs[i];
+		ret = ft_post_tx(eps[i], remote_addr[i], opts.transfer_size, &send_ctx[i]);
+		if (ret)
+			goto cleanup_and_close;
+	}
+
+	for (i = 0; i < num_eps; i++) {
+		tx_cq_cntr = 0;
+		ret = ft_get_tx_comp(1);
+		if (ret < 0)
+			goto cleanup_and_close;
+	}
+
+	for (i = 0; i < num_eps; i++) {
+		rx_cq_cntr = 0;
+		ret = ft_get_rx_comp(1);
+		if (ret < 0)
+			goto cleanup_and_close;
+		if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
+			ret = ft_check_buf((char *)recv_bufs[i], opts.transfer_size);
+			if (ret)
+				goto cleanup_and_close;
+		}
+	}
+	printf("PASSED multi ep pingpong\n");
+
+cleanup_and_close:
+	free(buffers);
+
+	return ret;
+}
+
+static int setup_client_ep(struct fid_ep **ep)
+{
+	int ret;
+
+	ret = fi_endpoint(domain, fi, ep, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_endpoint", ret);
+		return ret;
+	}
+
+	ret = ft_setup_ep(*ep, eq,
+			av, txcq,
+			rxcq, txcntr,
+			rxcntr, false);
+	if (ret)
+		return ret;
+
+	ret = ft_connect_ep(*ep, eq, fi->dest_addr);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static int setup_server_ep(struct fid_ep **ep)
+{
+	int ret;
+
+	ret = ft_retrieve_conn_req(eq, &fi);
+	if (ret)
+		goto failed_accept;
+
+	ret = fi_endpoint(domain, fi, ep, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_endpoint", ret);
+		goto failed_accept;
+	}
+
+	ret = ft_setup_ep(*ep, eq,
+			av, txcq,
+			rxcq, txcntr,
+			rxcntr, false);
+	if (ret)
+		goto failed_accept;
+
+	ret = ft_accept_connection(*ep, eq);
+	if (ret)
+		goto failed_accept;
+
+	return 0;
+
+failed_accept:
+	fi_reject(pep, fi->handle, NULL, 0);
+	return ret;
+}
+
+static int setup_av_ep(struct fid_ep **ep, fi_addr_t *remote_addr)
+{
+	int ret;
+	hints->src_addr = NULL;
+
+	fi_freeinfo(fi);
+
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		return ret;
+	}
+
+	ret = fi_endpoint(domain, fi, ep, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_endpoint", ret);
+		return ret;
+	}
+
+	ret = ft_setup_ep(*ep, eq,
+			av, txcq,
+			rxcq, txcntr,
+			rxcntr, false);
+	if (ret)
+		return ret;
+
+	ret = ft_init_av_addr(av, *ep,
+			remote_addr);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static int run_test(void)
+{
+	int i, ret;
+
+	ret = alloc_multi_ep_res();
+	if (ret)
+		return ret;
+
+	if (hints->ep_attr->type == FI_EP_MSG) {
+		ret = ft_init_fabric_cm();
+		if (ret)
+			return ret;
+	} else {
+		opts.av_size = num_eps + 1;
+		ret = ft_init_fabric();
+		if (ret)
+			return ret;
+	}
+
+	/* Create additional endpoints. */
+	for (i = 0; i < num_eps; i++) {
+		if (hints->ep_attr->type == FI_EP_MSG) {
+			if (opts.dst_addr) {
+				ret = setup_client_ep(&eps[i]);
+				if (ret)
+					return ret;
+			} else {
+				ret = setup_server_ep(&eps[i]);
+				if (ret)
+					return ret;
+			}
+		} else {
+			ret = setup_av_ep(&eps[i], &remote_addr[i]);
+			if (ret)
+				return ret;
+		}
+	}
+
+	ret = multi_ep_pingpong();
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	int op;
+	int ret = 0;
+
+	opts = INIT_OPTS;
+	opts.transfer_size = 256;
+	num_eps = 3;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt(argc, argv, "c:vh" ADDR_OPTS INFO_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case 'c':
+			num_eps = atoi(optarg);
+			break;
+		case 'v':
+			opts.options |= FT_OPT_VERIFY_DATA;
+			break;
+		case '?':
+		case 'h':
+			ft_usage(argv[0], "Multi endpoint pingpong test");
+			FT_PRINT_OPTS_USAGE("-c <int>", "number of endpoints to create and test");
+			FT_PRINT_OPTS_USAGE("-v", "Enable DataCheck testing");
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	ft_skip_mr = 1;
+	hints->caps = FI_MSG;
+	hints->mode = FI_CONTEXT;
+
+	ret = run_test();
+
+	free_ep_res();
+	ft_free_res();
+	return ft_exit_code(ret);
+}

--- a/simple/multi_mr.c
+++ b/simple/multi_mr.c
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_cm.h>
+
+#define FT_FIVERSION FI_VERSION(1,5)
+#include "shared.h"
+
+struct test_mr {
+	uint8_t *buf;
+	struct fid_cntr *rcntr;
+	uint64_t rcntr_next;
+	struct fid_mr *mr;
+	struct fi_rma_iov *remote;
+};
+
+struct test_mr *mr_res_array;
+uint8_t *mr_buf_array;
+struct fi_rma_iov *remote_array;
+uint64_t mr_count;
+int verbose;
+
+static int wait_cntr(struct fid_cntr *cntr, uint64_t *cntr_next)
+{
+	/* 30 second wait timeout */
+	int ret = fi_cntr_wait(cntr, *cntr_next, 30 * 1000);
+	if (ret < 0)
+		return ret;
+
+	*cntr_next += 1;
+
+	return 0;
+}
+
+static int free_mr_res()
+{
+	int ret, i;
+
+	if (!mr_res_array)
+		return 0;
+
+	for (i = 0; i < mr_count; i++) {
+		ret = fi_close(&mr_res_array[i].mr->fid);
+		if (ret) {
+			FT_PRINTERR("fi_close", ret);
+			return ret;
+		}
+
+		ret = fi_close(&mr_res_array[i].rcntr->fid);
+		if (ret) {
+			FT_PRINTERR("fi_close", ret);
+			return ret;
+		}
+	}
+	free(mr_res_array);
+	free(remote_array);
+	free(mr_buf_array);
+
+	return 0;
+}
+
+static int alloc_multi_mr_res()
+{
+	int i = 0;
+
+	mr_res_array = calloc(mr_count, sizeof(*mr_res_array));
+	if (!mr_res_array)
+		return -FI_ENOMEM;
+
+	remote_array = calloc(mr_count, sizeof(*remote_array));
+	if (!remote_array)
+		return -FI_ENOMEM;
+
+	mr_buf_array = calloc(mr_count, opts.transfer_size);
+	if (!mr_buf_array)
+		return -FI_ENOMEM;
+
+	for (i = 0; i < mr_count; i++) {
+		mr_res_array[i].remote = &remote_array[i];
+		mr_res_array[i].buf = &mr_buf_array[i];
+	}
+
+	return 0;
+}
+
+static int init_multi_mr_res()
+{
+	int ret = 0, i;
+
+	if ((1ULL << fi->domain_attr->mr_key_size) < mr_count) {
+		fprintf(stderr, "ERROR: too many memory regions for unique mr keys");
+		return -FI_EINVAL;
+	}
+
+	ret = alloc_multi_mr_res();
+	if (ret)
+		return ret;
+
+	for (i = 0; i < mr_count; i++) {
+		ret = fi_cntr_open(domain,
+				&cntr_attr,
+				&mr_res_array[i].rcntr,
+				NULL);
+		if (ret) {
+			FT_PRINTERR("fi_cntr_open", ret);
+			return ret;
+		}
+
+		mr_res_array[i].remote->len = opts.transfer_size;
+		mr_res_array[i].remote->addr = 0;
+
+		memset(mr_res_array[i].buf, 0, opts.transfer_size);
+
+		mr_res_array[i].rcntr_next = 1;
+
+		mr_res_array[i].remote->key = i + 1;
+
+		ret = fi_mr_reg(domain, mr_res_array[i].buf,
+				opts.transfer_size, FI_REMOTE_WRITE,
+				0, mr_res_array[i].remote->key,
+				0, &mr_res_array[i].mr, NULL);
+		if (ret) {
+			FT_PRINTERR("fi_mr_reg", ret);
+			return ret;
+		}
+
+		if (verbose) {
+			printf("MR_REG:domain_ptr, buf_ptr, mr_size, mr_ptr, mr_key)\n");
+			printf("%p, %p, %d, %p, %lu)\n",
+					domain,
+					mr_res_array[i].buf,
+					opts.transfer_size,
+					&mr_res_array[i].mr,
+					(unsigned long)fi_mr_key(mr_res_array[i].mr));
+		}
+
+		ret = fi_mr_bind(mr_res_array[i].mr,
+				&mr_res_array[i].rcntr->fid,
+				FI_REMOTE_WRITE);
+		if (ret) {
+			FT_PRINTERR("fi_mr_bind", ret);
+			return ret;
+		}
+	}
+
+	return ret;
+}
+
+static int mr_key_test()
+{
+	int i, ret = 0;
+	struct fi_context rma_ctx;
+
+	for (i = 0; i < mr_count; i++) {
+		tx_buf = (char *)mr_res_array[i].buf;
+
+		if (opts.dst_addr) {
+			ft_fill_buf(mr_res_array[i].buf,
+					opts.transfer_size);
+
+			if (verbose)
+				printf("write to host's key %lx\n",
+						(unsigned long)fi_mr_key(mr_res_array[i].mr));
+
+			ft_post_rma(FT_RMA_WRITE, ep, opts.transfer_size,
+					mr_res_array[i].remote, &rma_ctx);
+
+			if (verbose)
+				printf("sent successfully\n");
+
+			ret = wait_cntr(mr_res_array[i].rcntr,
+					&mr_res_array[i].rcntr_next);
+			if (ret)
+				return ret;
+
+			if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
+				if (verbose)
+					printf("checking result in buffer %p, key %lx\n",
+							mr_res_array[i].buf,
+							(unsigned long)fi_mr_key(mr_res_array[i].mr));
+
+				ret = ft_check_buf(mr_res_array[i].buf,
+						opts.transfer_size);
+				if (ret)
+					return ret;
+			}
+		} else {
+			ret = wait_cntr(mr_res_array[i].rcntr,
+					&mr_res_array[i].rcntr_next);
+			if (ret)
+				return ret;
+
+			if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
+				if (verbose)
+					printf("checking result in buffer %p, key %lx\n",
+							mr_res_array[i].buf,
+							(unsigned long)fi_mr_key(mr_res_array[i].mr));
+
+				ret = ft_check_buf(mr_res_array[i].buf,
+						opts.transfer_size);
+				if (ret)
+					return ret;
+			}
+
+			ft_fill_buf(mr_res_array[i].buf,
+					opts.transfer_size);
+
+			if (verbose)
+				printf("write to client's key %lx\n",
+						(unsigned long)fi_mr_key(mr_res_array[i].mr));
+
+			ft_post_rma(FT_RMA_WRITE, ep, opts.transfer_size,
+					mr_res_array[i].remote, &rma_ctx);
+
+			if (verbose)
+					printf("sent successfully\n");
+		}
+	}
+	printf("GOOD, multi mr key test complete\n");
+
+	return ret;
+}
+
+static int init_fabric_cm(void)
+{
+	int ret;
+	if (!opts.dst_addr) {
+		ret = ft_start_server();
+		if (ret)
+			return ret;
+	}
+
+	ret = opts.dst_addr ? ft_client_connect() : ft_server_connect();
+
+	return ret;
+}
+
+static int run_test(void)
+{
+	int ret = 0;
+
+	ft_mr_alloc_func = init_multi_mr_res;
+
+	if (hints->ep_attr->type == FI_EP_MSG)
+		ret = init_fabric_cm();
+	else
+		ret = ft_init_fabric();
+	if (ret)
+		return ret;
+
+	ret = mr_key_test();
+
+	ft_sync();
+	ft_finalize();
+
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	int op;
+	int ret = 0;
+
+	opts = INIT_OPTS;
+	opts.transfer_size = 4096;
+	mr_count = 2;
+	verbose = 0;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt(argc, argv, "c:Vvh" ADDR_OPTS INFO_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case 'c':
+			mr_count = strtoull(optarg, NULL, 10);
+			break;
+		case 'V':
+			verbose = 1;
+			break;
+		case 'v':
+			opts.options |= FT_OPT_VERIFY_DATA;
+			break;
+		case '?':
+		case 'h':
+			ft_usage(argv[0], "Ping-pong multi memory region test");
+			FT_PRINT_OPTS_USAGE("-c <int>", "number of memory regions to create and test");
+			FT_PRINT_OPTS_USAGE("-V", "Enable verbose printing");
+			FT_PRINT_OPTS_USAGE("-v", "Enable DataCheck testing");
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	hints->caps = FI_RMA | FI_RMA_EVENT | FI_MSG;
+	hints->mode = FI_CONTEXT | FI_LOCAL_MR;
+
+	ret = run_test();
+
+	free_mr_res();
+	ft_free_res();
+	return ft_exit_code(ret);
+}

--- a/simple/multi_mr.c
+++ b/simple/multi_mr.c
@@ -259,20 +259,6 @@ static int mr_key_test()
 	return ret;
 }
 
-static int init_fabric_cm(void)
-{
-	int ret;
-	if (!opts.dst_addr) {
-		ret = ft_start_server();
-		if (ret)
-			return ret;
-	}
-
-	ret = opts.dst_addr ? ft_client_connect() : ft_server_connect();
-
-	return ret;
-}
-
 static int run_test(void)
 {
 	int ret = 0;
@@ -280,7 +266,7 @@ static int run_test(void)
 	ft_mr_alloc_func = init_multi_mr_res;
 
 	if (hints->ep_attr->type == FI_EP_MSG)
-		ret = init_fabric_cm();
+		ret = ft_init_fabric_cm();
 	else
 		ret = ft_init_fabric();
 	if (ret)

--- a/simple/rdm_multi_domain.c
+++ b/simple/rdm_multi_domain.c
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <unistd.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_cm.h>
+#define FT_FIVERSION FI_VERSION(1, 5)
+#include "shared.h"
+
+struct test_domain {
+	uint8_t *buf;
+	struct fid_domain *dom;
+	struct fid_ep *ep;
+	struct fid_cntr *rx_cntr;
+	uint64_t rma_op_cnt;
+	struct fid_cntr *tx_cntr;
+	struct fid_av *av;
+	struct fid_mr *mr;
+};
+
+struct test_domain *domain_res_array;
+uint8_t *mr_buf_array;
+fi_addr_t *peer_addrs;
+int domain_cnt;
+int verbose;
+
+static int alloc_domain_res()
+{
+	domain_res_array = calloc(domain_cnt, sizeof(*domain_res_array));
+	if (!domain_res_array)
+		return -FI_ENOMEM;
+
+	mr_buf_array = calloc(domain_cnt, opts.transfer_size);
+	if (!mr_buf_array)
+		return -FI_ENOMEM;
+
+	peer_addrs = calloc(domain_cnt, sizeof(*peer_addrs));
+	if (!peer_addrs)
+		return -FI_ENOMEM;
+
+	return 0;
+}
+
+static int open_domain_res(struct test_domain *domain)
+{
+	int ret;
+
+	av_attr.type = FI_AV_MAP;
+	av_attr.count = domain_cnt;
+	av_attr.name = NULL;
+
+	ret = fi_cntr_open(domain->dom,
+			&cntr_attr, &domain->rx_cntr, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_cntr_open", ret);
+		return ret;
+	}
+
+	ret = fi_cntr_open(domain->dom,
+			&cntr_attr, &domain->tx_cntr, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_cntr_open", ret);
+		return ret;
+	}
+
+	ret = fi_av_open(domain->dom,
+			&av_attr, &domain->av, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_av_open", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int init_ep_mr_res(struct test_domain *domain, struct fi_info *info)
+{
+	int ret;
+
+	domain->rma_op_cnt = 0;
+
+	ret = fi_endpoint(domain->dom, info, &domain->ep, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_endpoint", ret);
+		return ret;
+	}
+
+	ret = fi_ep_bind(domain->ep,
+			&domain->av->fid, 0);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	ret = fi_ep_bind(domain->ep,
+			&domain->tx_cntr->fid, FI_WRITE);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind", ret);
+		return ret;
+	}
+
+	ret = fi_enable(domain->ep);
+	if (ret) {
+		FT_PRINTERR("fi_enable", ret);
+		return ret;
+	}
+
+	ret = fi_mr_reg(domain->dom, domain->buf,
+			opts.transfer_size, FI_REMOTE_WRITE,
+			0, FT_MR_KEY, 0, &domain->mr, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_mr_reg", ret);
+		return ret;
+	}
+
+	if (verbose) {
+		printf("fi_mr_reg(fi_domain = %p,buffer = %p,size = %d,",
+				domain->dom, domain->buf, opts.transfer_size);
+		printf("memory_region = %p,mr_key %ld)\n",
+				domain->mr, (unsigned long)fi_mr_key(domain->mr));
+	}
+
+	ret = fi_mr_bind(domain->mr,
+			&domain->rx_cntr->fid,
+			FI_REMOTE_WRITE);
+	if (ret) {
+		FT_PRINTERR("fi_mr_bind", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int init_peer_addresses()
+{
+	int dom_idx, ret;
+
+	for (dom_idx = 0; dom_idx < domain_cnt; dom_idx++) {
+		ret = ft_init_av_addr(domain_res_array[dom_idx].av,
+				domain_res_array[dom_idx].ep, &peer_addrs[dom_idx]);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int init_domain_res()
+{
+	int dom_idx, ret;
+
+	for (dom_idx = 0; dom_idx < domain_cnt; dom_idx++) {
+		struct fi_info *info;
+		hints->src_addr = NULL;
+		ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &info);
+		if (ret) {
+			FT_PRINTERR("fi_getinfo", ret);
+			return ret;
+		}
+
+		info->domain_attr->mr_mode = FI_MR_SCALABLE;
+		ret = fi_domain(fabric, info,
+				&domain_res_array[dom_idx].dom,
+				NULL);
+		if (ret) {
+			FT_PRINTERR("fi_domain", ret);
+			return ret;
+		}
+
+		domain_res_array[dom_idx].buf = &mr_buf_array[dom_idx];
+
+		ret = open_domain_res(&domain_res_array[dom_idx]);
+		if (ret)
+			return ret;
+
+		ret = init_ep_mr_res(&domain_res_array[dom_idx], info);
+		if (ret)
+			return ret;
+
+		fi_freeinfo(info);
+	}
+
+	return 0;
+}
+
+static void free_domain_res()
+{
+	int dom_idx;
+
+	for (dom_idx = 0; dom_idx < domain_cnt; dom_idx++) {
+		FT_CLOSE_FID(domain_res_array[dom_idx].ep);
+		FT_CLOSE_FID(domain_res_array[dom_idx].av);
+		FT_CLOSE_FID(domain_res_array[dom_idx].mr);
+		FT_CLOSE_FID(domain_res_array[dom_idx].tx_cntr);
+		FT_CLOSE_FID(domain_res_array[dom_idx].rx_cntr);
+		FT_CLOSE_FID(domain_res_array[dom_idx].dom);
+	}
+	free(peer_addrs);
+	free(mr_buf_array);
+	free(domain_res_array);
+}
+
+static int write_data(void *buffer, size_t size, int dom_idx,
+		int remote_dom_idx)
+{
+	struct fi_context rma_ctx;
+	int ret = -FI_EAGAIN;
+
+	while (ret == -FI_EAGAIN) {
+		ret = fi_write(domain_res_array[dom_idx].ep, buffer, size,
+				fi_mr_desc(domain_res_array[dom_idx].mr), peer_addrs[remote_dom_idx],
+				0, fi_mr_key(domain_res_array[dom_idx].mr), &rma_ctx);
+	}
+
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static int multi_domain_test()
+{
+	int ret, remote_dom_idx, dom_idx;
+
+	ft_sync();
+
+	for (dom_idx = 0; dom_idx < domain_cnt; dom_idx++) {
+		for (remote_dom_idx = 0; remote_dom_idx < domain_cnt; remote_dom_idx++) {
+			if (verbose)
+				printf("write to host's domain idx %d, memory region\n", remote_dom_idx);
+
+			ret = write_data(tx_buf, opts.transfer_size, dom_idx, remote_dom_idx);
+			if (ret)
+				return ret;
+
+			domain_res_array[dom_idx].rma_op_cnt++;
+		}
+	}
+
+	for (dom_idx = 0; dom_idx < domain_cnt; dom_idx++) {
+		ret = fi_cntr_wait(domain_res_array[dom_idx].tx_cntr,
+				domain_res_array[dom_idx].rma_op_cnt, 30 * 1000);
+		if (ret < 0)
+			return ret;
+
+		if (verbose)
+			printf("writes from domain idx %d completed\n", dom_idx);
+	}
+
+	for (dom_idx = 0; dom_idx < domain_cnt; dom_idx++) {
+		if (verbose)
+			printf("check for writes to domain idx %d\n", dom_idx);
+
+		ret = fi_cntr_wait(domain_res_array[dom_idx].rx_cntr,
+				domain_res_array[dom_idx].rma_op_cnt, 30 * 1000);
+		if (ret < 0)
+			return ret;
+
+		if (verbose)
+			printf("got all writes to domain idx %d\n", dom_idx);
+	}
+	printf("GOOD, multi domain test complete\n");
+	return 0;
+}
+
+static int run_test(void)
+{
+	int ret;
+
+	ret = ft_init_fabric();
+	if (ret)
+		return ret;
+
+	ret = alloc_domain_res();
+	if (ret)
+		return ret;
+	ret = init_domain_res();
+	if (ret)
+		return ret;
+
+	ret = init_peer_addresses();
+	if (ret)
+		return ret;
+
+	ret = multi_domain_test();
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	int op, ret;
+
+	domain_cnt = 2;
+	opts = INIT_OPTS;
+	opts.transfer_size = 4096;
+	verbose = 0;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt(argc, argv, "c:Vh" ADDR_OPTS INFO_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case 'c':
+			domain_cnt = strtoull(optarg, NULL, 10);
+			break;
+		case 'V':
+			verbose = 1;
+			break;
+		case '?':
+		case 'h':
+			ft_usage(argv[0], "Ping-pong multi-domain test");
+			FT_PRINT_OPTS_USAGE("-c <int>", "number of domains to create and test");
+			FT_PRINT_OPTS_USAGE("-V", "Enable verbose printing");
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_RMA | FI_RMA_EVENT | FI_MSG;
+	hints->mode = FI_CONTEXT | FI_LOCAL_MR;
+
+	ret = run_test();
+
+	if (domain_res_array)
+		free_domain_res();
+	ft_free_res();
+
+	return ft_exit_code(ret);
+}

--- a/simple/recv_cancel.c
+++ b/simple/recv_cancel.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include "shared.h"
+
+#define CANCEL_TAG 0xC
+#define STANDARD_TAG 0xA
+
+static int recv_cancel_client(void)
+{
+	int ret;
+
+	/* sync with server */
+	ret = ft_rx(ep, 1);
+	if (ret)
+		return ret;
+
+	ft_tag = CANCEL_TAG;
+	ret = ft_post_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+	if (ret)
+		return ret;
+
+	if (opts.verbose)
+		fprintf(stdout, "CANCEL msg posted to server\n");
+
+	ft_tag = STANDARD_TAG;
+	ret = ft_post_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+	if (ret)
+		return ret;
+
+	if (opts.verbose)
+		fprintf(stdout, "STANDARD msg posted to server\n");
+
+	ret = ft_get_tx_comp(tx_seq);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static int recv_cancel_host(void)
+{
+	int ret = 0;
+	int retries = 0;
+	struct fi_cq_err_entry recv_completion, cancel_error_entry;
+	struct fi_context cancel_recv_ctx, standard_recv_ctx;
+
+	/* Pre-post two recvs, one of which will be cancelled */
+	ft_tag = CANCEL_TAG;
+	ret = ft_post_rx(ep, opts.transfer_size, &cancel_recv_ctx);
+	if (ret)
+		return ret;
+
+	ft_tag = STANDARD_TAG;
+	ret = ft_post_rx(ep, opts.transfer_size, &standard_recv_ctx);
+	if (ret)
+		return ret;
+
+	/* Cancel the first recv*/
+	ret = fi_cancel((struct fid *)ep, &cancel_recv_ctx);
+	if (ret) {
+		FT_PRINTERR("fi_cancel", ret);
+		return ret;
+	}
+
+	/* sync with client */
+	ft_tag = 0;
+	ret = ft_tx(ep, remote_fi_addr, 1, &tx_ctx);
+	if (ret)
+		return ret;
+
+	/* Wait for fi_cq_read to fail indicating an err entry */
+	do {
+		ret = fi_cq_read(rxcq, &recv_completion, 1);
+		if (ret == -FI_EAVAIL)
+			break;
+		else
+			retries++;
+		usleep(1000);
+	} while ((ret == -FI_EAGAIN) && (retries < 5000));
+	if (retries >= 5000) {
+		FT_PRINTERR("ERROR: failed to detect error CQ entry in cq_read", -FI_EOTHER);
+		return -FI_EOTHER;
+	} else {
+		if (opts.verbose)
+			fprintf(stdout, "GOOD: detected error cq entry in cq_read\n");
+	}
+
+	/* Verify the error CQ has been populated */
+	if (fi_cq_readerr(rxcq, &cancel_error_entry, 0) != 1) {
+		FT_PRINTERR("ERROR: No cancel CQ error entry was populated", -FI_EOTHER);
+		return -FI_EOTHER;
+	}
+
+	if (cancel_error_entry.err != FI_ECANCELED) {
+		FT_PRINTERR("ERROR: error code is incorrect", -FI_EOTHER);
+		return -FI_EOTHER;
+	}
+
+	if (!(cancel_error_entry.flags & FI_RECV)) {
+		FT_PRINTERR("ERROR: cancelled completion flags is incorrect", -FI_EOTHER);
+		return -FI_EOTHER;
+	}
+
+	if (opts.verbose)
+		fprintf(stdout, "GOOD: error entry has expected values\n");
+
+	/* Verify only one CQ err entry can be read */
+	if (fi_cq_readerr(rxcq, &cancel_error_entry, 0) != -FI_EAGAIN) {
+		FT_PRINTERR("ERROR: Another CQ error entry was populated", -FI_EOTHER);
+		return -FI_EOTHER;
+	}
+
+	if (opts.verbose)
+		fprintf(stdout, "GOOD: no additional error entries have been detected\n");
+
+	/* Check for second recv completion*/
+	do {
+		ret = fi_cq_read(rxcq, &recv_completion, 1);
+		if (ret > 0) {
+			if (recv_completion.op_context != &standard_recv_ctx) {
+				FT_PRINTERR("ERROR: op_context does not match recv ctx", -FI_EOTHER);
+				return -FI_EOTHER;
+			}
+		} else if ((ret <= 0) && (ret != -FI_EAGAIN)) {
+			FT_PRINTERR("fi_cq_read", ret);
+		}
+	} while (ret == -FI_EAGAIN);
+
+	if (opts.verbose)
+		fprintf(stdout, "GOOD: Completed uncancelled recv\n");
+
+	fprintf(stdout, "GOOD: Completed Recv Cancel Test\n");
+
+	return 0;
+}
+
+static int run_test(void)
+{
+	int ret;
+	if (hints->ep_attr->type == FI_EP_MSG)
+		ret = ft_init_fabric_cm();
+	else
+		ret = ft_init_fabric();
+	if (ret)
+		return ret;
+
+	if (opts.dst_addr)
+		return recv_cancel_client();
+	else
+		return recv_cancel_host();
+}
+
+int main(int argc, char **argv)
+{
+	int op;
+	int ret = 0;
+
+	opts = INIT_OPTS;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt(argc, argv, "Vh" ADDR_OPTS INFO_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case 'V':
+			opts.verbose = 1;
+			break;
+		case '?':
+		case 'h':
+			ft_usage(argv[0], "Recv Cancel Functional test");
+			FT_PRINT_OPTS_USAGE("-V", "Enable Verbose printing");
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	hints->caps = FI_TAGGED;
+	hints->mode = FI_CONTEXT;
+
+	ret = run_test();
+
+	ft_free_res();
+	return ft_exit_code(ret);
+}

--- a/simple/unexpected_msg.c
+++ b/simple/unexpected_msg.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <time.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_cm.h>
+#define FT_FIVERSION FI_VERSION(1, 5)
+#include "shared.h"
+
+char *sock_sync_port = "2710";
+
+static size_t concurrent_msgs = 5;
+static size_t num_iters = 600;
+uint64_t num_send;
+uint64_t num_recv;
+
+static int wait_msg(struct fid_cq *cq, struct fi_cq_err_entry *status)
+{
+	int ret;
+
+	if (opts.comp_method == FT_COMP_SREAD) {
+		ret = fi_cq_sread(cq, (void *)status, 1, NULL, -1);
+	} else {
+		do {
+			ret = fi_cq_read(cq, (void *)status, 1);
+		} while (ret == -FI_EAGAIN);
+	}
+
+	if (ret < 1)
+		printf("ERROR fi_cq_(s)read returned %d %s\n", ret, strerror(ret));
+	return ret;
+}
+
+static int run_test_loop(void)
+{
+	int ret = 0;
+	int i, j;
+	int *sbufs[concurrent_msgs];
+	int *rbufs[concurrent_msgs];
+	int *tx_buffers, *rx_buffers;
+	struct fi_context ctx_send[concurrent_msgs];
+	struct fi_context ctx_recv[concurrent_msgs];
+
+	tx_buffers = calloc(concurrent_msgs, opts.transfer_size);
+	if (!tx_buffers)
+		return -FI_ENOMEM;
+
+	rx_buffers = calloc(concurrent_msgs, opts.transfer_size);
+	if (!rx_buffers)
+		return -FI_ENOMEM;
+
+	for (j = 0; j < concurrent_msgs; j++) {
+		sbufs[j] = (int *)((uintptr_t)tx_buffers + opts.transfer_size * j);
+		rbufs[j] = (int *)((uintptr_t)rx_buffers + opts.transfer_size * j);
+	}
+
+	for (i = 0; i < num_iters; i++) {
+		struct fi_cq_err_entry status;
+
+		/* Init buffers and post sends */
+		for (j = 0; j < concurrent_msgs; j++) {
+			tx_buf = (void *)sbufs[j];
+			if (ft_check_opts(FT_OPT_VERIFY_DATA))
+				ft_fill_buf(tx_buf, opts.transfer_size);
+			ft_tag = 0x1234;
+			ret = ft_post_tx(ep, remote_fi_addr, opts.transfer_size, &ctx_send[j]);
+			if (ret) {
+				printf("ERROR send_msg returned %d\n", ret);
+				goto cleanup_and_close;
+			}
+		}
+
+		ret = ft_sock_sync(0);
+		if (ret)
+			goto cleanup_and_close;
+
+		/* Post CONCURRENT_MSG recvs */
+		for (j = 0; j < concurrent_msgs; j++) {
+			rx_buf = (void *)rbufs[j];
+			ft_tag = 0x1234;
+			ret = ft_post_rx(ep, opts.transfer_size, &ctx_recv[j]);
+			if (ret) {
+				printf("ERROR recv_msg returned %d\n", ret);
+				goto cleanup_and_close;
+			}
+		}
+
+		/* Complete receives */
+		for (j = 0; j < concurrent_msgs; j++) {
+			ret = wait_msg(rxcq, &status);
+			if (ret < 1)
+				goto cleanup_and_close;
+
+			/* Check Data */
+			if (status.buf != rbufs[j]) {
+				printf("ERROR bad completion buf %p rbuf %p\n", status.buf, rbufs[j]);
+				ret = -FI_EOTHER;
+				goto cleanup_and_close;
+			}
+
+			if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
+				ret = ft_check_buf(status.buf,
+						opts.transfer_size);
+				if (ret)
+					goto cleanup_and_close;
+			}
+		}
+
+		/* Complete sends */
+		for (j = 0; j < concurrent_msgs; j++) {
+			ret = ft_get_tx_comp(tx_seq);
+			if (ret)
+				goto cleanup_and_close;
+		}
+
+		if (i % 100 == 0)
+			printf("%d GOOD iter %d/%ld completed\n",
+					getpid(), i, num_iters);
+	}
+
+	printf("%d GOOD all done\n", getpid());
+
+cleanup_and_close:
+	free(tx_buffers);
+	free(rx_buffers);
+
+	return ret;
+}
+
+static int run_test(void)
+{
+	int ret;
+	int retries = 100;
+
+	if (hints->ep_attr->type == FI_EP_MSG)
+		ret = ft_init_fabric_cm();
+	else
+		ret = ft_init_fabric();
+	if (ret)
+		return ret;
+
+	if (opts.dst_addr) {
+		while (retries > 0) {
+			ret = ft_sock_connect(opts.dst_addr, sock_sync_port);
+			if (ret) {
+				usleep(100);
+				retries--;
+			}
+			else
+				break;
+		}
+		if (ret)
+			return ret;
+	} else {
+		ret = ft_sock_listen(sock_sync_port);
+		if (ret)
+			return ret;
+		ret = ft_sock_accept();
+		if (ret)
+			return ret;
+	}
+
+	ret = run_test_loop();
+
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	int op;
+	int ret;
+
+	opts = INIT_OPTS;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt(argc, argv, "m:i:c:vSh" ADDR_OPTS INFO_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case 'c':
+			concurrent_msgs = strtoul(optarg, NULL, 0);
+			break;
+		case 'i':
+			num_iters = strtoul(optarg, NULL, 0);
+			break;
+		case 'S':
+			opts.comp_method = FT_COMP_SREAD;
+			break;
+		case 'v':
+			opts.options |= FT_OPT_VERIFY_DATA;
+			break;
+		case 'm':
+			opts.transfer_size = strtoul(optarg, NULL, 0);
+			break;
+		case '?':
+		case 'h':
+			ft_usage(argv[0], "Unexpected message functional test");
+			FT_PRINT_OPTS_USAGE("-c <int>", "Concurrent messages per iteration ");
+			FT_PRINT_OPTS_USAGE("-v", "Enable DataCheck testing");
+			FT_PRINT_OPTS_USAGE("-i <int>", "Number of iterations");
+			FT_PRINT_OPTS_USAGE("-S", "Use fi_cq_sread instead of polling fi_cq_read");
+			FT_PRINT_OPTS_USAGE("-m <size>", "Size of unexpected messages");
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	hints->mode = FI_CONTEXT;
+	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
+	hints->rx_attr->total_buffered_recv = 0;
+	hints->caps = FI_TAGGED;
+
+	ret = run_test();
+
+	ft_free_res();
+	ft_sock_shutdown(sock);
+	return ft_exit_code(ret);
+}


### PR DESCRIPTION
Implemented new Functional tests for verifying:
- Multiple Memory Regions in use for sending messages between client/server to specified memory regions
- Multiple Domains in use for sending messages between client/server to specified domains
- Multiple Endpoints communicating between client/server created on a single domain.
- Cancelling a pending Receive and retrieving the correct error log.
- Unexpected messages handled by the provider

 Implemented support in the common infrastructure for:
- allowing easier setup of new RDM/DGRAM endpoints
- increase ease of init for connect/accept FI_EP_MSG endpoints for multi ep init
- added new init for CM (connect/accept) FI_EP_MSG testing
- configurable address vector size
- configurable tag for tagged messaging
- configurable option to enable verbose printing
- common init for new address vectors
- function pointer to customize allocating memory regions for tests

Signed-off-by: nrspruit <neil.r.spruit@intel.com>