### PR TITLE
common/shared: Updated ft_post_tx/rx to allow for NULL mr

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1391,23 +1391,25 @@ ssize_t ft_post_tx(struct fid_ep *ep, fi_addr_t fi_addr, size_t size,
 	if (hints->caps & FI_TAGGED) {
 		if (data != NO_CQ_DATA) {
 			FT_POST(fi_tsenddata, ft_get_tx_comp, tx_seq, "transmit", ep,
-					tx_buf, size + ft_tx_prefix_size(), fi_mr_desc(mr),
-					data, fi_addr, ft_tag ? ft_tag : tx_seq, ctx);
+				tx_buf, size + ft_tx_prefix_size(),
+				mr ? fi_mr_desc(mr) : NULL,
+				data, fi_addr, ft_tag ? ft_tag : tx_seq, ctx);
 		} else {
 			FT_POST(fi_tsend, ft_get_tx_comp, tx_seq, "transmit", ep,
-					tx_buf, size + ft_tx_prefix_size(), fi_mr_desc(mr),
-					fi_addr, ft_tag ? ft_tag : tx_seq, ctx);
+				tx_buf, size + ft_tx_prefix_size(),
+				mr ? fi_mr_desc(mr) : NULL,
+				fi_addr, ft_tag ? ft_tag : tx_seq, ctx);
 		}
 	} else {
 		if (data != NO_CQ_DATA) {
 			FT_POST(fi_senddata, ft_get_tx_comp, tx_seq, "transmit", ep,
-					tx_buf,	size + ft_tx_prefix_size(), fi_mr_desc(mr),
-					data, fi_addr, ctx);
+				tx_buf,	size + ft_tx_prefix_size(),
+				mr ? fi_mr_desc(mr) : NULL, data, fi_addr, ctx);
 
 		} else {
 			FT_POST(fi_send, ft_get_tx_comp, tx_seq, "transmit", ep,
-					tx_buf,	size + ft_tx_prefix_size(), fi_mr_desc(mr),
-					fi_addr, ctx);
+				tx_buf,	size + ft_tx_prefix_size(),
+				mr ? fi_mr_desc(mr) : NULL, fi_addr, ctx);
 		}
 	}
 	return 0;
@@ -1600,12 +1602,13 @@ ssize_t ft_post_rx(struct fid_ep *ep, size_t size, struct fi_context* ctx)
 {
 	if (hints->caps & FI_TAGGED) {
 		FT_POST(fi_trecv, ft_get_rx_comp, rx_seq, "receive", ep, rx_buf,
-				MAX(size, FT_MAX_CTRL_MSG) + ft_rx_prefix_size(),
-				fi_mr_desc(mr), 0, ft_tag ? ft_tag : rx_seq, 0, ctx);
+			MAX(size, FT_MAX_CTRL_MSG) + ft_rx_prefix_size(),
+			mr ? fi_mr_desc(mr) : NULL, 0,
+			ft_tag ? ft_tag : rx_seq, 0, ctx);
 	} else {
 		FT_POST(fi_recv, ft_get_rx_comp, rx_seq, "receive", ep, rx_buf,
-				MAX(size, FT_MAX_CTRL_MSG) + ft_rx_prefix_size(),
-				fi_mr_desc(mr),	0, ctx);
+			MAX(size, FT_MAX_CTRL_MSG) + ft_rx_prefix_size(),
+			mr ? fi_mr_desc(mr) : NULL, 0, ctx);
 	}
 	return 0;
 }


### PR DESCRIPTION
-Currently, when calling ft_post_tx/rx it is expected that the common
framework has a valid mr allocated.
-This limits the tests developed for fabtests from using the common post
functions given the test does not allocate the mr

-To resolve this a check has been made to pass in NULL for the desc if
the mr is not set

Change-Id: I00c05797bd2280ca13bc8ae6d9e8444e9e160e73
Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>

Changes from Neil's patch - white space re-formatting, convert 0 -> NULL.