### PR TITLE
travis-ci: Add a workaround for a Travis CI Mac OS issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ before_install:
       brew upgrade automake || true; brew upgrade libtool || true;
     fi
 install:
+    # Disable rvm override of cd
+    # see https://github.com/travis-ci/travis-ci/issues/8703
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        unset -f cd;
+      fi
     - set -e
     - git clone https://github.com/ofiwg/libfabric.git
     - cd libfabric


### PR DESCRIPTION
Travis CI has an issue where Mac OS builds are failing.
See https://github.com/travis-ci/travis-ci/issues/8703

Apparently it's an issue with rvm on Mac OS. Use the workaround
mentioned in the Github issue.

This patch can be reverted once the original issue is fixed.