### PR TITLE
complex/ubertest: Support for testing FI_SELECTIVE_COMPLETION

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -144,6 +144,7 @@ enum {
 	FT_MAX_MR_MODES		= 11,
 	FT_DEFAULT_CREDITS	= 128,
 	FT_COMP_BUF_SIZE	= 256,
+	FT_MAX_FLAGS		= 64,
 };
 
 enum ft_comp_type {
@@ -244,6 +245,10 @@ struct ft_set {
 	uint64_t		constant_caps[FT_MAX_CAPS];
 	uint64_t		test_flags;
 	uint64_t		mr_mode[FT_MAX_MR_MODES];
+	uint64_t 		rx_cq_bind_flags[FT_MAX_FLAGS];
+	uint64_t 		tx_cq_bind_flags[FT_MAX_FLAGS];
+	uint64_t 		rx_op_flags[FT_MAX_FLAGS];
+	uint64_t 		tx_op_flags[FT_MAX_FLAGS];
 };
 
 struct ft_series {
@@ -291,6 +296,10 @@ struct ft_info {
 	char			service[FI_NAME_MAX];
 	char			prov_name[FI_NAME_MAX];
 	char			fabric_name[FI_NAME_MAX];
+	uint64_t 		rx_cq_bind_flags;
+	uint64_t 		tx_cq_bind_flags;
+	uint64_t 		rx_op_flags;
+	uint64_t 		tx_op_flags;
 };
 
 
@@ -330,6 +339,8 @@ void ft_format_iov(struct iovec *iov, size_t cnt, char *buf, size_t len);
 void ft_format_iocs(struct iovec *iov, size_t *iov_count);
 void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt);
 int ft_get_ctx(struct ft_xcontrol *ctrl, struct fi_context **ctx);
+int ft_check_cq_completion(uint64_t cq_bind_flags, uint64_t op_flags,
+		enum ft_class_function class_function, uint64_t msg_flags);
 
 int ft_send_sync_msg();
 int ft_recv_n_msg();

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -258,6 +258,30 @@ static struct key_t keys[] = {
 		.val_size = sizeof(((struct ft_set *)0)->constant_caps) / FT_MAX_CAPS,
 	},
 	{
+		.str = "rx_cq_bind_flags",
+		.offset = offsetof(struct ft_set, rx_cq_bind_flags),
+		.val_type = VAL_NUM,
+		.val_size = sizeof(((struct ft_set *)0)->rx_cq_bind_flags) / FT_MAX_FLAGS,
+	},
+	{
+		.str = "tx_cq_bind_flags",
+		.offset = offsetof(struct ft_set, tx_cq_bind_flags),
+		.val_type = VAL_NUM,
+		.val_size = sizeof(((struct ft_set *)0)->tx_cq_bind_flags) / FT_MAX_FLAGS,
+	},
+	{
+		.str = "rx_op_flags",
+		.offset = offsetof(struct ft_set, rx_op_flags),
+		.val_type = VAL_NUM,
+		.val_size = sizeof(((struct ft_set *)0)->rx_op_flags) / FT_MAX_FLAGS,
+	},
+	{
+		.str = "tx_op_flags",
+		.offset = offsetof(struct ft_set, tx_op_flags),
+		.val_type = VAL_NUM,
+		.val_size = sizeof(((struct ft_set *)0)->tx_op_flags) / FT_MAX_FLAGS,
+	},
+	{
 		.str = "test_flags",
 		.offset = offsetof(struct ft_set, test_flags),
 		.val_type = VAL_NUM,
@@ -377,6 +401,7 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		FT_ERR("Unknown datatype");
 	} else if (!strncmp(key->str, "msg_flags", strlen("msg_flags"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_REMOTE_CQ_DATA, uint64_t, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_COMPLETION, uint64_t, buf);
 		FT_ERR("Unknown message flag");
 	} else if (!strncmp(key->str, "mr_mode", strlen("mr_mode"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MR_VIRT_ADDR, uint64_t, buf);
@@ -393,6 +418,18 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FI_TAGGED, uint64_t, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_DIRECTED_RECV, uint64_t, buf);
 		FT_ERR("Unknown caps");
+	} else if (!strncmp(key->str, "rx_cq_bind_flags", strlen("rx_cq_bind_flags"))) {
+		TEST_ENUM_SET_N_RETURN(str, len, FI_SELECTIVE_COMPLETION, uint64_t, buf);
+		FT_ERR("Unknown rx_cq_bind_flags");
+	} else if (!strncmp(key->str, "tx_cq_bind_flags", strlen("tx_cq_bind_flags"))) {
+		TEST_ENUM_SET_N_RETURN(str, len, FI_SELECTIVE_COMPLETION, uint64_t, buf);
+		FT_ERR("Unknown tx_cq_bind_flags");
+	} else if (!strncmp(key->str, "rx_op_flags", strlen("rx_op_flags"))) {
+		TEST_ENUM_SET_N_RETURN(str, len, FI_COMPLETION, uint64_t, buf);
+		FT_ERR("Unknown rx_op_flags");
+	} else if (!strncmp(key->str, "tx_op_flags", strlen("tx_op_flags"))) {
+		TEST_ENUM_SET_N_RETURN(str, len, FI_COMPLETION, uint64_t, buf);
+		FT_ERR("Unknown tx_op_flags");
 	} else {
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_QUEUE, enum ft_comp_type, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_CNTR, enum ft_comp_type, buf);
@@ -777,13 +814,34 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	}
 
 	if (set->constant_caps[0]) {
+		i = 0;
 		while (set->constant_caps[i])
 			info->caps |= set->constant_caps[i++];
 	}
-	i = 0;
 	if (set->mr_mode[0]) {
+		i = 0;
 		while (set->mr_mode[i])
 			info->mr_mode |= set->mr_mode[i++];
+	}
+	if (set->rx_cq_bind_flags[0]) {
+		i = 0;
+		while (set->rx_cq_bind_flags[i])
+			info->rx_cq_bind_flags |= set->rx_cq_bind_flags[i++];
+	}
+	if (set->tx_cq_bind_flags[0]) {
+		i = 0;
+		while (set->tx_cq_bind_flags[i])
+			info->tx_cq_bind_flags |= set->tx_cq_bind_flags[i++];
+	}
+	if (set->rx_op_flags[0]) {
+		i = 0;
+		while (set->rx_op_flags[i])
+			info->rx_op_flags |= set->rx_op_flags[i++];
+	}
+	if (set->tx_op_flags[0]) {
+		i = 0;
+		while (set->tx_op_flags[i])
+			info->tx_op_flags |= set->tx_op_flags[i++];
 	}
 
 	info->mode = (set->mode[series->cur_mode] == FT_MODE_NONE) ?

--- a/complex/ft_main.c
+++ b/complex/ft_main.c
@@ -248,6 +248,9 @@ static void ft_fw_convert_info(struct fi_info *info, struct ft_info *test_info)
 		info->fabric_attr->name = strndup(test_info->fabric_name,
 					sizeof test_info->fabric_name - 1);
 	}
+
+	info->tx_attr->op_flags = test_info->tx_op_flags;
+	info->rx_attr->op_flags = test_info->rx_op_flags;
 }
 
 static void


### PR DESCRIPTION
-Added support for testing that a given provider fully supports the
	options of selectively generating completion events.

-Added new flag categories for the test_config:
	-rx_cq_bind_flags -> allows for passing FI_SELECTIVE_COMPLETION
		to rx cq_bind.
	-tx_cq_bind_flags -> allows for passing FI_SELECTIVE_COMPLETION
		to tx cq_bind.
	-rx_op_flags -> allows for setting FI_COMPLETION in the
		rx_op_flags on the endpoints.
	-tx_op_flags -> allows for setting FI_COMPLETION in the
		tx_op_flags on the endpoints.

-Added support for FI_COMPLETION msg_flag for use in *msg functions.

-Added new functions ft_get_tx_cq_completion & ft_get_rx_cq_completion
	which check the current test case to test if a tx/rx completion
	event is expected.

-Added setting the tx/rx attribute flags based on the tx/rx op_flags
	set for the test case.

-Update calls to set the context value to first check to see if a completion
	is expected, otherwise leave the context as NULL.

-Updated the calls to get completion events to check if a completion is
	expected and if not update the credits to signify completion of the
	tx/rx operation.

-Updated the *msg apis to all use the msg_flags if FI_COMPLETION is set.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>