### PR TITLE
simple/unexpected_msg: Added Support for Remote CQ data testing

### DIFF
--- a/benchmarks/benchmark_shared.c
+++ b/benchmarks/benchmark_shared.c
@@ -177,7 +177,7 @@ int bandwidth(void)
 				ret = ft_inject(ep, remote_fi_addr, opts.transfer_size);
 			else
 				ret = ft_post_tx(ep, remote_fi_addr, opts.transfer_size,
-						 &tx_ctx_arr[j]);
+						 NO_CQ_DATA, &tx_ctx_arr[j]);
 			if (ret)
 				return ret;
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -212,6 +212,7 @@ extern int listen_sock;
 #define FAB_OPTS "f:d:p:"
 #define INFO_OPTS FAB_OPTS "e:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
+#define NO_CQ_DATA 0
 
 extern char default_port[8];
 
@@ -384,7 +385,7 @@ size_t ft_rx_prefix_size();
 size_t ft_tx_prefix_size();
 ssize_t ft_post_rx(struct fid_ep *ep, size_t size, struct fi_context* ctx);
 ssize_t ft_post_tx(struct fid_ep *ep, fi_addr_t fi_addr, size_t size,
-		struct fi_context* ctx);
+		uint64_t data, struct fi_context* ctx);
 ssize_t ft_rx(struct fid_ep *ep, size_t size);
 ssize_t ft_tx(struct fid_ep *ep, fi_addr_t fi_addr, size_t size, struct fi_context *ctx);
 ssize_t ft_inject(struct fid_ep *ep, fi_addr_t fi_addr, size_t size);

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -92,7 +92,7 @@ static int send_recv()
 	ft_sync();
 
 	fprintf(stdout, "Posting a send...\n");
-	ret = ft_post_tx(ep, remote_fi_addr, tx_size, &tx_ctx);
+	ret = ft_post_tx(ep, remote_fi_addr, tx_size, NO_CQ_DATA, &tx_ctx);
 	if (ret)
 		return ret;
 

--- a/simple/msg_epoll.c
+++ b/simple/msg_epoll.c
@@ -95,7 +95,7 @@ static int send_recv()
 			fprintf(stderr, "Transmit buffer too small.\n");
 			return -FI_ETOOSMALL;
 		}
-		ret = ft_post_tx(ep, remote_fi_addr, message_len, &tx_ctx);
+		ret = ft_post_tx(ep, remote_fi_addr, message_len, NO_CQ_DATA, &tx_ctx);
 		if (ret)
 			return ret;
 

--- a/simple/multi_ep.c
+++ b/simple/multi_ep.c
@@ -115,7 +115,7 @@ static int do_transfers(void)
 			ft_fill_buf(send_bufs[i], opts.transfer_size);
 
 		tx_buf = send_bufs[i];
-		ret = ft_post_tx(eps[i], remote_addr[i], opts.transfer_size, &send_ctx[i]);
+		ret = ft_post_tx(eps[i], remote_addr[i], opts.transfer_size, NO_CQ_DATA, &send_ctx[i]);
 		if (ret)
 			return ret;
 	}

--- a/simple/poll.c
+++ b/simple/poll.c
@@ -118,7 +118,7 @@ static int send_recv()
 	int i, tx_cntr_done = 0, rx_cntr_done = 0;
 
 	fprintf(stdout, "Posting a send...\n");
-	ret = ft_post_tx(ep, remote_fi_addr, tx_size, &tx_ctx);
+	ret = ft_post_tx(ep, remote_fi_addr, tx_size, NO_CQ_DATA, &tx_ctx);
 	if (ret)
 		return ret;
 

--- a/simple/recv_cancel.c
+++ b/simple/recv_cancel.c
@@ -47,7 +47,7 @@ static int recv_cancel_client(void)
 		return ret;
 
 	ft_tag = CANCEL_TAG;
-	ret = ft_post_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+	ret = ft_post_tx(ep, remote_fi_addr, opts.transfer_size, NO_CQ_DATA, &tx_ctx);
 	if (ret)
 		return ret;
 
@@ -55,7 +55,7 @@ static int recv_cancel_client(void)
 		fprintf(stdout, "CANCEL msg posted to server\n");
 
 	ft_tag = STANDARD_TAG;
-	ret = ft_post_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+	ret = ft_post_tx(ep, remote_fi_addr, opts.transfer_size, NO_CQ_DATA, &tx_ctx);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
  -simple/unexpected_msg
	-Added support for sending Remote CQ data for testing
  -common/shared
	-Added support in ft_post_tx to send CQ data for tagged and
		untagged messages
	-Added define for NO_CQ_DATA to be passed to ft_post_tx

   -Updated all uses of ft_post_tx to use NO_CQ_DATA unless testing
	CQ data passing

Change-Id: I0da3bcd6a30b7afa34d1968d938b03ff3df21616
Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>