### PR TITLE
common: Fix passing an invalid MR desc if the FI_MR_LOCAL/FI_LOCAL_MR bit isn't set

### DIFF
--- a/benchmarks/dgram_pingpong.c
+++ b/benchmarks/dgram_pingpong.c
@@ -52,7 +52,7 @@ static int run(void)
 	/* Post an extra receive to avoid lacking a posted receive in the
 	 * finalize.
 	 */
-	ret = fi_recv(ep, rx_buf, rx_size + ft_rx_prefix_size(), fi_mr_desc(mr),
+	ret = fi_recv(ep, rx_buf, rx_size + ft_rx_prefix_size(), mr_desc,
 			0, &rx_ctx);
 
 	if (!(opts.options & FT_OPT_SIZE)) {

--- a/include/shared.h
+++ b/include/shared.h
@@ -160,6 +160,7 @@ extern struct fid_ep *ep, *alias_ep;
 extern struct fid_cq *txcq, *rxcq;
 extern struct fid_cntr *txcntr, *rxcntr;
 extern struct fid_mr *mr, no_mr;
+extern void *mr_desc;
 extern struct fid_av *av;
 extern struct fid_eq *eq;
 extern struct fid_mc *mc;
@@ -379,15 +380,15 @@ static inline bool ft_check_prefix_forced(struct fi_info *info,
 	return true;
 }
 
-int ft_sync();
+int ft_sync(void);
 int ft_sync_pair(int status);
-int ft_fork_and_pair();
-int ft_wait_child();
+int ft_fork_and_pair(void);
+int ft_wait_child(void);
 int ft_finalize(void);
 int ft_finalize_ep(struct fid_ep *ep);
 
-size_t ft_rx_prefix_size();
-size_t ft_tx_prefix_size();
+size_t ft_rx_prefix_size(void);
+size_t ft_tx_prefix_size(void);
 ssize_t ft_post_rx(struct fid_ep *ep, size_t size, struct fi_context* ctx);
 ssize_t ft_post_tx(struct fid_ep *ep, fi_addr_t fi_addr, size_t size,
 		uint64_t data, struct fi_context* ctx);

--- a/simple/dgram_waitset.c
+++ b/simple/dgram_waitset.c
@@ -84,8 +84,8 @@ static int send_recv()
 	struct fi_cq_entry comp;
 	int ret;
 
-	ret = fi_recv(ep, rx_buf, rx_size + ft_rx_prefix_size(), fi_mr_desc(mr),
-		      0, &rx_ctx);
+	ret = fi_recv(ep, rx_buf, rx_size + ft_rx_prefix_size(),
+		      mr_desc, 0, &rx_ctx);
 	if (ret)
 		return ret;
 

--- a/simple/rdm_deferred_wq.c
+++ b/simple/rdm_deferred_wq.c
@@ -54,7 +54,7 @@ static void format_simple_msg(struct fi_msg *msg, struct iovec *iov, void *src,
 			      size_t size, void *ctx)
 {
 	msg->context = ctx;
-	msg->desc = fi_mr_desc(mr);
+	msg->desc = mr_desc;
 	msg->iov_count = 1;
 	msg->addr = remote_fi_addr;
 	msg->data = 0;
@@ -69,7 +69,7 @@ static void format_simple_msg_tagged(struct fi_msg_tagged *msg, struct iovec *io
 			      uint64_t tag)
 {
 	msg->context = ctx;
-	msg->desc = fi_mr_desc(mr);
+	msg->desc = mr_desc;
 	msg->iov_count = 1;
 	msg->addr = remote_fi_addr;
 	msg->data = 0;
@@ -85,7 +85,7 @@ static void format_simple_msg_rma(struct fi_msg_rma *msg, struct iovec *iov,
 			   size_t size, void *ctx)
 {
 	msg->context = ctx;
-	msg->desc = fi_mr_desc(mr);
+	msg->desc = mr_desc;
 	msg->iov_count = 1;
 	msg->addr = remote_fi_addr;
 	msg->rma_iov_count = 1;
@@ -106,7 +106,7 @@ static void format_simple_msg_atomic(struct fi_msg_atomic *msg, struct fi_ioc *i
 			      enum fi_op op)
 {
 	msg->context = ctx;
-	msg->desc = fi_mr_desc(mr);
+	msg->desc = mr_desc;
 	msg->iov_count = 1;
 	msg->rma_iov_count = 1;
 	msg->addr = remote_fi_addr;
@@ -197,7 +197,7 @@ static int send_wait_check()
 	int ret;
 
 	if (opts.dst_addr) {
-		ret = fi_write(ep, tx_buf, strlen(welcome_text), fi_mr_desc(mr),
+		ret = fi_write(ep, tx_buf, strlen(welcome_text), mr_desc,
 				remote_fi_addr, 0, FT_MR_KEY, &tx_ctx);
  		if (ret) {
  			FT_PRINTERR("fi_write", ret);

--- a/simple/rdm_rma_simple.c
+++ b/simple/rdm_rma_simple.c
@@ -57,8 +57,9 @@ static int run_test(void)
                         fprintf(stderr, "Transmit buffer too small.\n");
                         return -FI_ETOOSMALL;
                 }
-		ret = fi_write(ep, tx_buf, message_len, fi_mr_desc(mr),
-				remote_fi_addr, 0, FT_MR_KEY, &fi_ctx_write);
+		ret = fi_write(ep, tx_buf, message_len, mr_desc,
+			       remote_fi_addr, 0, FT_MR_KEY,
+			       &fi_ctx_write);
 		if (ret)
 			return ret;
 

--- a/simple/rdm_rma_trigger.c
+++ b/simple/rdm_rma_trigger.c
@@ -49,8 +49,9 @@ static int rma_write_trigger(void *src, size_t size,
 	triggered_ctx.event_type = FI_TRIGGER_THRESHOLD;
 	triggered_ctx.trigger.threshold.cntr = cntr;
 	triggered_ctx.trigger.threshold.threshold = threshold;
-	ret = fi_write(alias_ep, src, size, fi_mr_desc(mr), remote_fi_addr, 0,
-			FT_MR_KEY, &triggered_ctx);
+	ret = fi_write(alias_ep, src, size, mr_desc,
+		       remote_fi_addr, 0,
+		       FT_MR_KEY, &triggered_ctx);
  	if (ret){
  		FT_PRINTERR("fi_write", ret);
  		return ret;
@@ -80,7 +81,7 @@ static int run_test(void)
 			goto out;
 
 		fprintf(stdout, "RMA write to server\n");
-		ret = fi_write(ep, tx_buf, strlen(welcome_text1), fi_mr_desc(mr),
+		ret = fi_write(ep, tx_buf, strlen(welcome_text1), mr_desc,
 				remote_fi_addr, 0, FT_MR_KEY, &tx_ctx);
  		if (ret){
  			FT_PRINTERR("fi_write", ret);

--- a/simple/rdm_tagged_peek.c
+++ b/simple/rdm_tagged_peek.c
@@ -70,7 +70,7 @@ static int tag_queue_op(uint64_t tag, int recv, uint64_t flags)
 		iov.iov_base = buf;
 		iov.iov_len = rx_size;
 		msg.msg_iov = &iov;
-		desc = fi_mr_desc(mr);
+		desc = mr_desc;
 		msg.desc = &desc;
 		msg.iov_count = 1;
 		msg.addr = remote_fi_addr;
@@ -191,8 +191,9 @@ static int run(void)
 		/* sync with sender before ft_finalize, since we sent
 		 * and received messages outside of the sequence numbers
 		 * maintained by common code */
-		ret = fi_tsend(ep, tx_buf, 1, fi_mr_desc(mr),
-				remote_fi_addr, 0xabc, &tx_ctx_arr[0]);
+		ret = fi_tsend(ep, tx_buf, 1, mr_desc,
+				remote_fi_addr, 0xabc,
+				&tx_ctx_arr[0]);
 		if (ret)
 			return ret;
 		ret = wait_for_send_comp(1);
@@ -201,8 +202,9 @@ static int run(void)
 	} else {
 		printf("Sending five tagged messages\n");
 		for(i = 0; i < 5; i++) {
-			ret = fi_tsend(ep, tx_buf, tx_size, fi_mr_desc(mr),
-					remote_fi_addr, 0x900d+i, &tx_ctx_arr[i]);
+			ret = fi_tsend(ep, tx_buf, tx_size, mr_desc,
+				       remote_fi_addr, 0x900d+i,
+				       &tx_ctx_arr[i]);
 			if (ret)
 				return ret;
 		}

--- a/simple/scalable_ep.c
+++ b/simple/scalable_ep.c
@@ -162,7 +162,7 @@ static int bind_ep_res(void)
 		}
 
 		ret = fi_recv(rx_ep[i], rx_buf, MAX(rx_size, FT_MAX_CTRL_MSG),
-				fi_mr_desc(mr), 0, NULL);
+			      mr_desc, 0, NULL);
 		if (ret) {
 			FT_PRINTERR("fi_recv", ret);
 			return ret;
@@ -208,8 +208,8 @@ static int run_test()
 		for (i = 0; i < ctx_cnt && !ret; i++) {
 			fprintf(stdout, "Posting send for ctx: %d\n", i);
 			tb[0] = DATA + i;
-			ret = fi_send(tx_ep[i], tx_buf, tx_size, fi_mr_desc(mr),
-					remote_rx_addr[i], NULL);
+			ret = fi_send(tx_ep[i], tx_buf, tx_size, mr_desc,
+				      remote_rx_addr[i], NULL);
 			if (ret) {
 				FT_PRINTERR("fi_send", ret);
 				return ret;
@@ -288,7 +288,7 @@ static int init_av(void)
 		}
 
 		ret = fi_send(tx_ep[0], tx_buf, addrlen,
-				fi_mr_desc(mr), remote_fi_addr, NULL);
+			      mr_desc, remote_fi_addr, NULL);
 		if (ret) {
 			FT_PRINTERR("fi_send", ret);
 			return ret;
@@ -307,7 +307,7 @@ static int init_av(void)
 			return ret;
 
 		ret = fi_send(tx_ep[0], tx_buf, 1,
-				fi_mr_desc(mr), remote_fi_addr, NULL);
+			      mr_desc, remote_fi_addr, NULL);
 		if (ret) {
 			FT_PRINTERR("fi_send", ret);
 			return ret;
@@ -317,7 +317,7 @@ static int init_av(void)
 	for (i = 0; i < ctx_cnt; i++)
 		remote_rx_addr[i] = fi_rx_addr(remote_fi_addr, i, rx_ctx_bits);
 
-	ret = fi_recv(rx_ep[0], rx_buf, rx_size, fi_mr_desc(mr), 0, NULL);
+	ret = fi_recv(rx_ep[0], rx_buf, rx_size, mr_desc, 0, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_recv", ret);
 		return ret;

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -228,7 +228,7 @@ static inline int execute_base_atomic_op(enum fi_op op)
 {
 	int ret;
 
-	ret = fi_atomic(ep, buf, 1, fi_mr_desc(mr), remote_fi_addr, remote.addr,
+	ret = fi_atomic(ep, buf, 1, mr_desc, remote_fi_addr, remote.addr,
 		       	remote.key, datatype, op, &fi_ctx_atomic);
 	if (ret) {
 		FT_PRINTERR("fi_atomic", ret);
@@ -243,7 +243,7 @@ static inline int execute_fetch_atomic_op(enum fi_op op)
 {
 	int ret;
 
-	ret = fi_fetch_atomic(ep, buf, 1, fi_mr_desc(mr), result,
+	ret = fi_fetch_atomic(ep, buf, 1, mr_desc, result,
 			fi_mr_desc(mr_result), remote_fi_addr, remote.addr,
 			remote.key, datatype, op, &fi_ctx_atomic);
 	if (ret) {
@@ -259,7 +259,7 @@ static inline int execute_compare_atomic_op(enum fi_op op)
 {
 	int ret;
 
-	ret = fi_compare_atomic(ep, buf, 1, fi_mr_desc(mr), compare,
+	ret = fi_compare_atomic(ep, buf, 1, mr_desc, compare,
 			fi_mr_desc(mr_compare), result, fi_mr_desc(mr_result),
 			remote_fi_addr, remote.addr, remote.key, datatype, op,
 			&fi_ctx_atomic);


### PR DESCRIPTION
The patch is intended to fix the following:
- Marks local functions as static functions and adds `void` to the argument list if the function argument list is empty.
- Pass NULL as a MR descriptor to the `fi_read`, `fi_write`, `fi_(t)send`, `fi_(t)senddata`, `fi_(t)recv`, `fi_(t)sendmsg`, `fi_(t)recvmsg` in case of a provider doesn't require `FI_MR_LOCAL`/`FI_LOCAL_MR` bit set.
The `ft_info_to_mr_access` function set flags as follows:
if the provider requires `FI_MR_LOCAL`/`FI_LOCAL_MR` bit set, the MR `FI_SEND`, `FI_RECV` (if the provider supports `FI_MSG | FI_TAGGED`) and `FI_READ`, `FI_WRITE`, `FI_REMOTE_READ`, `FI_REMOTE_WRITE` (if the provider supports `FI_RMA | FI_ATOMIC`) access flags are set.
if the provider doesn't require `FI_MR_LOCAL`/`FI_LOCAL_MR` bit set, the MR `FI_REMOTE_READ` and `FI_REMOTE_WRITE` access flags are only set. I.e. this flag is invalid to be accessed for the RMA, TAGGED, MSG operations as a local MR descriptor.


Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>