### PR TITLE
complex/fi_ubertest: add verification scripts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,7 @@ nobase_dist_config_DATA = \
         test_configs/sockets/all.test \
         test_configs/sockets/quick.test \
 	test_configs/sockets/complete.test \
+	test_configs/sockets/verify.test \
         test_configs/udp/all.test \
         test_configs/udp/lat_bw.test \
         test_configs/udp/quick.test \
@@ -80,7 +81,8 @@ nobase_dist_config_DATA = \
 	test_configs/usnic/all.test \
 	test_configs/usnic/quick.test \
 	test_configs/psm/all.test \
-	test_configs/psm2/all.test
+	test_configs/psm2/all.test \
+	test_configs/psm2/verify.test
 
 noinst_LTLIBRARIES = libfabtests.la
 libfabtests_la_SOURCES = \

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -425,12 +425,12 @@ function complex_test {
 
 	start_time=$(date '+%s')
 
-	s_cmd="${BIN_PATH}${test_exe} -s $S_INTERFACE -x"
+	s_cmd="${BIN_PATH}${test_exe} -x"
 	FI_LOG_LEVEL=error ${SERVER_CMD} "$s_cmd" &> $s_outp &
 	p1=$!
 	sleep 1
 
-	c_cmd="${BIN_PATH}${test_exe} -s $C_INTERFACE -p \"${PROV}\" -t $config $S_INTERFACE"
+	c_cmd="${BIN_PATH}${test_exe} -p \"${PROV}\" -t $config $S_INTERFACE"
 	FI_LOG_LEVEL=error ${CLIENT_CMD} "$c_cmd" &> $c_outp &
 	p2=$!
 
@@ -475,6 +475,9 @@ function main {
 
 	if [[ $1 == "quick" ]]; then
 		local -r tests="unit simple short"
+	elif [[ $1 == "verify" ]]; then
+		local -r tests="complex"
+		complex_cfg=$1
 	else
 		local -r tests=$(echo $1 | sed 's/all/unit,simple,standard,complex/g' | tr ',' ' ')
 		if [[ $1 == "all" ]]; then

--- a/test_configs/psm2/verify.test
+++ b/test_configs/psm2/verify.test
@@ -1,0 +1,246 @@
+{
+	prov_name: psm2,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+		FT_FUNC_INJECT,
+	],
+	ep_type: [
+		FI_EP_RDM
+	],
+	av_type: [
+		FI_AV_TABLE
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: psm2,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_SENDDATA,
+		FT_FUNC_INJECTDATA,
+	],
+	ep_type: [
+		FI_EP_RDM
+	],
+	av_type: [
+		FI_AV_TABLE
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: psm2,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_WRITEMSG,
+		FT_FUNC_INJECT_WRITE,
+		FT_FUNC_WRITEDATA,
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+		FT_FUNC_READMSG,
+	],
+	ep_type: [
+		FI_EP_RDM
+	],
+	av_type: [
+		FI_AV_TABLE
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: psm2,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_ATOMIC,
+		FT_FUNC_ATOMICV,
+		FT_FUNC_ATOMICMSG,
+		FT_FUNC_FETCH_ATOMIC,
+		FT_FUNC_FETCH_ATOMICV,
+		FT_FUNC_FETCH_ATOMICMSG,
+		FT_FUNC_INJECT_ATOMIC,
+	],
+	op:[
+		FI_MIN,
+		FI_MAX,
+		FI_SUM,
+		FI_PROD,
+		FI_LOR,
+		FI_LAND,
+		FI_BOR,
+		FI_BAND,
+		FI_LXOR,
+		FI_BXOR,
+		FI_ATOMIC_WRITE,
+	],
+	datatype:[
+		FI_INT8,
+		FI_UINT8,
+		FI_INT16,
+		FI_UINT16,
+		FI_INT32,
+		FI_UINT32,
+		FI_INT64,
+		FI_UINT64,
+		FI_FLOAT,
+		FI_DOUBLE,
+		FI_LONG_DOUBLE,
+		FI_FLOAT_COMPLEX,
+		FI_DOUBLE_COMPLEX,
+		FI_LONG_DOUBLE_COMPLEX,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_ATOMIC,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: psm2,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_FETCH_ATOMIC,
+		FT_FUNC_FETCH_ATOMICV,
+		FT_FUNC_FETCH_ATOMICMSG,
+	],
+	op:[
+		FI_ATOMIC_READ,
+	],
+	datatype:[
+		FI_INT8,
+		FI_UINT8,
+		FI_INT16,
+		FI_UINT16,
+		FI_INT32,
+		FI_UINT32,
+		FI_INT64,
+		FI_UINT64,
+		FI_FLOAT,
+		FI_DOUBLE,
+		FI_LONG_DOUBLE,
+		FI_FLOAT_COMPLEX,
+		FI_DOUBLE_COMPLEX,
+		FI_LONG_DOUBLE_COMPLEX,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_ATOMIC,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: psm2,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_COMPARE_ATOMIC,
+		FT_FUNC_COMPARE_ATOMICV,
+		FT_FUNC_COMPARE_ATOMICMSG,
+	],
+	op:[
+		FI_CSWAP,
+		FI_CSWAP_NE,
+		FI_CSWAP_LE,
+		FI_CSWAP_LT,
+		FI_CSWAP_GE,
+		FI_CSWAP_GT,
+		FI_MSWAP,
+	],
+	datatype:[
+		FI_INT8,
+		FI_UINT8,
+		FI_INT16,
+		FI_UINT16,
+		FI_INT32,
+		FI_UINT32,
+		FI_INT64,
+		FI_UINT64,
+		FI_FLOAT,
+		FI_DOUBLE,
+		FI_LONG_DOUBLE,
+		FI_FLOAT_COMPLEX,
+		FI_DOUBLE_COMPLEX,
+		FI_LONG_DOUBLE_COMPLEX,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_ATOMIC,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},

--- a/test_configs/sockets/verify.test
+++ b/test_configs/sockets/verify.test
@@ -1,0 +1,279 @@
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+		FT_FUNC_SENDDATA,
+		FT_FUNC_INJECT,
+		FT_FUNC_INJECTDATA,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_MAP,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_WRITEMSG,
+		FT_FUNC_INJECT_WRITE,
+		FT_FUNC_WRITEDATA,
+		FT_FUNC_INJECT_WRITEDATA,
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+		FT_FUNC_READMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_ATOMIC,
+		FT_FUNC_ATOMICV,
+		FT_FUNC_ATOMICMSG,
+		FT_FUNC_FETCH_ATOMIC,
+		FT_FUNC_FETCH_ATOMICV,
+		FT_FUNC_FETCH_ATOMICMSG,
+		FT_FUNC_INJECT_ATOMIC,
+	],
+	op:[
+		FI_MIN,
+		FI_MAX,
+		FI_SUM,
+		FI_PROD,
+		FI_LOR,
+		FI_LAND,
+		FI_BOR,
+		FI_BAND,
+		FI_LXOR,
+		FI_BXOR,
+		FI_ATOMIC_WRITE,
+	],
+	datatype:[
+		FI_INT8,
+		FI_UINT8,
+		FI_INT16,
+		FI_UINT16,
+		FI_INT32,
+		FI_UINT32,
+		FI_INT64,
+		FI_UINT64,
+		FI_FLOAT,
+		FI_DOUBLE,
+		FI_LONG_DOUBLE,
+		FI_FLOAT_COMPLEX,
+		FI_DOUBLE_COMPLEX,
+		FI_LONG_DOUBLE_COMPLEX,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_ATOMIC,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_FETCH_ATOMIC,
+		FT_FUNC_FETCH_ATOMICV,
+		FT_FUNC_FETCH_ATOMICMSG,
+	],
+	op:[
+		FI_ATOMIC_READ,
+	],
+	datatype:[
+		FI_INT8,
+		FI_UINT8,
+		FI_INT16,
+		FI_UINT16,
+		FI_INT32,
+		FI_UINT32,
+		FI_INT64,
+		FI_UINT64,
+		FI_FLOAT,
+		FI_DOUBLE,
+		FI_LONG_DOUBLE,
+		FI_FLOAT_COMPLEX,
+		FI_DOUBLE_COMPLEX,
+		FI_LONG_DOUBLE_COMPLEX,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_ATOMIC,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_COMPARE_ATOMIC,
+		FT_FUNC_COMPARE_ATOMICV,
+		FT_FUNC_COMPARE_ATOMICMSG,
+	],
+	op:[
+		FI_CSWAP,
+		FI_CSWAP_NE,
+		FI_CSWAP_LE,
+		FI_CSWAP_LT,
+		FI_CSWAP_GE,
+		FI_CSWAP_GT,
+		FI_MSWAP,
+	],
+	datatype:[
+		FI_INT8,
+		FI_UINT8,
+		FI_INT16,
+		FI_UINT16,
+		FI_INT32,
+		FI_UINT32,
+		FI_INT64,
+		FI_UINT64,
+		FI_FLOAT,
+		FI_DOUBLE,
+		FI_LONG_DOUBLE,
+		FI_FLOAT_COMPLEX,
+		FI_DOUBLE_COMPLEX,
+		FI_LONG_DOUBLE_COMPLEX,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_ATOMIC,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+		FT_FUNC_SENDDATA,
+		FT_FUNC_INJECTDATA,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_MAP,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	msg_flags: FI_REMOTE_CQ_DATA,
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_WRITEMSG,
+		FT_FUNC_WRITEDATA,
+		FT_FUNC_INJECT_WRITEDATA,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_MAP,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	msg_flags: FI_REMOTE_CQ_DATA,
+	test_flags: FT_FLAG_QUICKTEST
+},


### PR DESCRIPTION
- add scripts to run ubertest with verification for sockets and psm2
- add option to runfabtests.sh to run ubertest verification with added scripts
- modify runfabtests.sh complex test command (sometimes causing failure with source option)

*Verified passing with sockets. Psm2 in testing due to a recent ubertest bug causing problems with actually running it. All of the tests in the config file should be passing psm2 after those issues are resolved.

Signed-off-by: aingerson <alexia.ingerson@intel.com>