### PR TITLE
simple/cq_completion_check: cq completion functional test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,7 @@ bin_PROGRAMS = \
 	simple/fi_unexpected_msg \
 	simple/fi_inj_complete \
 	simple/fi_resource_freeing \
+	simple/fi_cq_completion_check \
 	streaming/fi_resmgmt_test \
 	streaming/fi_msg_rma \
 	streaming/fi_rdm_atomic \
@@ -205,6 +206,10 @@ simple_fi_inj_complete_LDADD = libfabtests.la
 simple_fi_resource_freeing_SOURCES = \
 	simple/resource_freeing.c
 simple_fi_resource_freeing_LDADD = libfabtests.la
+
+simple_fi_cq_completion_check_SOURCES = \
+	simple/cq_completion_check.c
+simple_fi_cq_completion_check_LDADD = libfabtests.la
 
 streaming_fi_resmgmt_test_SOURCES = \
 	streaming/resmgmt_test.c

--- a/Makefile.win
+++ b/Makefile.win
@@ -60,7 +60,8 @@ benchmarks: $(outdir)\msg_pingpong.exe $(outdir)\rdm_cntr_pingpong.exe \
 simple: $(outdir)\cq_data.exe $(outdir)\dgram.exe $(outdir)\dgram_waitset.exe $(outdir)\msg.exe \
 	$(outdir)\msg_epoll.exe $(outdir)\msg_sockets.exe \
 	$(outdir)\poll.exe $(outdir)\rdm.exe $(outdir)\rdm_rma_simple.exe $(outdir)\rdm_rma_trigger.exe \
-	$(outdir)\rdm_tagged_peek.exe $(outdir)\scalable_ep.exe $(outdir)\inj_complete.exe
+	$(outdir)\rdm_tagged_peek.exe $(outdir)\scalable_ep.exe $(outdir)\inj_complete.exe \
+	$(outdir)\cq_completion_check.exe
 
 unit: $(outdir)\av_test.exe $(outdir)\dom_test.exe $(outdir)\eq_test.exe
 
@@ -104,6 +105,8 @@ $(outdir)\rdm_tagged_peek.exe: {simple}rdm_tagged_peek.c $(basedeps)
 $(outdir)\scalable_ep.exe: {simple}scalable_ep.c $(basedeps)
 
 $(outdir)\inj_complete.exe: {simple}inj_complete.c $(basedeps)
+
+$(outdir)\cq_completion_check.exe: {simple}cq_completion_check.c $(basedeps)
 
 $(outdir)\av_test.exe: {unit}av_test.c $(basedeps) {unit}common.c
 

--- a/fabtests.vcxproj
+++ b/fabtests.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="simple\rdm_netdir.c" />
     <ClCompile Include="simple\scalable_ep.c" />
     <ClCompile Include="simple\inj_complete.c" />
+    <ClCompile Include="simple\cq_completion_check.c" />
     <ClCompile Include="unit\av_test.c" />
     <ClCompile Include="unit\cntr_test.c" />
     <ClCompile Include="unit\common.c" />

--- a/fabtests.vcxproj.filters
+++ b/fabtests.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClCompile Include="simple\inj_complete.c">
       <Filter>Source Files\simple</Filter>
     </ClCompile>
+    <ClCompile Include="simple\cq_completion_check.c">
+      <Filter>Source Files\simple</Filter>
+    </ClCompile>
     <ClCompile Include="complex\ft_comm.c">
       <Filter>Source Files\complex</Filter>
     </ClCompile>

--- a/scripts/runfabtests.cmd
+++ b/scripts/runfabtests.cmd
@@ -27,7 +27,8 @@ set simple_tests=^
 	"rdm_rma_simple"^
 	"rdm_rma_trigger"^
 	"rdm_tagged_peek"^
-	"scalable_ep"
+	"scalable_ep"^
+	"cq_completion_check"
 rem	"msg_epoll"
 
 set short_tests=^

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -120,6 +120,7 @@ simple_tests=(
 	"inj_complete -e msg -SR"
 	"inj_complete -e rdm -SR"
 	"inj_complete -e dgram -SR"
+	"cq_completion_check"
 )
 
 short_tests=(

--- a/simple/cq_completion_check.c
+++ b/simple/cq_completion_check.c
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2013-2017 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <unistd.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_cm.h>
+
+#include "shared.h"
+
+#define USE_SEND 0
+#define USE_SENDMSG 1
+#define NO_COMP 0
+#define GET_COMP 1
+
+static struct fid_ep *lcl_ep;
+static fi_addr_t remote_addr;
+
+static int send_msg(int use_sendmsg, int expect_completion, uint64_t flags)
+{
+	int ret;
+	struct fi_msg msg;
+	struct fi_context fi_ctx_send;
+	struct fi_cq_msg_entry  send_completion;
+
+	ft_sync();
+
+	ft_fill_buf(tx_buf, opts.transfer_size);
+
+	if (use_sendmsg) {
+		struct iovec msg_iov;
+		msg_iov.iov_base = tx_buf;
+		msg_iov.iov_len = opts.transfer_size;
+
+		msg.msg_iov = &msg_iov;
+		msg.desc = NULL;
+		msg.iov_count = 1;
+		msg.addr = remote_addr;
+		msg.data = 0;
+		msg.context = &fi_ctx_send;
+
+		ret = fi_sendmsg(lcl_ep, &msg, flags);
+
+		if (ret) {
+			FT_PRINTERR("fi_sendmsg", ret);
+			return ret;
+		}
+	} else {
+		ret = fi_send(lcl_ep, tx_buf, opts.transfer_size, NULL,
+				remote_addr, &fi_ctx_send);
+		if (ret) {
+			FT_PRINTERR("fi_send", ret);
+			return ret;
+		}
+	}
+
+	ret = fi_cq_sread(txcq, &send_completion, 1, NULL,
+				expect_completion ? 10000 : 2000);
+	if ((ret <= 0) && (ret != -FI_EAGAIN)) {
+		FT_PRINTERR("fi_cq_read", ret);
+		return ret;
+	}
+
+	if (ret > 0) {
+		if (!expect_completion) {
+			FT_PRINTERR("ERROR: No completion is expected but \
+					completion event found", -FI_EOTHER);
+			return -FI_EOTHER;
+		}
+		if (&fi_ctx_send != send_completion.op_context) {
+			FT_PRINTERR("ERROR: send ctx != cq_ctx", -FI_EOTHER);
+			return -FI_EOTHER;
+		}
+	} else {
+		if (expect_completion) {
+			FT_PRINTERR("ERROR: No completion event found",
+					-FI_EOTHER);
+			return -FI_EOTHER;
+		}
+	}
+
+	fprintf(stdout, "GOOD: Test success\n");
+
+	return 0;
+}
+
+static int receive_msg()
+{
+	int ret;
+	struct fi_context fi_ctx_recv;
+	struct fi_cq_msg_entry  recv_completion;
+
+	ret = fi_recv(lcl_ep, rx_buf, opts.transfer_size, NULL,
+			FI_ADDR_UNSPEC, &fi_ctx_recv);
+	if (ret) {
+		FT_PRINTERR("fi_send", ret);
+		return ret;
+	}
+
+	ft_sync();
+
+	ret = fi_cq_sread(rxcq, &recv_completion, 1, NULL, 10000);
+	if ((ret <= 0) && (ret != -FI_EAGAIN)) {
+		FT_PRINTERR("fi_cq_read", ret);
+		return ret;
+	}
+
+	if (ret > 0) {
+		if (recv_completion.op_context == NULL) {
+			FT_PRINTERR("ERROR: op_context is NULL", -FI_EOTHER);
+			return -FI_EOTHER;
+		}
+
+		if (!(recv_completion.flags & FI_RECV)) {
+			fprintf(stdout, "Flags %lx\n", (unsigned long)recv_completion.flags);
+			FT_PRINTERR("wrong completion flag set for the recv \
+					message", -FI_EOTHER);
+			return -FI_EOTHER;
+		}
+	} else{
+		FT_PRINTERR("ERROR: No completion event found", -FI_EOTHER);
+		return -FI_EOTHER;
+	}
+
+	ret = ft_check_buf(rx_buf, opts.transfer_size);
+	if(ret)
+		return ret;
+
+	fprintf(stdout, "GOOD: Test success\n");
+
+	return 0;
+}
+
+static int run_test(uint64_t sendflag, int use_sendmsg, int expect_completion)
+{
+	int ret = 0;
+
+	if (opts.dst_addr) {
+		if (ret) {
+			FT_PRINTERR("fi_ep_bind", ret);
+			return ret;
+		}
+		ret = send_msg(use_sendmsg, expect_completion, sendflag);
+		if (ret)
+			return ret;
+	} else {
+		ret = receive_msg();
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int alloc_res()
+{
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	return 0;
+}
+
+static int exit_test(int ret)
+{
+	FT_CLOSE_FID(lcl_ep);
+	ft_free_res();
+	return ft_exit_code(ret);
+
+}
+
+static int setup_av_ep(struct fid_ep **ep, fi_addr_t *remote_addr,
+			uint64_t epflags)
+{
+	int ret;
+	hints->src_addr = NULL;
+
+	fi_freeinfo(fi);
+
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
+	if (ret) {
+		FT_PRINTERR("fi_getinfo", ret);
+		return ret;
+	}
+
+	ret = fi_endpoint(domain, fi, ep, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_endpoint", ret);
+		return ret;
+	}
+
+	FT_EP_BIND(*ep, av, 0);
+	FT_EP_BIND(*ep, txcq, epflags);
+	FT_EP_BIND(*ep, rxcq, FI_RECV);
+
+	ret = fi_enable(*ep);
+	if (ret) {
+		FT_PRINTERR("fi_enable", ret);
+		return ret;
+	}
+
+	ret = ft_init_av_addr(av, *ep, remote_addr);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	int op, ret;
+	uint64_t completion_flag;
+
+	opts = INIT_OPTS;
+	opts.options |= FT_OPT_SIZE;
+	opts.transfer_size = 1024*1024;
+
+	ret = alloc_res();
+	if (ret)
+		return ft_exit_code(ret);
+
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG;
+	hints->mode = FI_CONTEXT;
+	hints->tx_attr->op_flags = 0;
+	cq_attr.format = FI_CQ_FORMAT_MSG;
+	completion_flag = 0;
+
+	while ((op = getopt(argc, argv, "ch" ADDR_OPTS INFO_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case 'c':
+			hints->tx_attr->op_flags = FI_COMPLETION;
+			completion_flag = FI_SELECTIVE_COMPLETION;
+			break;
+		case '?':
+		case 'h':
+			ft_usage(argv[0], "A simple cq completion check example.");
+			FT_PRINT_OPTS_USAGE("-c", "Run test with \
+					hints->tx_attr->op_flags=FI_COMPLETION");
+			return ft_exit_code(EXIT_FAILURE);
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	ret = ft_init_fabric();
+	if (ret)
+		return ft_exit_code(ret);
+
+	ret = setup_av_ep(&lcl_ep, &remote_addr, FI_TRANSMIT | completion_flag);
+	if (ret)
+		return ft_exit_code(ret);
+
+	if (!completion_flag)
+		fprintf(stdout, "Testing for op flag=0, ep flag=FI_TRANSMIT\n");
+	else
+		fprintf(stdout, "Testing for op flag=FI_COMPLETION, \
+			ep flag=FI_TRANSMIT | FI_SELECTIVE_COMPLETION\n");
+
+	ret = run_test(0, USE_SEND, GET_COMP);
+	if (ret)
+		return exit_test(ret);
+
+	ret = run_test(FI_COMPLETION, USE_SENDMSG, GET_COMP);
+	if (ret)
+		return exit_test(ret);
+
+	ret = run_test(0, USE_SENDMSG, completion_flag? NO_COMP : GET_COMP);
+	if (ret)
+		return exit_test(ret);
+
+	return exit_test(0);
+}

--- a/test_configs/udp/udp.exclude
+++ b/test_configs/udp/udp.exclude
@@ -16,4 +16,5 @@ unexpected_msg
 cmatose
 rc_pingpong
 inj_complete
+cq_completion_check
 


### PR DESCRIPTION
-simple/cq_completion_check functional test (fi_cq_completion_check)
   - Test for completion event with op flag=0 and different combinations of ep flags
   - Test for completion event with op flag=FI_COMPLETION  and different combinations of ep flags
   - Test using fi_sendmsg and fi_send

Change-Id: I9d3b1b321d51b7ce4238395af867b91ba33d8873
Signed-off-by: Sylvia Chan <sylvia.oi.yee.chan@intel.com>