### PR TITLE
multi_domain/ep: Disable from travis testing

### DIFF
--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -103,8 +103,6 @@ simple_tests=(
 	"rdm_shared_av"
 	"multi_mr -e msg -V"
 	"multi_mr -e rdm -V"
-	"rdm_multi_domain -V"
-	"multi_ep -e msg"
 	"recv_cancel -e rdm -V"
 	"unexpected_msg -e msg -i 10"
 	"unexpected_msg -e rdm -i 10"


### PR DESCRIPTION
Both tests continue to show hangs in travis.  They may be pointing
to issues with the socket provider, but until the failures are
resolved, disable from travis testing.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>