### PR TITLE
Revert "Add rxm provider to travis CI testing"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -338,6 +338,5 @@ dist-hook: fabtests.spec
 	cp fabtests.spec $(distdir)
 
 test:
-	./scripts/runfabtests.sh -vvv -S -R $(os_excludes)
-	./scripts/runfabtests.sh -vvv -S -R $(os_excludes) -f ./test_configs/udp/udp.exclude udp
-	./scripts/runfabtests.sh -vvv -S -R $(os_excludes) -f ./test_configs/ofi_rxm/ofi_rxm.exclude "sockets;ofi_rxm"
+	./scripts/runfabtests.sh -vvv -S $(os_excludes)
+	./scripts/runfabtests.sh -vvv -S $(os_excludes) -R -f ./test_configs/udp/udp.exclude udp


### PR DESCRIPTION
Reverts ofiwg/fabtests#762

Still see failures in rxm over sockets sometimes. The tests somehow passed when the original PR was merged.