### PR TITLE
simple/inj_complete: Add possbility to use verbs/psm providers

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -51,7 +51,7 @@ benchmarks: $(outdir)\msg_pingpong.exe $(outdir)\rdm_cntr_pingpong.exe \
 simple: $(outdir)\cq_data.exe $(outdir)\dgram.exe $(outdir)\dgram_waitset.exe $(outdir)\msg.exe \
 	$(outdir)\msg_epoll.exe $(outdir)\msg_sockets.exe \
 	$(outdir)\poll.exe $(outdir)\rdm.exe $(outdir)\rdm_rma_simple.exe $(outdir)\rdm_rma_trigger.exe \
-	$(outdir)\rdm_tagged_peek.exe $(outdir)\scalable_ep.exe
+	$(outdir)\rdm_tagged_peek.exe $(outdir)\scalable_ep.exe $(outdir)\inj_complete.exe
 
 unit: $(outdir)\av_test.exe $(outdir)\dom_test.exe $(outdir)\eq_test.exe
 
@@ -93,6 +93,8 @@ $(outdir)\rdm_rma_trigger.exe: {simple}rdm_rma_trigger.c $(basedeps)
 $(outdir)\rdm_tagged_peek.exe: {simple}rdm_tagged_peek.c $(basedeps)
 
 $(outdir)\scalable_ep.exe: {simple}scalable_ep.c $(basedeps)
+
+$(outdir)\inj_complete.exe: {simple}inj_complete.c $(basedeps)
 
 $(outdir)\av_test.exe: {unit}av_test.c $(basedeps) {unit}common.c
 

--- a/common/shared.c
+++ b/common/shared.c
@@ -1899,10 +1899,13 @@ int ft_cq_read_verify(struct fid_cq *cq, void *op_context)
 
 		if (ret > 0) {
 			if (op_context != completion.op_context) {
-				fprintf(stderr, "ERROR: send ctx=%p cq_ctx=%p\n",
+				fprintf(stderr, "ERROR: op ctx=%p cq_ctx=%p\n",
 					op_context, completion.op_context);
 				return -FI_EOTHER;
 			}
+			if (!ft_tag_is_valid(cq, &completion,
+					     ft_tag ? ft_tag : rx_cq_cntr))
+				return -FI_EOTHER;
 		} else if ((ret <= 0) && (ret != -FI_EAGAIN)) {
 			FT_PRINTERR("POLL: Error\n", ret);
 			if (ret == -FI_EAVAIL)

--- a/common/shared.c
+++ b/common/shared.c
@@ -1807,13 +1807,14 @@ int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 	struct fi_msg msg;
 	struct fi_msg_tagged tagged_msg;
 	struct iovec msg_iov;
+	void *mr_desc = mr ? fi_mr_desc(mr) : 0;
 
 	msg_iov.iov_base = tx_buf;
 	msg_iov.iov_len = size;
 
 	if (hints->caps & FI_TAGGED) {
 		tagged_msg.msg_iov = &msg_iov;
-		tagged_msg.desc = mr ? fi_mr_desc(mr) : 0;
+		tagged_msg.desc = &mr_desc;
 		tagged_msg.iov_count = 1;
 		tagged_msg.addr = fi_addr;
 		tagged_msg.data = NO_CQ_DATA;
@@ -1828,7 +1829,7 @@ int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		}
 	} else {
 		msg.msg_iov = &msg_iov;
-		msg.desc = mr ? fi_mr_desc(mr) : 0;
+		msg.desc = &mr_desc;
 		msg.iov_count = 1;
 		msg.addr = fi_addr;
 		msg.data = NO_CQ_DATA;
@@ -1851,13 +1852,14 @@ int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 	struct fi_msg msg;
 	struct fi_msg_tagged tagged_msg;
 	struct iovec msg_iov;
+	void *mr_desc = mr ? fi_mr_desc(mr) : 0;
 
 	msg_iov.iov_base = rx_buf;
 	msg_iov.iov_len = size;
 
 	if (hints->caps & FI_TAGGED) {
 		tagged_msg.msg_iov = &msg_iov;
-		tagged_msg.desc = mr ? fi_mr_desc(mr) : 0;
+		tagged_msg.desc = &mr_desc;
 		tagged_msg.iov_count = 1;
 		tagged_msg.addr = fi_addr;
 		tagged_msg.data = NO_CQ_DATA;
@@ -1872,7 +1874,7 @@ int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		}
 	} else {
 		msg.msg_iov = &msg_iov;
-		msg.desc = mr ? fi_mr_desc(mr) : 0;
+		msg.desc = &mr_desc;
 		msg.iov_count = 1;
 		msg.addr = fi_addr;
 		msg.data = NO_CQ_DATA;

--- a/fabtests.vcxproj
+++ b/fabtests.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -95,6 +95,7 @@
     <ClCompile Include="simple\rdm_tagged_peek.c" />
     <ClCompile Include="simple\rdm_netdir.c" />
     <ClCompile Include="simple\scalable_ep.c" />
+    <ClCompile Include="simple\inj_complete.c" />
     <ClCompile Include="unit\av_test.c" />
     <ClCompile Include="unit\cntr_test.c" />
     <ClCompile Include="unit\common.c" />

--- a/fabtests.vcxproj.filters
+++ b/fabtests.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -91,6 +91,9 @@
       <Filter>Source Files\simple</Filter>
     </ClCompile>
     <ClCompile Include="simple\scalable_ep.c">
+      <Filter>Source Files\simple</Filter>
+    </ClCompile>
+    <ClCompile Include="simple\inj_complete.c">
       <Filter>Source Files\simple</Filter>
     </ClCompile>
     <ClCompile Include="complex\ft_comm.c">

--- a/simple/inj_complete.c
+++ b/simple/inj_complete.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
+#include <getopt.h>
 #include <rdma/fi_tagged.h>
 #include "shared.h"
 

--- a/simple/inj_complete.c
+++ b/simple/inj_complete.c
@@ -197,9 +197,10 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	ft_skip_mr = 1;
+	hints->mode = FI_CONTEXT;
 	hints->caps = FI_TAGGED;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	ret = run_test();
 

--- a/test_configs/udp/udp.exclude
+++ b/test_configs/udp/udp.exclude
@@ -15,3 +15,5 @@ shared_ctx
 unexpected_msg
 cmatose
 rc_pingpong
+inj_complete
+


### PR DESCRIPTION
This patch was prepared to reach he following goals:
- Add missed compability to be able use this test for the verbs, psm, sockets, RxM providers at least
- In addition to the checking of the `op_context`, add the verification of the tag
- Fix a small bag - App should pass an array of the MR's desc rather a pointer to the MR desc for the fi_[send|recv]msg functions
- Exclude `fi_inj_complete` test for the prov/udp, because UDP doesn't support FI_TAGGED
- Add `fi_inj_complete` test to the VS project and Makefile.win 

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>