### PR TITLE
runfabtests.sh: Add option to specify test exclusions file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,10 @@ configdir = $(datarootdir)/${PACKAGE_NAME}
 AM_CFLAGS = -g -Wall -D_GNU_SOURCE -D 'CONFIG_PATH="${configdir}"' -I$(srcdir)/include
 ACLOCAL_AMFLAGS = -I config
 
+if MACOS
+os_excludes = -f ./test_configs/osx.exclude
+endif
+
 bin_PROGRAMS = \
 	simple/fi_msg \
 	simple/fi_msg_sockets \
@@ -58,6 +62,7 @@ dist_noinst_SCRIPTS = \
 	scripts/parseyaml.py
 
 nobase_dist_config_DATA = \
+	test_configs/osx.exclude \
         test_configs/eq_cq.test \
         test_configs/lat_bw.test \
         test_configs/sockets/all.test \
@@ -67,8 +72,10 @@ nobase_dist_config_DATA = \
         test_configs/udp/lat_bw.test \
         test_configs/udp/quick.test \
         test_configs/udp/simple.test \
+	test_configs/udp/udp.exclude \
         test_configs/verbs/all.test \
         test_configs/verbs/quick.test \
+	test_configs/verbs/verbs.exclude \
 	test_configs/usnic/all.test \
 	test_configs/usnic/quick.test \
 	test_configs/psm/all.test \
@@ -317,5 +324,5 @@ dist-hook: fabtests.spec
 	cp fabtests.spec $(distdir)
 
 test:
-	./scripts/runfabtests.sh -vvv
-	./scripts/runfabtests.sh -vvv udp
+	./scripts/runfabtests.sh -vvv -S $(os_excludes)
+	./scripts/runfabtests.sh -vvv -S $(os_excludes) -R -f ./test_configs/udp/udp.exclude udp

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -199,7 +199,9 @@ function errcho {
 }
 
 function print_border {
-	echo "# --------------------------------------------------------------"
+	printf "# "
+	printf "%.0s-" {1..78}
+	printf "\n"
 }
 
 function print_results {
@@ -213,7 +215,7 @@ function print_results {
 
 	if [ $VERBOSE -eq 0 ] ; then
 		# print a simple, single-line format that is still valid YAML
-		printf "%-50s%10s\n" "$test_exe:" "$test_result"
+		printf "%-70s%10s\n" "$test_exe:" "$test_result"
 	else
 		# Print a more detailed YAML format that is not a superset of
 		# the non-verbose output.  See ofiwg/fabtests#259 for a
@@ -465,7 +467,7 @@ function main {
 	fi
 
 	if [ $VERBOSE -eq 0 ] ; then
-		printf "# %-50s%10s\n" "Test" "Result"
+		printf "# %-68s%10s\n" "Test" "Result"
 		print_border
 	fi
 

--- a/test_configs/osx.exclude
+++ b/test_configs/osx.exclude
@@ -1,0 +1,4 @@
+# Regex patterns of tests to exclude in runfabtests.sh
+
+# Exclude msg_epoll test as OSX doesn't have epoll system call
+msg_epoll

--- a/test_configs/udp/udp.exclude
+++ b/test_configs/udp/udp.exclude
@@ -1,0 +1,17 @@
+# Regex patterns of tests to exclude in runfabtests.sh
+
+^msg
+-e msg
+rdm
+poll
+av_test.*
+eq_test
+mr_test
+cm_data
+cq_data
+cntr_test
+scalable_ep
+shared_ctx
+unexpected_msg
+cmatose
+rc_pingpong

--- a/test_configs/verbs/verbs.exclude
+++ b/test_configs/verbs/verbs.exclude
@@ -1,0 +1,24 @@
+# Regex patterns of tests to exclude in runfabtests.sh
+
+# Exclude all prefix tests
+-k
+
+dgram
+^poll
+
+# This test requires FI_RMA_EVENT
+rdm_rma_simple
+
+trigger
+
+# Verbs supports only shared receive context
+shared_ctx$|shared_ctx --no|shared_ctx -e msg$|shared_ctx -e msg --no-rx
+
+scalable_ep
+shared_av
+multi_mr
+recv_cancel
+unexpected_msg
+rma.+rdm.+writedata
+rdm.+atomic
+rdm.+cntr


### PR DESCRIPTION
- Increase runfabtests.sh output width for better alignment
- User can now specify a file containing a list of tests to exclude
- Add a strict mode which would treat -FI_ENODATA and -FI_ENOSYS errors
  as failures
- Allow user to specify regular expression patterns in exclude tests
  command line arg and in exclude file.
- Added exclusions list for verbs and udp providers
- Add OS specific exclusions in Makefile

This is a follow-up for PR #670 