### PR TITLE
shared: Fix mapping RMA tests to RMA capabilities

### DIFF
--- a/benchmarks/rma_bw.c
+++ b/benchmarks/rma_bw.c
@@ -97,13 +97,18 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
+	hints->caps = FI_MSG | FI_RMA;
+	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
+	hints->mode = FI_CONTEXT;
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+
 	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS BENCHMARK_OPTS)) != -1) {
 		switch (op) {
 		default:
 			ft_parse_benchmark_opts(op, optarg);
 			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
-			ret = ft_parse_rma_opts(op, optarg, &opts);
+			ret = ft_parse_rma_opts(op, optarg, hints, &opts);
 			if (ret)
 				return ret;
 			break;
@@ -122,15 +127,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	hints->caps = FI_MSG | FI_RMA;
-	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
-	hints->mode = FI_CONTEXT;
-	if (opts.rma_op == FT_RMA_WRITEDATA) {
-		hints->mode |= FI_RX_CQ_DATA;
-		hints->domain_attr->cq_data_size = 4;
-	}
-	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	ret = run();
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -184,7 +184,8 @@ extern struct ft_opts opts;
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints);
 void ft_parse_addr_opts(int op, char *optarg, struct ft_opts *opts);
 void ft_parsecsopts(int op, char *optarg, struct ft_opts *opts);
-int ft_parse_rma_opts(int op, char *optarg, struct ft_opts *opts);
+int ft_parse_rma_opts(int op, char *optarg, struct fi_info *hints,
+		      struct ft_opts *opts);
 void ft_addr_usage();
 void ft_usage(char *name, char *desc);
 void ft_mcusage(char *name, char *desc);
@@ -305,7 +306,6 @@ size_t datatype_to_size(enum fi_datatype datatype);
 
 int ft_alloc_bufs();
 int ft_open_fabric_res();
-int ft_set_rma_caps(struct fi_info *fi, enum ft_rma_opcodes rma_op);
 int ft_getinfo(struct fi_info *hints, struct fi_info **info);
 int ft_init_fabric();
 int ft_start_server();

--- a/streaming/msg_rma.c
+++ b/streaming/msg_rma.c
@@ -115,12 +115,16 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
+	hints->caps = FI_MSG | FI_RMA;
+	hints->ep_attr->type = FI_EP_MSG;
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+
 	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
 			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
-			ret = ft_parse_rma_opts(op, optarg, &opts);
+			ret = ft_parse_rma_opts(op, optarg, hints, &opts);
 			if (ret)
 				return ret;
 			break;
@@ -134,14 +138,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	hints->ep_attr->type = FI_EP_MSG;
-	hints->caps = FI_MSG | FI_RMA;
-	if (opts.rma_op == FT_RMA_WRITEDATA) {
-		hints->mode |= FI_RX_CQ_DATA;
-		hints->domain_attr->cq_data_size = 4;
-	}
-	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	ret = run();
 

--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -107,12 +107,16 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
+	hints->caps = FI_MSG | FI_RMA;
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+
 	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
 			ft_parseinfo(op, optarg, hints);
 			ft_parsecsopts(op, optarg, &opts);
-			ret = ft_parse_rma_opts(op, optarg, &opts);
+			ret = ft_parse_rma_opts(op, optarg, hints, &opts);
 			if (ret)
 				return ret;
 			break;
@@ -126,14 +130,6 @@ int main(int argc, char **argv)
 
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
-
-	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_MSG | FI_RMA;
-	if (opts.rma_op == FT_RMA_WRITEDATA) {
-		hints->mode |= FI_RX_CQ_DATA;
-		hints->domain_attr->cq_data_size = 4;
-	}
-	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	ret = run();
 


### PR DESCRIPTION
The RMA capability bit is independent of memory registration.
Restructure the processing of rma_op command line options, so that
the op can be used to configure the hints passed into fi_getinfo.
This fixes an issue where the local access (e.g. FI_WRITE or FI_READ)
end up being lost when an rma_op is specified.  Additionally, it
avoids modifying the returned fi_info, and instead updates hints
prior to them being used.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>