### PR TITLE
dgram_pingpong.c: Fix FI_MSG_PREFIX support.

### DIFF
--- a/benchmarks/dgram_pingpong.c
+++ b/benchmarks/dgram_pingpong.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
 	if (opts.options & FT_OPT_SIZE)
 		hints->ep_attr->max_msg_size = opts.transfer_size;
 	hints->caps = FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode |= FI_CONTEXT;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	ret = run();


### PR DESCRIPTION
Commit a84977486 seems to have broken the FI_MSG_PREFIX support. Make
sure not to overwrite the previous mode bits set when adding FI_CONTEXT
support.

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>