### PR TITLE
common/shared: Fixed ft_tag_is_valid to check ft_tag if set

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1660,7 +1660,7 @@ static int ft_spin_for_comp(struct fid_cq *cq, uint64_t *cur,
 		if (ret > 0) {
 			if (timeout >= 0)
 				clock_gettime(CLOCK_MONOTONIC, &a);
-			if (!ft_tag_is_valid(cq, &comp, rx_cq_cntr))
+			if (!ft_tag_is_valid(cq, &comp, ft_tag ? ft_tag : rx_cq_cntr))
 				return -FI_EOTHER;
 			(*cur)++;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {
@@ -1689,7 +1689,7 @@ static int ft_wait_for_comp(struct fid_cq *cq, uint64_t *cur,
 	while (total - *cur > 0) {
 		ret = fi_cq_sread(cq, &comp, 1, NULL, timeout);
 		if (ret > 0) {
-			if (!ft_tag_is_valid(cq, &comp, rx_cq_cntr))
+			if (!ft_tag_is_valid(cq, &comp, ft_tag ? ft_tag : rx_cq_cntr))
 				return -FI_EOTHER;
 			(*cur)++;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {
@@ -1723,7 +1723,7 @@ static int ft_fdwait_for_comp(struct fid_cq *cq, uint64_t *cur,
 
 		ret = fi_cq_read(cq, &comp, 1);
 		if (ret > 0) {
-			if (!ft_tag_is_valid(cq, &comp, rx_cq_cntr))
+			if (!ft_tag_is_valid(cq, &comp, ft_tag ? ft_tag : rx_cq_cntr))
 				return -FI_EOTHER;
 			(*cur)++;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {


### PR DESCRIPTION
-Currently the use of ft_tag_is_valid does not take into account the ft_tag
variable for custom tags in fabtests. This results in the calls to ft_tag_is_valid
failing if ft_tag is used.

-To resolve this issue the calls in the common framework to read
completions has been fixed to check if ft_tag is set

Change-Id: I18501a3a296df4ac965f6234a3598dd7b741b36b
Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>