### PR TITLE
Update test exclusions and mr_mode bits for some tests

### DIFF
--- a/simple/recv_cancel.c
+++ b/simple/recv_cancel.c
@@ -215,6 +215,7 @@ int main(int argc, char **argv)
 
 	hints->caps = FI_TAGGED;
 	hints->mode = FI_CONTEXT;
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ALLOCATED;
 
 	ret = run_test();
 

--- a/simple/unexpected_msg.c
+++ b/simple/unexpected_msg.c
@@ -263,6 +263,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->mode = FI_CONTEXT;
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ALLOCATED;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->rx_attr->total_buffered_recv = 0;
 	hints->caps = FI_TAGGED;

--- a/test_configs/ofi_rxm/ofi_rxm.exclude
+++ b/test_configs/ofi_rxm/ofi_rxm.exclude
@@ -1,0 +1,26 @@
+# Regex patterns of tests to exclude in runfabtests.sh
+
+# Exclude all prefix tests
+-k
+
+^msg|-e msg
+^dgram|-e dgram
+
+cm_data
+cq_data
+poll
+rdm_rma_simple
+trigger
+shared_ctx
+scalable_ep
+shared_av
+multi_mr
+atomic
+inj_complete
+rdm_cntr_pingpong
+rdm_multi_recv
+cmatose
+rc_pingpong
+
+# Remove this once ubertest supports setting MR modes
+ubertest

--- a/test_configs/verbs/verbs.exclude
+++ b/test_configs/verbs/verbs.exclude
@@ -22,3 +22,8 @@ unexpected_msg
 rma.+rdm.+writedata
 rdm.+atomic
 rdm.+cntr
+inj_complete.*-e msg
+inj_complete.*-e dgram
+
+# Remove this once ubertest supports setting MR modes
+ubertest


### PR DESCRIPTION
- Add exclude file for rxm provider and update verbs.exclude
- simple: Advertise support for OFI_MR_BASIC_MAP for recv_cancel, unexpected_msg tests
 These tests don't use RMA so we can support OFI_MR_BASIC_MAP bits so that
some providers are not excluded for this test