### PR TITLE
complex/ubertest: Updated Ubertest to support testing FI_DIRECTED_RECV

### DIFF
--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -381,6 +381,7 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FI_REMOTE_READ, uint64_t, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_REMOTE_WRITE, uint64_t, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_TAGGED, uint64_t, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_DIRECTED_RECV, uint64_t, buf);
 		FT_ERR("Unknown caps");
 	} else {
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_QUEUE, enum ft_comp_type, buf);
@@ -759,13 +760,15 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->test_flags = set->test_flags;
 	info->test_class = set->test_class[series->cur_class];
 
-	if (set->constant_caps[0]) {
-		while (set->constant_caps[i])
-			info->caps |= set->constant_caps[i++];
-	} else {
+	if (info->test_class) {
 		info->caps = set->test_class[series->cur_class];
 		if (info->caps & (FT_CAP_RMA | FT_CAP_ATOMIC))
 			info->caps |= FT_CAP_MSG;
+	}
+
+	if (set->constant_caps[0]) {
+		while (set->constant_caps[i])
+			info->caps |= set->constant_caps[i++];
 	}
 
 	info->mode = (set->mode[series->cur_mode] == FT_MODE_NONE) ?

--- a/complex/ft_endpoint.c
+++ b/complex/ft_endpoint.c
@@ -114,10 +114,6 @@ int ft_open_active(void)
 		return ret;
 	}
 
-	ret = ft_post_recv_bufs();
-	if (ret)
-		return ret;
-
 	return 0;
 }
 

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -43,6 +43,9 @@ static int ft_post_recv(void)
 	if (ret)
 		return ret;
 
+	if (fabric_info->caps & FI_DIRECTED_RECV)
+		ft_rx_ctrl.addr = ft_tx_ctrl.addr;
+
 	switch (test_info.class_function) {
 	case FT_FUNC_SENDV:
 		ft_format_iov(ft_rx_ctrl.iov, ft_ctrl.iov_array[ft_rx_ctrl.iov_iter],
@@ -81,6 +84,9 @@ static int ft_post_trecv(void)
 	ret = ft_get_ctx(&ft_rx_ctrl, &ctx);
 	if (ret)
 		return ret;
+
+	if (fabric_info->caps & FI_DIRECTED_RECV)
+		ft_rx_ctrl.addr = ft_tx_ctrl.addr;
 
 	switch (test_info.class_function) {
 	case FT_FUNC_SENDV:

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -953,6 +953,11 @@ int ft_init_test()
 		FT_PRINTERR("ft_enable_comm", ret);
 		goto cleanup;
 	}
+
+	ret = ft_post_recv_bufs();
+	if (ret)
+		return ret;
+
 	return 0;
 cleanup:
 	ft_cleanup();


### PR DESCRIPTION
-Added FI_DIRECTED_RECV as a supported constant capability
-Updated ubertest to support adding constant_caps to the test class in
progress
-Moved pre-posting recvs until after the remote addr is known allowing
for testing FI_DIRECTED_RECV
-Updated the value of ft_rx_ctrl.addr to be the same as ft_tx_ctrl.addr
given FI_DIRECTED_RECV is requested when posting recvs.
-Only affects unconnected endpoint tests, connected endpoint tests are unaffected

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>