### PR TITLE
complex/ft_comp: Fix FT_COMP_ALL to reset credits for CQ read

### DIFF
--- a/complex/ft_comp.c
+++ b/complex/ft_comp.c
@@ -295,6 +295,8 @@ static int ft_cntr_x(struct fid_cntr *cntr, struct ft_xcontrol *ft_x,
 int ft_comp_rx(int timeout)
 {
 	int ret;
+	size_t cur_credits = ft_rx_ctrl.credits;
+
 	if (ft_use_comp_cntr(test_info.comp_type)) {
 		ret = ft_cntr_x(rxcntr, &ft_rx_ctrl, timeout);
 		if (ret)
@@ -305,6 +307,8 @@ int ft_comp_rx(int timeout)
 					test_info.rx_op_flags,
 					test_info.class_function,
 					test_info.msg_flags)) {
+			if (test_info.comp_type == FT_COMP_ALL)
+				ft_rx_ctrl.credits = cur_credits;
 			ret = ft_comp_x(rxcq, &ft_rx_ctrl, "rxcq", timeout);
 			if (ret)
 				return ret;
@@ -324,6 +328,8 @@ int ft_comp_rx(int timeout)
 int ft_comp_tx(int timeout)
 {
 	int ret;
+	size_t cur_credits = ft_tx_ctrl.credits;
+
 	if (ft_use_comp_cntr(test_info.comp_type)) {
 		ret = ft_cntr_x(txcntr, &ft_tx_ctrl, timeout);
 		if (ret)
@@ -334,6 +340,8 @@ int ft_comp_tx(int timeout)
 					test_info.tx_op_flags,
 					test_info.class_function,
 					test_info.msg_flags)) {
+			if (test_info.comp_type == FT_COMP_ALL)
+				ft_tx_ctrl.credits = cur_credits;
 			ret = ft_comp_x(txcq, &ft_tx_ctrl, "txcq", timeout);
 			if (ret)
 				return ret;


### PR DESCRIPTION
-With the current FT_COMP_ALL at completion time the cntr records the
number of completions into the tx/rx credits.

-After reaching the threshold in the counter the CQ is called, however
the tx/rx credits are not reset such that the CQ ends up returning
with a success before reading or waiting for all the CQ events to fire.

-This issue is fixed by resetting the tx/rx credits after the counter
completes such that the CQ correctly reads all the events before
returning successfully.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>