### PR TITLE
Updates to fi_ubertest

### DIFF
--- a/complex/fabtest.h
+++ b/complex/fabtest.h
@@ -113,9 +113,10 @@ struct ft_atomic_control {
 struct ft_mr_control {
 	void			*buf;
 	struct fid_mr		*mr;
-	uint64_t		peer_mr_addr;
 	void			*memdesc;
 	uint64_t		mr_key;
+	uint64_t		peer_mr_addr;
+	uint64_t		peer_mr_key;
 };
 
 struct ft_control {

--- a/complex/ft_config.c
+++ b/complex/ft_config.c
@@ -404,7 +404,10 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FI_COMPLETION, uint64_t, buf);
 		FT_ERR("Unknown message flag");
 	} else if (!strncmp(key->str, "mr_mode", strlen("mr_mode"))) {
+		TEST_ENUM_SET_N_RETURN(str, len, FI_MR_LOCAL, uint64_t, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MR_VIRT_ADDR, uint64_t, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_MR_ALLOCATED, uint64_t, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_MR_PROV_KEY, uint64_t, buf);
 		FT_ERR("Unknown MR mode");
 	} else if (!strncmp(key->str, "constant_caps", strlen("constant_caps"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_RMA, uint64_t, buf);

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -192,8 +192,9 @@ static int ft_setup_xcontrol_bufs(struct ft_xcontrol *ctrl)
 		memset(ctrl->buf, 0, size);
 	}
 
-	if ((fabric_info->mode & FI_LOCAL_MR) && !ctrl->mr) {
-		ret = fi_mr_reg(domain, ctrl->buf, size, FI_RECV | FI_SEND,
+	if ((fabric_info->domain_attr->mr_mode & FI_MR_LOCAL) && !ctrl->mr) {
+		ret = fi_mr_reg(domain, ctrl->buf, size,
+				ft_info_to_mr_access(fabric_info),
 				0, 0, 0, &ctrl->mr, NULL);
 		if (ret) {
 			FT_PRINTERR("fi_mr_reg", ret);
@@ -239,7 +240,7 @@ static int ft_setup_atomic_control(struct ft_atomic_control *ctrl)
 		memset(ctrl->orig_buf, 0, size);
 	}
 
-	if (fabric_info->mode & FI_LOCAL_MR) {
+	if (fabric_info->domain_attr->mr_mode & FI_MR_LOCAL) {
 		access = FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE;
 		if (!ctrl->res_mr) {
 			ret = fi_mr_reg(domain, ctrl->res_buf, size, access,

--- a/complex/ft_domain.c
+++ b/complex/ft_domain.c
@@ -292,7 +292,7 @@ static int ft_setup_mr_control(struct ft_mr_control *ctrl)
 			return ret;
 		}
 		ctrl->memdesc = fi_mr_desc(ctrl->mr);
-		ctrl->mr_key = fi_mr_key(ctrl->mr);
+		ctrl->peer_mr_key = ctrl->mr_key = fi_mr_key(ctrl->mr);
 	}
 	
 	return 0;

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -661,8 +661,9 @@ static int ft_send_rma_sync(void)
 		return ret;
 
 	ft_send_retry(ret, fi_writedata, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
-		0, ft_tx_ctrl.memdesc, ft_tx_ctrl.remote_cq_data,
-		ft_tx_ctrl.addr, 0, ft_mr_ctrl.mr_key, ctx);
+		      0, ft_tx_ctrl.memdesc, ft_tx_ctrl.remote_cq_data,
+		      ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
+		      ft_mr_ctrl.mr_key, ctx);
 	ft_tx_ctrl.credits--;
 	return ret;
 }

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -301,7 +301,7 @@ static int ft_post_send_rma(void)
 	switch (test_info.class_function) {
 	case FT_FUNC_READ:
 		ft_send_retry(ret, fi_read, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
-			ft_tx_ctrl.rma_msg_size, ft_mr_ctrl.memdesc,
+			ft_tx_ctrl.rma_msg_size, ft_tx_ctrl.memdesc,
 			ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
 			ft_mr_ctrl.mr_key, ctx);
 		ft_tx_ctrl.credits--;
@@ -378,7 +378,7 @@ static int ft_post_send_rma(void)
 		break;
 	case FT_FUNC_WRITEDATA:
 		ft_send_retry(ret, fi_writedata, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
-			ft_tx_ctrl.rma_msg_size, ft_mr_ctrl.memdesc,
+			ft_tx_ctrl.rma_msg_size, ft_tx_ctrl.memdesc,
 			ft_tx_ctrl.remote_cq_data, ft_tx_ctrl.addr,
 			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.mr_key, ctx);
 		ft_tx_ctrl.credits--;
@@ -391,7 +391,7 @@ static int ft_post_send_rma(void)
 		break;
 	default:
 		ft_send_retry(ret, fi_write, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
-			ft_tx_ctrl.rma_msg_size, ft_mr_ctrl.memdesc,
+			ft_tx_ctrl.rma_msg_size, ft_tx_ctrl.memdesc,
 			ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
 			ft_mr_ctrl.mr_key, ctx);
 		ft_tx_ctrl.credits--;
@@ -661,7 +661,7 @@ static int ft_send_rma_sync(void)
 		return ret;
 
 	ft_send_retry(ret, fi_writedata, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
-		0, ft_mr_ctrl.memdesc, ft_tx_ctrl.remote_cq_data,
+		0, ft_tx_ctrl.memdesc, ft_tx_ctrl.remote_cq_data,
 		ft_tx_ctrl.addr, 0, ft_mr_ctrl.mr_key, ctx);
 	ft_tx_ctrl.credits--;
 	return ret;

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -303,7 +303,7 @@ static int ft_post_send_rma(void)
 		ft_send_retry(ret, fi_read, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
 			ft_tx_ctrl.rma_msg_size, ft_tx_ctrl.memdesc,
 			ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
-			ft_mr_ctrl.mr_key, ctx);
+			ft_mr_ctrl.peer_mr_key, ctx);
 		ft_tx_ctrl.credits--;
 		break;
 	case FT_FUNC_READV:
@@ -312,7 +312,7 @@ static int ft_post_send_rma(void)
 		ft_send_retry(ret, fi_readv, ft_tx_ctrl.ep, ft_tx_ctrl.iov,
 			ft_tx_ctrl.iov_desc, ft_ctrl.iov_array[ft_tx_ctrl.iov_iter],
 			ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
-			ft_mr_ctrl.mr_key, ctx);
+			ft_mr_ctrl.peer_mr_key, ctx);
 		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
 		ft_tx_ctrl.credits--;
 		break;
@@ -328,7 +328,7 @@ static int ft_post_send_rma(void)
 		msg.data = 0;
 
 		rma_iov.addr = ft_mr_ctrl.peer_mr_addr;
-		rma_iov.key = ft_mr_ctrl.mr_key;
+		rma_iov.key = ft_mr_ctrl.peer_mr_key;
 		for (i = 0, rma_iov.len = 0; i < msg.iov_count; i++)
 			rma_iov.len += ft_tx_ctrl.iov[i].iov_len;
 
@@ -344,7 +344,7 @@ static int ft_post_send_rma(void)
 		ft_send_retry(ret, fi_writev, ft_tx_ctrl.ep, ft_tx_ctrl.iov,
 			ft_tx_ctrl.iov_desc, ft_ctrl.iov_array[ft_tx_ctrl.iov_iter],
 			ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
-			ft_mr_ctrl.mr_key, ctx);
+			ft_mr_ctrl.peer_mr_key, ctx);
 		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
 		ft_tx_ctrl.credits--;
 		break;
@@ -360,7 +360,7 @@ static int ft_post_send_rma(void)
 		msg.data = ft_tx_ctrl.remote_cq_data;
 
 		rma_iov.addr = ft_mr_ctrl.peer_mr_addr;
-		rma_iov.key = ft_mr_ctrl.mr_key;
+		rma_iov.key = ft_mr_ctrl.peer_mr_key;
 		for (i = 0, rma_iov.len = 0; i < msg.iov_count; i++)
 			rma_iov.len += ft_tx_ctrl.iov[i].iov_len;
 
@@ -374,26 +374,26 @@ static int ft_post_send_rma(void)
 	case FT_FUNC_INJECT_WRITE:
 		ft_send_retry(ret, fi_inject_write, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
 			ft_tx_ctrl.rma_msg_size, ft_tx_ctrl.addr,
-			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.mr_key);
+			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.peer_mr_key);
 		break;
 	case FT_FUNC_WRITEDATA:
 		ft_send_retry(ret, fi_writedata, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
 			ft_tx_ctrl.rma_msg_size, ft_tx_ctrl.memdesc,
 			ft_tx_ctrl.remote_cq_data, ft_tx_ctrl.addr,
-			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.mr_key, ctx);
+			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.peer_mr_key, ctx);
 		ft_tx_ctrl.credits--;
 		break;
 	case FT_FUNC_INJECT_WRITEDATA:
 		ft_send_retry(ret, fi_inject_writedata, ft_tx_ctrl.ep,
 			ft_tx_ctrl.buf, ft_tx_ctrl.rma_msg_size,
 			ft_tx_ctrl.remote_cq_data, ft_tx_ctrl.addr,
-			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.mr_key);
+			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.peer_mr_key);
 		break;
 	default:
 		ft_send_retry(ret, fi_write, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
 			ft_tx_ctrl.rma_msg_size, ft_tx_ctrl.memdesc,
 			ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
-			ft_mr_ctrl.mr_key, ctx);
+			ft_mr_ctrl.peer_mr_key, ctx);
 		ft_tx_ctrl.credits--;
 		break;
 	}
@@ -423,7 +423,7 @@ int ft_post_send_atomic(void)
 		ft_format_iocs(ft_tx_ctrl.iov, &iov_count);
 		ft_send_retry(ret, fi_atomicv, ft_tx_ctrl.ep, ft_atom_ctrl.ioc,
 			ft_tx_ctrl.iov_desc, iov_count, ft_tx_ctrl.addr,
-			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.mr_key,
+			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.peer_mr_key,
 			ft_atom_ctrl.datatype, ft_atom_ctrl.op, ctx);
 		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
 		ft_tx_ctrl.credits--;
@@ -440,7 +440,7 @@ int ft_post_send_atomic(void)
 		msg.datatype = ft_atom_ctrl.datatype;
 
 		rma_iov.addr = ft_mr_ctrl.peer_mr_addr;
-		rma_iov.key = ft_mr_ctrl.mr_key;
+		rma_iov.key = ft_mr_ctrl.peer_mr_key;
 
 		for (i = 0, rma_iov.count = 0; i < msg.iov_count; i++)
 			rma_iov.count += ft_atom_ctrl.ioc[i].count;
@@ -456,7 +456,7 @@ int ft_post_send_atomic(void)
 			ft_tx_ctrl.buf, ft_atom_ctrl.count, ft_tx_ctrl.memdesc,
 			ft_atom_ctrl.res_buf, ft_atom_ctrl.res_memdesc,
 			ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
-			ft_mr_ctrl.mr_key, ft_atom_ctrl.datatype,
+			ft_mr_ctrl.peer_mr_key, ft_atom_ctrl.datatype,
 			ft_atom_ctrl.op, ctx);
 		ft_tx_ctrl.credits--;
 		break;
@@ -466,7 +466,7 @@ int ft_post_send_atomic(void)
 			ft_atom_ctrl.ioc, ft_tx_ctrl.iov_desc, iov_count,
 			ft_atom_ctrl.res_ioc, ft_atom_ctrl.res_memdesc,
 			iov_count, ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
-			ft_mr_ctrl.mr_key, ft_atom_ctrl.datatype,
+			ft_mr_ctrl.peer_mr_key, ft_atom_ctrl.datatype,
 			ft_atom_ctrl.op, ctx);
 		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
 		ft_tx_ctrl.credits--;
@@ -483,7 +483,7 @@ int ft_post_send_atomic(void)
 		msg.datatype = ft_atom_ctrl.datatype;
 
 		rma_iov.addr = ft_mr_ctrl.peer_mr_addr;
-		rma_iov.key = ft_mr_ctrl.mr_key;
+		rma_iov.key = ft_mr_ctrl.peer_mr_key;
 
 		for (i = 0, rma_iov.count = 0; i < msg.iov_count; i++)
 			rma_iov.count += ft_atom_ctrl.ioc[i].count;
@@ -503,7 +503,7 @@ int ft_post_send_atomic(void)
 			ft_atom_ctrl.comp_buf, ft_atom_ctrl.comp_memdesc,
 			ft_atom_ctrl.res_buf, ft_atom_ctrl.res_memdesc,
 			ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
-			ft_mr_ctrl.mr_key, ft_atom_ctrl.datatype,
+			ft_mr_ctrl.peer_mr_key, ft_atom_ctrl.datatype,
 			ft_atom_ctrl.op, ctx);
 		ft_tx_ctrl.credits--;
 		break;
@@ -514,7 +514,7 @@ int ft_post_send_atomic(void)
 			ft_atom_ctrl.comp_ioc, ft_atom_ctrl.comp_memdesc,
 			iov_count, ft_atom_ctrl.res_ioc,
 			ft_atom_ctrl.res_memdesc, iov_count, ft_tx_ctrl.addr,
-			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.mr_key,
+			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.peer_mr_key,
 			ft_atom_ctrl.datatype, ft_atom_ctrl.op, ctx);
 		ft_next_iov_cnt(&ft_tx_ctrl, fabric_info->tx_attr->iov_limit);
 		ft_tx_ctrl.credits--;
@@ -531,7 +531,7 @@ int ft_post_send_atomic(void)
 		msg.datatype = ft_atom_ctrl.datatype;
 
 		rma_iov.addr = ft_mr_ctrl.peer_mr_addr;
-		rma_iov.key = ft_mr_ctrl.mr_key;
+		rma_iov.key = ft_mr_ctrl.peer_mr_key;
 
 		for (i = 0, rma_iov.count = 0; i < msg.iov_count; i++)
 			rma_iov.count += ft_atom_ctrl.ioc[i].count;
@@ -549,14 +549,14 @@ int ft_post_send_atomic(void)
 	case FT_FUNC_INJECT_ATOMIC:
 		ft_send_retry(ret, fi_inject_atomic, ft_tx_ctrl.ep,
 			ft_tx_ctrl.buf, ft_atom_ctrl.count, ft_tx_ctrl.addr, 
-			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.mr_key,
+			ft_mr_ctrl.peer_mr_addr, ft_mr_ctrl.peer_mr_key,
 			ft_atom_ctrl.datatype, ft_atom_ctrl.op);
 		break;
 	default:
 		ft_send_retry(ret, fi_atomic, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
 				ft_atom_ctrl.count, ft_tx_ctrl.memdesc,
 				ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
-				ft_mr_ctrl.mr_key, ft_atom_ctrl.datatype,
+				ft_mr_ctrl.peer_mr_key, ft_atom_ctrl.datatype,
 				ft_atom_ctrl.op, ctx);
 		ft_tx_ctrl.credits--;
 	}
@@ -663,7 +663,7 @@ static int ft_send_rma_sync(void)
 	ft_send_retry(ret, fi_writedata, ft_tx_ctrl.ep, ft_tx_ctrl.buf,
 		      0, ft_tx_ctrl.memdesc, ft_tx_ctrl.remote_cq_data,
 		      ft_tx_ctrl.addr, ft_mr_ctrl.peer_mr_addr,
-		      ft_mr_ctrl.mr_key, ctx);
+		      ft_mr_ctrl.peer_mr_key, ctx);
 	ft_tx_ctrl.credits--;
 	return ret;
 }


### PR DESCRIPTION
- complex: Fix incorrect mem desc reference for transmit buffers (cc: v1.5.x)
- complex: Fix remote memory addr in RMA sync
- complex: Fix check for local MR mode and also pass correct access flags (cc: v1.5.x)
- complex: Add support for handling FI_MR_PROV_KEY, FI_MR_LOCAL, FI_MR_ALLOCATED