### PR TITLE
shared: Disable writing completions to a CQ if using counters

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -837,9 +837,18 @@ int ft_setup_ep(struct fid_ep *ep, struct fid_eq *eq,
 
 	if (fi->ep_attr->type == FI_EP_MSG || fi->caps & FI_MULTICAST)
 		FT_EP_BIND(ep, eq, 0);
+
 	FT_EP_BIND(ep, av, 0);
-	FT_EP_BIND(ep, txcq, FI_TRANSMIT);
-	FT_EP_BIND(ep, rxcq, FI_RECV);
+
+	flags = FI_TRANSMIT;
+	if (!(opts.options & FT_OPT_TX_CQ))
+		flags |= FI_SELECTIVE_COMPLETION;
+	FT_EP_BIND(ep, txcq, flags);
+
+	flags = FI_RECV;
+	if (!(opts.options & FT_OPT_RX_CQ))
+		flags |= FI_SELECTIVE_COMPLETION;
+	FT_EP_BIND(ep, rxcq, flags);
 
 	ret = ft_get_cq_fd(txcq, &tx_fd);
 	if (ret)


### PR DESCRIPTION
Commit cb0f9596 added always binding an EP to rx/tx CQs.  This
resulted in the EP generating all completions to the CQs, even if
counters are being used as the primary completion mechanism.
The result is that the CQs can fill up and never drain.

Fix this by using selective completions when binding to the CQs
when counters are in use.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>