### PR TITLE
complex/ubertest: Fix ubertest to hold client getinfo until server init

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -339,6 +339,8 @@ int ft_send_dgram_flood();
 int ft_sendrecv_dgram();
 int ft_send_rma();
 
+void ft_cleanup(void);
+int ft_open_res();
 int ft_init_test();
 int ft_run_test();
 int ft_reset_ep();

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -893,7 +893,7 @@ static int ft_run_unit(void)
 	return fail;
 }
 
-static void ft_cleanup(void)
+void ft_cleanup(void)
 {
 	FT_CLOSE_FID(ft_rx_ctrl.mr);
 	FT_CLOSE_FID(ft_tx_ctrl.mr);
@@ -906,7 +906,7 @@ static void ft_cleanup(void)
 	memset(&ft_ctrl, 0, sizeof ft_ctrl);
 }
 
-int ft_init_test()
+int ft_open_res()
 {
 	int ret;
 
@@ -935,6 +935,16 @@ int ft_init_test()
 			goto cleanup;
 		}
 	}
+
+	return 0;
+cleanup:
+	ft_cleanup();
+	return ret;
+}
+
+int ft_init_test()
+{
+	int ret;
 
 	ft_sock_sync(0);
 


### PR DESCRIPTION
-Updated the ubertest init to hold the client from calling getinfo until
after the server has opened all its resources
-Created a new ft_open_res that allows for opening the resources for a
process without requiring a sync with the client/server
-Exposed ft_cleanup such that resources can be freed on the server
given the client has run out of fi_infos to test and needs a new server
fi_info if it exists

Change-Id: I02f51d67e2f774c2a039d3f257f8d9048b205c63
Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>