### PR TITLE
simple/cq_data: Add the request of the FI_RX_CQ_DATA mode

### DIFF
--- a/simple/cq_data.c
+++ b/simple/cq_data.c
@@ -140,6 +140,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_MSG;
 	hints->caps = FI_MSG;
+	hints->mode = FI_RX_CQ_DATA;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	cq_attr.format = FI_CQ_FORMAT_DATA;


### PR DESCRIPTION
This is a quote from the fi_getinfo's man-page:

> **FI_RX_CQ_DATA**
> 
> _This mode bit only applies to data transfers that set FI_REMOTE_CQ_DATA. When set, a data transfer that carries remote CQ data will consume a receive buffer at the target. This is true even for operations that would normally not consume posted receive buffers, such as RMA write operations._


Since this test utilzes CQ data, the test should request the `FI_RX_CQ_DATA` mode for the providers to allocate an additional memory space or something else (depends on the provider) to receive carried data. 

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>