### PR TITLE
Ubertest Updates/Fixes

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -148,6 +148,7 @@ enum ft_comp_type {
 	FT_COMP_UNSPEC,
 	FT_COMP_QUEUE,
 	FT_COMP_CNTR,
+	FT_COMP_ALL,
 	FT_MAX_COMP
 };
 
@@ -314,6 +315,8 @@ int ft_open_comp();
 int ft_bind_comp(struct fid_ep *ep);
 int ft_comp_rx(int timeout);
 int ft_comp_tx(int timeout);
+int ft_use_comp_cntr(enum ft_comp_type comp_type);
+int ft_use_comp_cq(enum ft_comp_type comp_type);
 
 int ft_open_active();
 int ft_open_passive();

--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -336,6 +336,7 @@ int ft_send_dgram_flood();
 int ft_sendrecv_dgram();
 int ft_send_rma();
 
+int ft_init_test();
 int ft_run_test();
 int ft_reset_ep();
 void ft_record_error(int error);

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -776,6 +776,9 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->ep_type = set->ep_type[series->cur_ep];
 	info->av_type = set->av_type[series->cur_av];
 	info->comp_type = set->comp_type[series->cur_comp];
+	if (info->caps & (FT_CAP_RMA | FT_CAP_ATOMIC) &&
+		(info->comp_type == FT_COMP_CNTR))
+		info->caps |= FI_RMA_EVENT;
 	info->eq_wait_obj = set->eq_wait_obj[series->cur_eq_wait_obj];
 	info->cntr_wait_obj = set->cntr_wait_obj[series->cur_cntr_wait_obj];
 

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -385,6 +385,7 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 	} else {
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_QUEUE, enum ft_comp_type, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_CNTR, enum ft_comp_type, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_ALL, enum ft_comp_type, buf);
 		TEST_SET_N_RETURN(str, len, "FT_MODE_ALL", FT_MODE_ALL, uint64_t, buf);
 		TEST_SET_N_RETURN(str, len, "FT_MODE_NONE", FT_MODE_NONE, uint64_t, buf);
 		TEST_SET_N_RETURN(str, len, "FT_FLAG_QUICKTEST", FT_FLAG_QUICKTEST, uint64_t, buf);
@@ -658,7 +659,7 @@ int fts_info_is_valid(void)
 		    test_info.class_function != FT_FUNC_SENDMSG &&
 		    test_info.class_function != FT_FUNC_WRITEMSG)
 			return 0;
-		if (test_info.comp_type == FT_COMP_CNTR)
+		if (ft_use_comp_cntr(test_info.comp_type))
 			return 0;
 	}
 
@@ -777,7 +778,7 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->av_type = set->av_type[series->cur_av];
 	info->comp_type = set->comp_type[series->cur_comp];
 	if (info->caps & (FT_CAP_RMA | FT_CAP_ATOMIC) &&
-		(info->comp_type == FT_COMP_CNTR))
+		(ft_use_comp_cntr(info->comp_type)))
 		info->caps |= FI_RMA_EVENT;
 	info->eq_wait_obj = set->eq_wait_obj[series->cur_eq_wait_obj];
 	info->cntr_wait_obj = set->cntr_wait_obj[series->cur_cntr_wait_obj];

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -221,6 +221,13 @@ static int ft_check_info(struct fi_info *hints, struct fi_info *info)
 static void ft_fw_convert_info(struct fi_info *info, struct ft_info *test_info)
 {
 	info->caps = test_info->caps;
+
+	if ((test_info->class_function == FT_FUNC_WRITEDATA) ||
+	    (test_info->class_function == FT_FUNC_INJECT_WRITEDATA) ||
+	    (test_info->class_function == FT_FUNC_INJECTDATA) ||
+	    (test_info->class_function == FT_FUNC_SENDDATA))
+		info->domain_attr->cq_data_size = 4;
+
 	info->mode = test_info->mode;
 
 	info->domain_attr->av_type = test_info->av_type;

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -177,6 +177,8 @@ static char *ft_comp_type_str(enum ft_comp_type comp_type)
 		return "comp_queue";
 	case FT_COMP_CNTR:
 		return "comp_cntr";
+	case FT_COMP_ALL:
+		return "comp_all";
 	default:
 		return "comp_unspec";
 	} 

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -377,7 +377,7 @@ static int ft_sync_test(int value)
 
 static int ft_sync_msg_needed()
 {
-	if (!(test_info.comp_type == FT_COMP_CNTR &&
+	if (!(ft_use_comp_cntr(test_info.comp_type) &&
 	    (test_info.test_class & (FI_RMA | FI_ATOMIC))) &&
 	    no_sync_needed(test_info.class_function, test_info.msg_flags))
 		return 0;
@@ -593,7 +593,7 @@ static int ft_bw_rma(void)
 			return ret;
 	} else {
 		if (no_sync_needed(test_info.class_function, test_info.msg_flags) &&
-		    test_info.comp_type != FT_COMP_CNTR)
+		    !(ft_use_comp_cntr(test_info.comp_type)))
 			i = ft_ctrl.xfer_iter;
 		else
 			i = 1;

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -906,7 +906,7 @@ static void ft_cleanup(void)
 	memset(&ft_ctrl, 0, sizeof ft_ctrl);
 }
 
-int ft_run_test()
+int ft_init_test()
 {
 	int ret;
 
@@ -936,14 +936,6 @@ int ft_run_test()
 		}
 	}
 
-	if (!opts.dst_addr) {
-		ret = ft_sock_send(sock, &test_info, sizeof test_info);
-		if (ret) {
-			FT_PRINTERR("ft_sock_send", ret);
-			return ret;
-		}
-	}
-
 	ft_sock_sync(0);
 
 	ret = ft_enable_comm();
@@ -951,6 +943,15 @@ int ft_run_test()
 		FT_PRINTERR("ft_enable_comm", ret);
 		goto cleanup;
 	}
+	return 0;
+cleanup:
+	ft_cleanup();
+	return ret;
+}
+
+int ft_run_test()
+{
+	int ret;
 
 	switch (test_info.test_type) {
 	case FT_TEST_UNIT:
@@ -974,7 +975,6 @@ int ft_run_test()
 	}
 
 	ft_sync_test(0);
-cleanup:
 	ft_cleanup();
 
 	return ret ? ret : -ft_ctrl.error;


### PR DESCRIPTION
Updates/Fixes to Ubertest including:
- Fix to ubertest to set cq_data_size when testing FI_REMOTE_CQ_DATA
- Added support for handling multiple fi_info structs for providers allowing for multi network device/config in testing
- Fixed ubertest to always open and bind a CQ to active endpoints for TX/RX event handling
- Fixed ubertest to support testing RMA/Atomic Counter completions by setting FI_RMA_EVENT given RMA/Atomic Counter completions are expected
- Added support to ubertest to allow test cases that get both CQ & CNTR completions in the same test case