### PR TITLE
streaming/rdm_rma: Add FI_CONTEXT mode to be able run over verbs/RDM

### DIFF
--- a/streaming/rdm_rma.c
+++ b/streaming/rdm_rma.c
@@ -107,6 +107,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
+	hints->mode = FI_CONTEXT;
 	hints->caps = FI_MSG | FI_RMA;
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;


### PR DESCRIPTION
It enables support of this test for the verbs/RDM provider

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>