### PR TITLE
getinfo_test: Several cleanups and tests for 1.0 mr_mode bits

### DIFF
--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -413,6 +413,26 @@ static int check_mr_scalable(struct fi_info *info)
 		EXIT_FAILURE : 0;
 }
 
+static int init_mr_unspec(struct fi_info *hints)
+{
+	hints->caps |= FI_RMA;
+	hints->domain_attr->mr_mode = FI_MR_UNSPEC;
+	return 0;
+}
+
+static int test_mr_v1_0(char *node, char *service, uint64_t flags,
+			struct fi_info *test_hints, struct fi_info **info)
+{
+	return fi_getinfo(FI_VERSION(1, 0), node, service, flags, test_hints, info);
+}
+
+static int check_mr_unspec(struct fi_info *info)
+{
+	return (info->domain_attr->mr_mode != FI_MR_BASIC &&
+		info->domain_attr->mr_mode != FI_MR_SCALABLE) ?
+		EXIT_FAILURE : 0;
+}
+
 static int getinfo_unit_test(char *node, char *service, uint64_t flags,
 		struct fi_info *base_hints, ft_getinfo_init init, ft_getinfo_test test,
 		ft_getinfo_check check, int ret_exp)
@@ -574,6 +594,12 @@ getinfo_test(mr_mode, 1, "Test FI_MR_BASIC", NULL, NULL, 0,
 	     hints, init_mr_basic, NULL, check_mr_basic, -FI_ENODATA)
 getinfo_test(mr_mode, 2, "Test FI_MR_SCALABLE", NULL, NULL, 0,
 	     hints, init_mr_scalable, NULL, check_mr_scalable, -FI_ENODATA)
+getinfo_test(mr_mode, 3, "Test FI_MR_UNSPEC (v1.0)", NULL, NULL, 0,
+	     hints, init_mr_unspec, test_mr_v1_0, check_mr_unspec, -FI_ENODATA)
+getinfo_test(mr_mode, 4, "Test FI_MR_BASIC (v1.0)", NULL, NULL, 0,
+	     hints, init_mr_basic, test_mr_v1_0, check_mr_basic, -FI_ENODATA)
+getinfo_test(mr_mode, 5, "Test FI_MR_SCALABLE (v1.0)", NULL, NULL, 0,
+     	     hints, init_mr_scalable, test_mr_v1_0, check_mr_scalable, -FI_ENODATA)
 
 
 static void usage(void)
@@ -645,6 +671,9 @@ int main(int argc, char **argv)
 		TEST_ENTRY_GETINFO(neg1),
 		TEST_ENTRY_GETINFO(mr_mode1),
 		TEST_ENTRY_GETINFO(mr_mode2),
+		TEST_ENTRY_GETINFO(mr_mode3),
+		TEST_ENTRY_GETINFO(mr_mode4),
+		TEST_ENTRY_GETINFO(mr_mode5),
 		{ NULL, "" }
 	};
 

--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -400,6 +400,19 @@ static int check_mr_basic(struct fi_info *info)
 		EXIT_FAILURE : 0;
 }
 
+static int init_mr_scalable(struct fi_info *hints)
+{
+	hints->caps |= FI_RMA;
+	hints->domain_attr->mr_mode = FI_MR_SCALABLE;
+	return 0;
+}
+
+static int check_mr_scalable(struct fi_info *info)
+{
+	return (info->domain_attr->mr_mode != FI_MR_SCALABLE) ?
+		EXIT_FAILURE : 0;
+}
+
 static int getinfo_unit_test(char *node, char *service, uint64_t flags,
 		struct fi_info *base_hints, ft_getinfo_init init, ft_getinfo_test test,
 		ft_getinfo_check check, int ret_exp)
@@ -559,6 +572,8 @@ getinfo_test(bad_waw_ordering, 1, "Test invalid rma WAW ordering size",
 /* MR mode tests */
 getinfo_test(mr_mode, 1, "Test FI_MR_BASIC", NULL, NULL, 0,
 	     hints, init_mr_basic, NULL, check_mr_basic, -FI_ENODATA)
+getinfo_test(mr_mode, 2, "Test FI_MR_SCALABLE", NULL, NULL, 0,
+	     hints, init_mr_scalable, NULL, check_mr_scalable, -FI_ENODATA)
 
 
 static void usage(void)
@@ -629,6 +644,7 @@ int main(int argc, char **argv)
 		TEST_ENTRY_GETINFO(bad_waw_ordering1),
 		TEST_ENTRY_GETINFO(neg1),
 		TEST_ENTRY_GETINFO(mr_mode1),
+		TEST_ENTRY_GETINFO(mr_mode2),
 		{ NULL, "" }
 	};
 

--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -46,7 +46,7 @@
 
 typedef int (*ft_getinfo_init)(struct fi_info *);
 typedef int (*ft_getinfo_test)(char *, char *, uint64_t, struct fi_info *, struct fi_info **);
-typedef int (*ft_getinfo_check)(void *);
+typedef int (*ft_getinfo_check)(struct fi_info *);
 
 static char err_buf[512];
 static char old_prov_var[128];
@@ -66,15 +66,13 @@ static int check_addr(void *addr, size_t addrlen, char *str)
 	return 0;
 }
 
-static int check_srcaddr(void *arg)
+static int check_srcaddr(struct fi_info *info)
 {
-	struct fi_info *info = arg;
 	return check_addr(info->src_addr, info->src_addrlen, "source");
 }
 
-static int check_src_dest_addr(void *arg)
+static int check_src_dest_addr(struct fi_info *info)
 {
-	struct fi_info *info = arg;
 	int ret;
 
 	ret = check_addr(info->src_addr, info->src_addrlen, "source");
@@ -84,9 +82,8 @@ static int check_src_dest_addr(void *arg)
 	return check_addr(info->dest_addr, info->dest_addrlen, "destination");
 }
 
-static int check_util_prov(void *arg)
+static int check_util_prov(struct fi_info *info)
 {
-	struct fi_info *info = arg;
 	const char *util_name;
 	size_t len;
 
@@ -99,9 +96,8 @@ static int check_util_prov(void *arg)
 	return 0;
 }
 
-static int check_api_version(void *arg)
+static int check_api_version(struct fi_info *info)
 {
-	struct fi_info *info = arg;
 	return info->fabric_attr->api_version != FT_FIVERSION;
 }
 
@@ -283,10 +279,8 @@ static int init_valid_rma_WAW_ordering_set_size(struct fi_info *hints)
 	return 0;
 }
 
-static int check_valid_rma_ordering_sizes(void *arg)
+static int check_valid_rma_ordering_sizes(struct fi_info *info)
 {
-	struct fi_info *info = arg;
-
 	if ((info->tx_attr->msg_order & FI_ORDER_RAW) ||
 			(info->rx_attr->msg_order & FI_ORDER_RAW)) {
 		if (info->ep_attr->max_order_raw_size <= 0)

--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -104,7 +104,7 @@ static int check_api_version(void *arg)
 	return info->fabric_attr->api_version != FT_FIVERSION;
 }
 
-int invalid_dom(struct fi_info *hints)
+static int invalid_dom(struct fi_info *hints)
 {
 	if (hints->domain_attr->name)
 		free(hints->domain_attr->name);
@@ -114,7 +114,7 @@ int invalid_dom(struct fi_info *hints)
 	return 0;
 }
 
-int validate_msg_ordering_bits(char *node, char *service, uint64_t flags,
+static int validate_msg_ordering_bits(char *node, char *service, uint64_t flags,
 		struct fi_info *hints, struct fi_info **info)
 {
 	int i, ret;
@@ -187,7 +187,7 @@ failed_getinfo:
 	return ret;
 }
 
-int init_valid_rma_RAW_ordering_no_set_size(struct fi_info *hints)
+static int init_valid_rma_RAW_ordering_no_set_size(struct fi_info *hints)
 {
 	hints->caps = FI_RMA;
 	hints->tx_attr->msg_order = FI_ORDER_RAW;
@@ -197,7 +197,7 @@ int init_valid_rma_RAW_ordering_no_set_size(struct fi_info *hints)
 	return 0;
 }
 
-int init_valid_rma_RAW_ordering_set_size(struct fi_info *hints)
+static int init_valid_rma_RAW_ordering_set_size(struct fi_info *hints)
 {
 	int ret;
 	struct fi_info *fi;
@@ -205,6 +205,7 @@ int init_valid_rma_RAW_ordering_set_size(struct fi_info *hints)
 	hints->caps = FI_RMA;
 	hints->tx_attr->msg_order = FI_ORDER_RAW;
 	hints->rx_attr->msg_order = FI_ORDER_RAW;
+
 	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
 	if (ret) {
 		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
@@ -218,7 +219,7 @@ int init_valid_rma_RAW_ordering_set_size(struct fi_info *hints)
 	return 0;
 }
 
-int init_valid_rma_WAR_ordering_no_set_size(struct fi_info *hints)
+static int init_valid_rma_WAR_ordering_no_set_size(struct fi_info *hints)
 {
 	hints->caps = FI_RMA;
 	hints->tx_attr->msg_order = FI_ORDER_WAR;
@@ -228,7 +229,7 @@ int init_valid_rma_WAR_ordering_no_set_size(struct fi_info *hints)
 	return 0;
 }
 
-int init_valid_rma_WAR_ordering_set_size(struct fi_info *hints)
+static int init_valid_rma_WAR_ordering_set_size(struct fi_info *hints)
 {
 	int ret;
 	struct fi_info *fi;
@@ -236,6 +237,7 @@ int init_valid_rma_WAR_ordering_set_size(struct fi_info *hints)
 	hints->caps = FI_RMA;
 	hints->tx_attr->msg_order = FI_ORDER_WAR;
 	hints->rx_attr->msg_order = FI_ORDER_WAR;
+
 	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
 	if (ret) {
 		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
@@ -249,7 +251,7 @@ int init_valid_rma_WAR_ordering_set_size(struct fi_info *hints)
 	return 0;
 }
 
-int init_valid_rma_WAW_ordering_no_set_size(struct fi_info *hints)
+static int init_valid_rma_WAW_ordering_no_set_size(struct fi_info *hints)
 {
 	hints->caps = FI_RMA;
 	hints->tx_attr->msg_order = FI_ORDER_WAW;
@@ -259,7 +261,7 @@ int init_valid_rma_WAW_ordering_no_set_size(struct fi_info *hints)
 	return 0;
 }
 
-int init_valid_rma_WAW_ordering_set_size(struct fi_info *hints)
+static int init_valid_rma_WAW_ordering_set_size(struct fi_info *hints)
 {
 	int ret;
 	struct fi_info *fi;
@@ -314,7 +316,7 @@ static int check_valid_rma_ordering_sizes(void *arg)
 	return 0;
 }
 
-int init_invalid_rma_RAW_ordering_size(struct fi_info *hints)
+static int init_invalid_rma_RAW_ordering_size(struct fi_info *hints)
 {
 	int ret;
 	struct fi_info *fi;
@@ -324,6 +326,7 @@ int init_invalid_rma_RAW_ordering_size(struct fi_info *hints)
 	hints->rx_attr->msg_order = FI_ORDER_RAW;
 	hints->ep_attr->max_order_war_size = 0;
 	hints->ep_attr->max_order_waw_size = 0;
+
 	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
 	if (ret) {
 		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
@@ -338,7 +341,7 @@ int init_invalid_rma_RAW_ordering_size(struct fi_info *hints)
 	return 0;
 }
 
-int init_invalid_rma_WAR_ordering_size(struct fi_info *hints)
+static int init_invalid_rma_WAR_ordering_size(struct fi_info *hints)
 {
 	int ret;
 	struct fi_info *fi;
@@ -348,6 +351,7 @@ int init_invalid_rma_WAR_ordering_size(struct fi_info *hints)
 	hints->rx_attr->msg_order = FI_ORDER_WAR;
 	hints->ep_attr->max_order_raw_size = 0;
 	hints->ep_attr->max_order_waw_size = 0;
+
 	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
 	if (ret) {
 		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);
@@ -362,7 +366,7 @@ int init_invalid_rma_WAR_ordering_size(struct fi_info *hints)
 	return 0;
 }
 
-int init_invalid_rma_WAW_ordering_size(struct fi_info *hints)
+static int init_invalid_rma_WAW_ordering_size(struct fi_info *hints)
 {
 	int ret;
 	struct fi_info *fi;
@@ -372,6 +376,7 @@ int init_invalid_rma_WAW_ordering_size(struct fi_info *hints)
 	hints->rx_attr->msg_order = FI_ORDER_WAW;
 	hints->ep_attr->max_order_raw_size = 0;
 	hints->ep_attr->max_order_war_size = 0;
+
 	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
 	if (ret) {
 		sprintf(err_buf, "fi_getinfo failed %s(%d)", fi_strerror(-ret), -ret);

--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -387,7 +387,18 @@ static int init_invalid_rma_WAW_ordering_size(struct fi_info *hints)
 	return 0;
 }
 
+static int init_mr_basic(struct fi_info *hints)
+{
+	hints->caps |= FI_RMA;
+	hints->domain_attr->mr_mode = FI_MR_BASIC;
+	return 0;
+}
 
+static int check_mr_basic(struct fi_info *info)
+{
+	return (info->domain_attr->mr_mode != FI_MR_BASIC) ?
+		EXIT_FAILURE : 0;
+}
 
 static int getinfo_unit_test(char *node, char *service, uint64_t flags,
 		struct fi_info *base_hints, ft_getinfo_init init, ft_getinfo_test test,
@@ -545,6 +556,9 @@ getinfo_test(bad_waw_ordering, 1, "Test invalid rma WAW ordering size",
 		NULL, NULL, 0, hints, init_invalid_rma_WAW_ordering_size,
 		NULL, NULL, -FI_ENODATA)
 
+/* MR mode tests */
+getinfo_test(mr_mode, 1, "Test FI_MR_BASIC", NULL, NULL, 0,
+	     hints, init_mr_basic, NULL, check_mr_basic, -FI_ENODATA)
 
 
 static void usage(void)
@@ -614,6 +628,7 @@ int main(int argc, char **argv)
 		TEST_ENTRY_GETINFO(bad_war_ordering1),
 		TEST_ENTRY_GETINFO(bad_waw_ordering1),
 		TEST_ENTRY_GETINFO(neg1),
+		TEST_ENTRY_GETINFO(mr_mode1),
 		{ NULL, "" }
 	};
 


### PR DESCRIPTION
This adds a check for handling FI_MR_BASIC and FI_MR_SCALABLE mr_mode.