### PR TITLE
common/shared.c, complex/ubertest, test_configs/shm : enable shared memory provider

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,7 +85,8 @@ nobase_dist_config_DATA = \
 	test_configs/psm2/all.test \
 	test_configs/psm2/verify.test \
 	test_configs/psm2/psm2.exclude \
-	test_configs/ofi_rxm/ofi_rxm.exclude
+	test_configs/ofi_rxm/ofi_rxm.exclude \
+	test_configs/shm/all.test
 
 noinst_LTLIBRARIES = libfabtests.la
 libfabtests_la_SOURCES = \

--- a/common/shared.c
+++ b/common/shared.c
@@ -1794,7 +1794,7 @@ static int ft_spin_for_comp(struct fid_cq *cq, uint64_t *cur,
 	if (timeout >= 0)
 		clock_gettime(CLOCK_MONOTONIC, &a);
 
-	while (total - *cur > 0) {
+	do {
 		ret = fi_cq_read(cq, &comp, 1);
 		if (ret > 0) {
 			if (timeout >= 0)
@@ -1811,7 +1811,7 @@ static int ft_spin_for_comp(struct fid_cq *cq, uint64_t *cur,
 				return -FI_ENODATA;
 			}
 		}
-	}
+	} while (total - *cur > 0);
 
 	return 0;
 }

--- a/complex/ft_msg.c
+++ b/complex/ft_msg.c
@@ -630,7 +630,7 @@ int ft_recv_n_msg(int n)
 		}
 
 		credits = ft_rx_ctrl.credits;
-		ret = ft_comp_rx(FT_COMP_TO);
+		ret = ft_comp_rx(0);
 		if (ret)
 			return ret;
 
@@ -672,8 +672,8 @@ int ft_send_sync_msg(void)
 {
 	int ret;
 
-	while (!ft_tx_ctrl.credits) {
-		ret = ft_comp_tx(FT_COMP_TO);
+	while (ft_tx_ctrl.credits != ft_tx_ctrl.max_credits) {
+		ret = ft_comp_tx(0);
 		if (ret)
 			return ret;
 	}

--- a/complex/ft_test.c
+++ b/complex/ft_test.c
@@ -934,7 +934,8 @@ static int ft_exchange_mr_addr_key(void)
 	}
 
 	ft_mr_ctrl.peer_mr_addr = peer_rma_iov.addr;
-	ft_mr_ctrl.peer_mr_key = peer_rma_iov.key;
+	if (test_info.mr_mode & FI_MR_PROV_KEY)
+		ft_mr_ctrl.peer_mr_key = peer_rma_iov.key;
 
 	return 0;
 }

--- a/test_configs/shm/all.test
+++ b/test_configs/shm/all.test
@@ -1,0 +1,60 @@
+{
+	prov_name: shm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+	        FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+		FT_FUNC_INJECT,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mr_mode: [
+		FI_MR_VIRT_ADDR,
+	],
+},
+{
+	prov_name: shm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_WRITEMSG,
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+		FT_FUNC_READMSG,
+		FT_FUNC_INJECT_WRITE,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mr_mode: [
+		FI_MR_VIRT_ADDR,
+	],
+},


### PR DESCRIPTION
- enable shared memory provider by altering some progress calls (provider relies on peer progress and currently only enabled with manual progress)
- enable ubertest for shared memory provider testing by adding config files
- only set peer_mr_key during exchange_addr_key if FI_MR_PROV_KEY set

Signed-off-by: aingerson <alexia.ingerson@intel.com>