### PR TITLE
 common/windows: Add support of the VS 2017 (v141 toolset)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,10 @@ build:
   project: fabtests.sln
 
 configuration:
-  - Debug
-  - Release
+  - Debug-v140
+  - Debug-v141
+  - Release-v140
+  - Release-v141
 
 install:
   - cd ..

--- a/Makefile.win
+++ b/Makefile.win
@@ -5,16 +5,25 @@ arch = x64
 !endif
 
 !if "$(config)" == ""
-config = Debug
+config = Debug-v140
 !endif
 
 output_root = .\\
 
-!if "$(config)" == "Debug"
-outdir = $(output_root)$(arch)\debug
+!if "$(config)" == "Debug-v140"
+outdir = $(output_root)$(arch)\debug-v140
 CFLAGS = $(CFLAGS) /Zi /Od /MTd
-!else
-outdir = $(output_root)$(arch)\release
+!endif
+!if "$(config)" == "Debug-v141"
+outdir = $(output_root)$(arch)\debug-v141
+CFLAGS = $(CFLAGS) /Zi /Od /MTd
+!endif
+!if "$(config)" == "Rlease-v140"
+outdir = $(output_root)$(arch)\release-v140
+CFLAGS = $(CFLAGS) /O2 /MT
+!endif
+!if "$(config)" == "Rlease-v141"
+outdir = $(output_root)$(arch)\release-v141
 CFLAGS = $(CFLAGS) /O2 /MT
 !endif
 

--- a/fabtests.sln
+++ b/fabtests.sln
@@ -7,14 +7,20 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fabtests", "fabtests.vcxpro
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
+		Debug-v140|x64 = Debug-v140|x64
+		Debug-v141|x64 = Debug-v141|x64
+		Release-v140|x64 = Release-v140|x64
+		Release-v141|x64 = Release-v141|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Debug|x64.ActiveCfg = Debug|x64
-		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Debug|x64.Build.0 = Debug|x64
-		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Release|x64.ActiveCfg = Release|x64
-		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Release|x64.Build.0 = Release|x64
+		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Debug-v140|x64.ActiveCfg = Debug-v140|x64
+		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Debug-v140|x64.Build.0 = Debug-v140|x64
+		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Debug-v141|x64.ActiveCfg = Debug-v141|x64
+		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Debug-v141|x64.Build.0 = Debug-v141|x64
+		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Release-v140|x64.ActiveCfg = Release-v140|x64
+		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Release-v140|x64.Build.0 = Release-v140|x64
+		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Release-v141|x64.ActiveCfg = Release-v141|x64
+		{076F757A-8827-4D3C-A87F-6E49623C16E1}.Release-v141|x64.Build.0 = Release-v141|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/fabtests.vcxproj
+++ b/fabtests.vcxproj
@@ -1,12 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
+    <ProjectConfiguration Include="Debug-v140|x64">
+      <Configuration>Debug-v140</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
+    <ProjectConfiguration Include="Debug-v141|x64">
+      <Configuration>Debug-v141</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-v140|x64">
+      <Configuration>Release-v140</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-v141|x64">
+      <Configuration>Release-v141</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
@@ -15,17 +23,31 @@
     <Keyword>MakeFileProj</Keyword>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-v140|x64'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-v141|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-v140|x64'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-v141|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -34,30 +56,47 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-v140|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-v141|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-v140|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-v141|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-v140|x64'">
     <NMakePreprocessorDefinitions>WIN32;_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
     <ExecutablePath>$(ProjectDir)Include;$(ExecutablePath)</ExecutablePath>
     <NMakeBuildCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) all</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) clean all</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) clean</NMakeCleanCommandLine>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-v141|x64'">
+    <NMakePreprocessorDefinitions>WIN32;_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <ExecutablePath>$(ProjectDir)Include;$(ExecutablePath)</ExecutablePath>
+    <NMakeBuildCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) all</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) clean all</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) clean</NMakeCleanCommandLine>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-v140|x64'">
     <NMakePreprocessorDefinitions>WIN32;NDEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
     <ExecutablePath>$(ProjectDir)Include;$(ExecutablePath)</ExecutablePath>
     <NMakeBuildCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) all</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) clean all</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) clean</NMakeCleanCommandLine>
   </PropertyGroup>
-  <ItemGroup>
-    <Text Include="readme.txt" />
-  </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-v141|x64'">
+    <NMakePreprocessorDefinitions>WIN32;NDEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <ExecutablePath>$(ProjectDir)Include;$(ExecutablePath)</ExecutablePath>
+    <NMakeBuildCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) all</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) clean all</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>nmake /F Makefile.win config=$(Configuration) arch=x$(PlatformArchitecture) clean</NMakeCleanCommandLine>
+  </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="benchmarks\benchmark_shared.c" />
     <ClCompile Include="benchmarks\dgram_pingpong.c" />

--- a/fabtests.vcxproj.filters
+++ b/fabtests.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -43,9 +43,6 @@
     <Filter Include="Source Files\benchmarks">
       <UniqueIdentifier>{f1716194-5311-4a40-a1f3-d4e96c93639f}</UniqueIdentifier>
     </Filter>
-  </ItemGroup>
-  <ItemGroup>
-    <Text Include="readme.txt" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="common\jsmn.c">


### PR DESCRIPTION
The intent of this PR is to add the support of the new version of the VS toolset (v141) that is used for the Visual Studio 2017. The following is done:
- Remove `readme.txt` file form the `fabtests.vcxproj`, because this file was removed
- Update Configuration's names in the `Makefile.win`
- Create four new configuration for the fabtests VS project:
   * `Debug-v140` (the same as previous `Debug` conf)
   * `Debug-v141` (the same as previous `Debug` conf, but this supports the v141 toolset)
   * `Release-v140` (the same as previous `Release` conf)
   * `Release-v141` (the same as previous `Release` conf, but this supports the v141 toolset)
- Updated AppVeyor script to support new configuration types for the fabtests.sln and libfabric.sln
  **Note: This PR Should be merged with an appropriate `libfabric` PR simultaneously**