### PR TITLE
Update cq_data, dgram_pingpong tests, add test exclusions for psm2

### DIFF
--- a/benchmarks/dgram_pingpong.c
+++ b/benchmarks/dgram_pingpong.c
@@ -119,6 +119,7 @@ int main(int argc, char **argv)
 	if (opts.options & FT_OPT_SIZE)
 		hints->ep_attr->max_msg_size = opts.transfer_size;
 	hints->caps = FI_MSG;
+	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	ret = run();

--- a/scripts/runfabtests.sh
+++ b/scripts/runfabtests.sh
@@ -79,7 +79,9 @@ neg_unit_tests=(
 
 simple_tests=(
 	"cm_data"
-	"cq_data"
+	"cq_data -e msg"
+	"cq_data -e rdm"
+	"cq_data -e dgram"
 	"dgram"
 	"dgram_waitset"
 	"msg"

--- a/test_configs/psm2/psm2.exclude
+++ b/test_configs/psm2/psm2.exclude
@@ -1,0 +1,21 @@
+# Regex patterns of tests to exclude in runfabtests.sh
+
+# Exclude all prefix tests
+-k
+
+# av_test supports only FI_SOCKADDR
+av_test
+
+^msg|-e msg
+
+cm_data
+
+# psm2 supports only shared transmit context
+shared_ctx$|shared_ctx -e dgram$|shared_ctx.*--no-tx-shared-ctx
+
+scalable_ep
+cmatose
+shared_av
+rdm_cntr_pingpong
+rc_pingpong
+ubertest

--- a/test_configs/verbs/verbs.exclude
+++ b/test_configs/verbs/verbs.exclude
@@ -19,7 +19,8 @@ shared_av
 multi_mr
 recv_cancel
 unexpected_msg
-rma.+rdm.+writedata
+rma.*-e rdm.*-o writedata
+rdm_rma.*-o writedata
 rdm.+atomic
 rdm.+cntr
 inj_complete.*-e msg


### PR DESCRIPTION
- simple: Expand CQ data test to support other EP types
- benchmarks: Add support for FI_CONTEXT in dgram_pingpong
- Add runfabtests exlusion list for psm2
- Add rdm_rma -o writedata test to verbs test exclusions