### PR TITLE
complex/ubertest: Fix open_res on server to use a stored fi_info

### DIFF
--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -337,6 +337,7 @@ static int ft_fw_process_list_server(struct fi_info *hints, struct fi_info *info
 {
 	int ret, subindex, remote_idx = 0, result = 0, end_test = 0;
 	static int server_ready = 0;
+	struct fi_info *open_res_info;
 
 	ret = ft_sock_send(sock, &test_info, sizeof test_info);
 	if (ret) {
@@ -354,7 +355,12 @@ static int ft_fw_process_list_server(struct fi_info *hints, struct fi_info *info
 		if (ret)
 			return ret;
 
+		/* Stores the fabric_info into a tmp variable, resolves an issue caused
+		*  by ft_accept with FI_EP_MSG which overwrites the fabric_info.
+		*/
+		open_res_info = fabric_info;
 		while (1) {
+			fabric_info = open_res_info;
 			ret = ft_open_res();
 			if (ret) {
 				FT_PRINTERR("ft_open_res", ret);


### PR DESCRIPTION
-Fixed calls to ft_open_res to use a stored fi_info on the server to
address an issue where ft_accept will overwrite the fabric_info with an
info that cannot be used to allocate the fabric and domain resources.
-This only affects the server side as ft_connect does not overwrite the
fabric_info on the client.

Change-Id: Id9d590d138b736ffdb101f7e99a34d05d5879a3e
Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>