### PR TITLE
multi_ep: Disable automatic testing until failure is resolved

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -105,7 +105,6 @@ simple_tests=(
 	"multi_mr -e rdm -V"
 	"rdm_multi_domain -V"
 	"multi_ep -e msg"
-	"multi_ep -e rdm"
 	"recv_cancel -e rdm -V"
 	"unexpected_msg -e msg -i 10"
 	"unexpected_msg -e rdm -i 10"


### PR DESCRIPTION
This test still fails frequently.  It's not clear if this is an
issue with the test or socket provider.  Disable for now to not
block other PRs, while the cause is determined.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>