### PR TITLE
complex/fi_ubertest: mr_mode support

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -113,6 +113,7 @@ struct ft_atomic_control {
 struct ft_mr_control {
 	void			*buf;
 	struct fid_mr		*mr;
+	uint64_t		peer_mr_addr;
 	void			*memdesc;
 	uint64_t		mr_key;
 };
@@ -140,6 +141,7 @@ enum {
 	FT_MAX_AV_TYPES		= 3,
 	FT_MAX_PROV_MODES	= 4,
 	FT_MAX_WAIT_OBJ		= 5,
+	FT_MAX_MR_MODES		= 11,
 	FT_DEFAULT_CREDITS	= 128,
 	FT_COMP_BUF_SIZE	= 256,
 };
@@ -241,6 +243,7 @@ struct ft_set {
 	uint64_t		test_class[FT_MAX_CLASS];
 	uint64_t		constant_caps[FT_MAX_CAPS];
 	uint64_t		test_flags;
+	uint64_t		mr_mode[FT_MAX_MR_MODES];
 };
 
 struct ft_series {
@@ -275,6 +278,7 @@ struct ft_info {
 	uint64_t		test_class;
 	uint64_t		caps;
 	uint64_t		mode;
+	uint64_t		mr_mode;
 	enum fi_av_type		av_type;
 	enum fi_ep_type		ep_type;
 	enum ft_comp_type	comp_type;

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -268,6 +268,12 @@ static struct key_t keys[] = {
 		.offset = offsetof(struct ft_set, msg_flags),
 		.val_type = VAL_NUM,
 		.val_size = sizeof(((struct ft_set *)0)->msg_flags),
+	},
+	{
+		.str = "mr_mode",
+		.offset = offsetof(struct ft_set, mr_mode),
+		.val_type = VAL_NUM,
+		.val_size = sizeof(((struct ft_set *)0)->mr_mode) / FT_MAX_MR_MODES,
 	}
 };
 
@@ -371,6 +377,10 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		FT_ERR("Unknown datatype");
 	} else if (!strncmp(key->str, "msg_flags", strlen("msg_flags"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_REMOTE_CQ_DATA, uint64_t, buf);
+		FT_ERR("Unknown message flag");
+	} else if (!strncmp(key->str, "mr_mode", strlen("mr_mode"))) {
+		TEST_ENUM_SET_N_RETURN(str, len, FI_MR_VIRT_ADDR, uint64_t, buf);
+		FT_ERR("Unknown MR mode");
 	} else if (!strncmp(key->str, "constant_caps", strlen("constant_caps"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_RMA, uint64_t, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MSG, uint64_t, buf);
@@ -769,6 +779,11 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	if (set->constant_caps[0]) {
 		while (set->constant_caps[i])
 			info->caps |= set->constant_caps[i++];
+	}
+	i = 0;
+	if (set->mr_mode[0]) {
+		while (set->mr_mode[i])
+			info->mr_mode |= set->mr_mode[i++];
 	}
 
 	info->mode = (set->mode[series->cur_mode] == FT_MODE_NONE) ?

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -202,6 +202,7 @@ static void ft_show_test_info(void)
 	printf(" cq_%s,", ft_wait_obj_str(test_info.cq_wait_obj));
 	printf(" cntr_%s,", ft_wait_obj_str(test_info.cq_wait_obj));
 	printf(" %s,", ft_comp_type_str(test_info.comp_type));
+	printf(" [%s],", fi_tostr(&test_info.mr_mode, FI_TYPE_MR_MODE));
 	printf(" [%s],", fi_tostr(&test_info.mode, FI_TYPE_MODE));
 	printf(" [%s]]\n", fi_tostr(&test_info.caps, FI_TYPE_CAPS));
 }
@@ -232,6 +233,7 @@ static void ft_fw_convert_info(struct fi_info *info, struct ft_info *test_info)
 
 	info->mode = test_info->mode;
 
+	info->domain_attr->mr_mode = test_info->mr_mode;
 	info->domain_attr->av_type = test_info->av_type;
 
 	info->ep_attr->type = test_info->ep_type;

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -906,6 +906,30 @@ void ft_cleanup(void)
 	memset(&ft_ctrl, 0, sizeof ft_ctrl);
 }
 
+static int ft_exchange_mr_address(void)
+{
+	uint64_t addr;
+	int ret;
+
+	if (test_info.mr_mode != FI_MR_VIRT_ADDR)
+		return 0;
+
+	addr = (uint64_t) ft_mr_ctrl.buf;
+	ret = ft_sock_send(sock, &addr, sizeof addr);
+	if (ret) {
+		FT_PRINTERR("ft_sock_send", ret);
+		return ret;
+	}
+
+	ret = ft_sock_recv(sock, &ft_mr_ctrl.peer_mr_addr, sizeof addr);
+	if (ret) {
+		FT_PRINTERR("ft_sock_recv", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
 int ft_open_res()
 {
 	int ret;
@@ -957,6 +981,12 @@ int ft_init_test()
 	ret = ft_post_recv_bufs();
 	if (ret)
 		return ret;
+
+	ret = ft_exchange_mr_address();
+	if (ret) {
+		FT_PRINTERR("ft_exchange_mr_address", ret);
+		goto cleanup;
+	}
 
 	return 0;
 cleanup:


### PR DESCRIPTION
- add mr_mode to config file (one per test set)
- add peer_mr_addr field to mr_ctrl and exchange virtual addresses if mr_mode = FI_MR_VIRT_ADDR
- add peer_mr_addr to all RMA and atomic calls (and fix line lengths)
- verified working on shared memory provider which requires MR_VIRT_ADDR

Signed-off-by: aingerson <alexia.ingerson@intel.com>