### PR TITLE
common/appveyor: Exclude testing VS15 with v141 toolset from AppVeyor matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,6 @@
-image: Visual Studio 2015
+image:
+  - Visual Studio 2015
+  - Visual Studio 2017
 
 build:
   project: fabtests.sln
@@ -8,6 +10,13 @@ configuration:
   - Debug-v141
   - Release-v140
   - Release-v141
+
+matrix:
+  exclude:
+    - configuration: Debug-v141
+      image: Visual Studio 2015
+    - configuration: Release-v141
+      image: Visual Studio 2015
 
 install:
   - cd ..

--- a/Makefile.win
+++ b/Makefile.win
@@ -18,11 +18,11 @@ CFLAGS = $(CFLAGS) /Zi /Od /MTd
 outdir = $(output_root)$(arch)\debug-v141
 CFLAGS = $(CFLAGS) /Zi /Od /MTd
 !endif
-!if "$(config)" == "Rlease-v140"
+!if "$(config)" == "Release-v140"
 outdir = $(output_root)$(arch)\release-v140
 CFLAGS = $(CFLAGS) /O2 /MT
 !endif
-!if "$(config)" == "Rlease-v141"
+!if "$(config)" == "Release-v141"
 outdir = $(output_root)$(arch)\release-v141
 CFLAGS = $(CFLAGS) /O2 /MT
 !endif


### PR DESCRIPTION
This fixes failing VS15/v141 jobs in the AppVeyor.

The v141 toolset is introduced together with VS17
This is impossible to compile VS15 configuration with v141 toolset
But the compiling VS17/v140 is kept for the AppVeyor to check backward compatibility of our VS project

**Note: Please merge this PR together with ofiwg/libfabric#3405 that fixes the same problem.**


Also this PR fixes format issues in the `Makefile.win`

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>