### PR TITLE
Ubertest cleanup, add support for OOB address exchange

### DIFF
--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -698,15 +698,16 @@ static void ft_fw_usage(char *program)
 	fprintf(stderr, "\nServer only options:\n");
 	FT_PRINT_OPTS_USAGE("-x", "exit after test run");
 	fprintf(stderr, "\nClient only options:\n");
-	FT_PRINT_OPTS_USAGE("-u <test_config_file>", "config file path (Either config file path or both provider and test config name are required)");
+	FT_PRINT_OPTS_USAGE("-u <test_config_file>", "test configuration file "
+		"(Either config file or both provider and test name are required)");
 	FT_PRINT_OPTS_USAGE("-p <provider_name>", " provider name");
-	FT_PRINT_OPTS_USAGE("-t <test_config_name>", "test config name");
+	FT_PRINT_OPTS_USAGE("-t <test_name>", "test name");
 	FT_PRINT_OPTS_USAGE("-y <start_test_index>", "");
 	FT_PRINT_OPTS_USAGE("-z <end_test_index>", "");
 	FT_PRINT_OPTS_USAGE("-s <address>", "source address");
 	FT_PRINT_OPTS_USAGE("-B <src_port>", "non default source port number");
-	FT_PRINT_OPTS_USAGE("-P <dst_port>", "non default destination port number"
-		       " (config file service parameter will override this)");
+	FT_PRINT_OPTS_USAGE("-P <dst_port>", "non default destination port number "
+		"(config file service parameter will override this)");
 }
 
 void ft_free()

--- a/include/shared.h
+++ b/include/shared.h
@@ -143,7 +143,6 @@ struct ft_opts {
 	enum ft_comp_method comp_method;
 	int machr;
 	enum ft_rma_opcodes rma_op;
-	int oob_sync;
 	char *oob_port;
 	int argc;
 
@@ -215,7 +214,7 @@ extern int ft_parent_proc;
 extern int ft_socket_pair[2];
 extern int sock;
 extern int listen_sock;
-#define ADDR_OPTS "B:P:s:a:b:"
+#define ADDR_OPTS "B:P:s:a:b::"
 #define FAB_OPTS "f:d:p:"
 #define INFO_OPTS FAB_OPTS "e:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
@@ -235,7 +234,7 @@ extern char default_port[8];
 		.verbose = 0, \
 		.sizes_enabled = FT_DEFAULT_SIZE, \
 		.rma_op = FT_RMA_WRITE, \
-		.oob_sync = 0, \
+		.oob_port = NULL, \
 		.argc = argc, .argv = argv \
 	}
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -143,6 +143,8 @@ struct ft_opts {
 	enum ft_comp_method comp_method;
 	int machr;
 	enum ft_rma_opcodes rma_op;
+	int oob_sync;
+	char *oob_port;
 	int argc;
 
 	/* Fail if the selected provider does not support FI_MSG_PREFIX.  */
@@ -213,7 +215,7 @@ extern int ft_parent_proc;
 extern int ft_socket_pair[2];
 extern int sock;
 extern int listen_sock;
-#define ADDR_OPTS "B:P:s:a:"
+#define ADDR_OPTS "B:P:s:a:b:"
 #define FAB_OPTS "f:d:p:"
 #define INFO_OPTS FAB_OPTS "e:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
@@ -233,6 +235,7 @@ extern char default_port[8];
 		.verbose = 0, \
 		.sizes_enabled = FT_DEFAULT_SIZE, \
 		.rma_op = FT_RMA_WRITE, \
+		.oob_sync = 0, \
 		.argc = argc, .argv = argv \
 	}
 

--- a/man/fabtests.7.md
+++ b/man/fabtests.7.md
@@ -109,6 +109,10 @@ The common options for most of the tests are listed below. Individual tests may 
 *-s <src_addr>*
 : The source address.
 
+*-b[=<oob_port>]
+: Enables out-of-band address exchange and synchronization over the optionally specified port.
+
+
 *-I <iter>*
 : Number of iterations of the test will run.
 


### PR DESCRIPTION
ubertest: Break excessively long help line and slight tweak to wording.
manual merge of OOB address exchange support, plus updates to simplify those changes.