### PR TITLE
simple/rdm_tagged_peek.c: Keep context in scope between FI_PEEK|FI_CLAIM and FI_CLAIM.

### DIFF
--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -38,6 +38,8 @@
 
 #include <shared.h>
 
+static struct fi_context fi_context;
+
 static int wait_for_send_comp(int count)
 {
 	int ret, completions = 0;
@@ -62,7 +64,6 @@ static int tag_queue_op(uint64_t tag, int recv, uint64_t flags)
 	struct fi_msg_tagged msg = {0};
 	struct fi_cq_err_entry cq_err;
 	struct iovec iov;
-	struct fi_context ctx;
 	void *desc;
 
 	if (recv) {
@@ -75,7 +76,7 @@ static int tag_queue_op(uint64_t tag, int recv, uint64_t flags)
 		msg.addr = remote_fi_addr;
 	}
 	msg.tag = tag;
-	msg.context = &ctx;
+	msg.context = &fi_context;
 
 	ret = fi_trecvmsg(ep, &msg, flags);
 	if (ret) {


### PR DESCRIPTION
The API requires that the context passed to fi_recvmsg() for
FI_PEEK|FI_CLAIM be a struct fi_context and that the same fi_context
must be passed to FI_CLAIM. The prior code met the API in the sense
that the fi_context to FI_CLAIM would have the same address, but it
had gone out of scope since the FI_PEEK and the contents were
lost. Since some providers hide the pointer to the claimed entry in
the context, this can lead to segfaults.

Making the context global keeps the fix as small as possible and
is consistent with the way the tests are written.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>