### PR TITLE
multi_ep: Remove testing of udp provider

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -106,7 +106,6 @@ simple_tests=(
 	"rdm_multi_domain -V"
 	"multi_ep -e msg"
 	"multi_ep -e rdm"
-	"multi_ep -e dgram"
 	"recv_cancel -e rdm -V"
 	"unexpected_msg -e msg -i 10"
 	"unexpected_msg -e rdm -i 10"


### PR DESCRIPTION
fi_multi_ep is a new test, however it fails frequently for the udp
provider.  Remove dgram testing as part of the runfabtests script.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>