### PR TITLE
rma tests: Request support for remote CQ data for writedata

### DIFF
--- a/benchmarks/rma_bw.c
+++ b/benchmarks/rma_bw.c
@@ -125,7 +125,11 @@ int main(int argc, char **argv)
 
 	hints->caps = FI_MSG | FI_RMA;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
-	hints->mode = FI_CONTEXT | FI_RX_CQ_DATA;
+	hints->mode = FI_CONTEXT;
+	if (opts.rma_op == FT_RMA_WRITEDATA) {
+		hints->mode |= FI_RX_CQ_DATA;
+		hints->domain_attr->cq_data_size = 4;
+	}
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	ret = run();

--- a/simple/multi_mr.c
+++ b/simple/multi_mr.c
@@ -42,7 +42,6 @@
 #include <rdma/fi_rma.h>
 #include <rdma/fi_cm.h>
 
-#define FT_FIVERSION FI_VERSION(1,5)
 #include "shared.h"
 
 struct test_mr {

--- a/simple/rdm_multi_domain.c
+++ b/simple/rdm_multi_domain.c
@@ -42,7 +42,7 @@
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_cm.h>
-#define FT_FIVERSION FI_VERSION(1, 5)
+
 #include "shared.h"
 
 struct test_domain {

--- a/simple/unexpected_msg.c
+++ b/simple/unexpected_msg.c
@@ -45,7 +45,7 @@
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_cm.h>
-#define FT_FIVERSION FI_VERSION(1, 5)
+
 #include "shared.h"
 
 

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -137,7 +137,10 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_MSG;
 	hints->caps = FI_MSG | FI_RMA;
-	hints->mode = FI_RX_CQ_DATA;
+	if (opts.rma_op == FT_RMA_WRITEDATA) {
+		hints->mode |= FI_RX_CQ_DATA;
+		hints->domain_attr->cq_data_size = 4;
+	}
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	ret = run();

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -129,7 +129,10 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_RMA;
-	hints->mode = FI_RX_CQ_DATA;
+	if (opts.rma_op == FT_RMA_WRITEDATA) {
+		hints->mode |= FI_RX_CQ_DATA;
+		hints->domain_attr->cq_data_size = 4;
+	}
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	ret = run();


### PR DESCRIPTION
RMA tests that use the writedata operation should indicate that
remote CQ data is required.  Do this by specifying a non-zero
remote_cq_data domain attribute.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>