### PR TITLE
complex/fi_ubertest: change inject buffer right after send

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -73,6 +73,7 @@ extern const unsigned int lg_size_cnt;
 struct ft_xcontrol {
 	struct fid_ep		*ep;
 	void			*buf;
+	void			*cpy_buf;
 	struct fid_mr		*mr;
 	void			*memdesc;
 	struct iovec		*iov;

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -185,7 +185,8 @@ static int ft_setup_xcontrol_bufs(struct ft_xcontrol *ctrl)
 	size = ft_ctrl.size_array[ft_ctrl.size_cnt - 1];
 	if (!ctrl->buf) {
 		ctrl->buf = calloc(1, size);
-		if (!ctrl->buf)
+		ctrl->cpy_buf = calloc(1, size);
+		if (!ctrl->buf || !ctrl->cpy_buf)
 			return -FI_ENOMEM;
 	} else {
 		memset(ctrl->buf, 0, size);

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -525,6 +525,10 @@ int ft_send_rma(void)
 		return ret;
 	}
 
+	if (is_inject_func(test_info.class_function) &&
+	    test_info.test_type == FT_TEST_UNIT)
+		memset(ft_tx_ctrl.buf, 0, ft_tx_ctrl.rma_msg_size);
+
 	if (!ft_tx_ctrl.credits) {
 		ret = ft_comp_tx(0);
 		if (ret)
@@ -650,6 +654,10 @@ int ft_send_msg(void)
 		FT_PRINTERR("send", ret);
 		return ret;
 	}
+
+	if (is_inject_func(test_info.class_function) &&
+	    test_info.test_type == FT_TEST_UNIT)
+		memset(ft_tx_ctrl.buf, 0, ft_tx_ctrl.msg_size);
 
 	if (!ft_tx_ctrl.credits) {
 		ret = ft_comp_tx(0);

--- a/complex/ft_verify.c
+++ b/complex/ft_verify.c
@@ -93,10 +93,12 @@ int ft_sync_fill_bufs(size_t size)
 		SWITCH_TYPES(ft_atom_ctrl.datatype, FT_FILL, ft_mr_ctrl.buf,
 			     ft_atom_ctrl.count);
 		memcpy(ft_atom_ctrl.orig_buf, ft_mr_ctrl.buf, size);
+		memcpy(ft_tx_ctrl.cpy_buf, ft_tx_ctrl.buf, size);
 	} else if (is_read_func(test_info.class_function)) {
 		ft_fill_buf(ft_mr_ctrl.buf, size);
 	} else {
 		ft_fill_buf(ft_tx_ctrl.buf, size);
+		memcpy(ft_tx_ctrl.cpy_buf, ft_tx_ctrl.buf, size);
 	}
 
 	ft_sock_sync(0);
@@ -113,7 +115,7 @@ static int verify_atomic(void)
 	size_t count;
 
 	dst = ft_atom_ctrl.orig_buf;
-	src = ft_tx_ctrl.buf;
+	src = ft_tx_ctrl.cpy_buf;
 	cmp = ft_atom_ctrl.comp_buf;
 	tmp = ft_rx_ctrl.buf;
 	res = ft_atom_ctrl.res_buf;


### PR DESCRIPTION
More thoroughly test inject functions by changing buffer content right after send.
Requires a new copied transfer buffer for validation purposes.

Signed-off-by: aingerson <alexia.ingerson@intel.com>