### PR TITLE
fabtests: Do not set all mr_mode bits

### DIFF
--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -884,7 +884,7 @@ int main(int argc, char **argv)
 
 	hints->mode = ~0;
 	hints->domain_attr->mode = ~0;
-	hints->domain_attr->mr_mode = ~0;
+	hints->domain_attr->mr_mode = ~(FI_MR_BASIC | FI_MR_SCALABLE);
 	hints->addr_format = FI_SOCKADDR;
 
 	// TODO make this test accept endpoint type argument

--- a/unit/cntr_test.c
+++ b/unit/cntr_test.c
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
 
 	hints->mode = ~0;
 	hints->domain_attr->mode = ~0;
-	hints->domain_attr->mr_mode = ~0;
+	hints->domain_attr->mr_mode = ~(FI_MR_BASIC | FI_MR_SCALABLE);
 
 	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
 	if (ret) {

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -571,7 +571,7 @@ int main(int argc, char **argv)
 
 	hints->mode = ~0;
 	hints->domain_attr->mode = ~0;
-	hints->domain_attr->mr_mode = ~0;
+	hints->domain_attr->mr_mode = ~(FI_MR_BASIC | FI_MR_SCALABLE);
 
 	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
 	if (ret) {

--- a/unit/mr_test.c
+++ b/unit/mr_test.c
@@ -225,9 +225,7 @@ int main(int argc, char **argv)
 
 	hints->mode = ~0;
 	hints->domain_attr->mode = ~0;
-	/* This would prevent testing "Scalable MR" which this test is not doing
-	 * it as of this change anyway */
-	hints->domain_attr->mr_mode = ~0;
+	hints->domain_attr->mr_mode = ~(FI_MR_BASIC | FI_MR_SCALABLE);
 
 	hints->caps |= FI_MSG | FI_RMA;
 


### PR DESCRIPTION
Several tests set mr_mode = ~0.  This results in setting
both FI_MR_BASIC and FI_MR_SCALABLE, in conjunction with
1.5+ mr_mode bits.  New checks in libfabric prohibit this
combination.

Remove setting the FI_MR_BASIC and FI_MR_SCALABLE bits.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>