### PR TITLE
streaming/rdm_atomic.c: Fix access flags on buffers

### DIFF
--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -405,18 +405,18 @@ static int alloc_ep_res(struct fi_info *fi)
 	// registers local data buffer buff that specifies
 	// the first operand of the atomic operation
 	ret = fi_mr_reg(domain, buf, buf_size,
-		FI_REMOTE_READ | FI_REMOTE_WRITE, 0,
-		get_mr_key(), 0, &mr, NULL);
+			(FI_SEND | FI_RECV | FI_READ | FI_WRITE |
+			 FI_REMOTE_READ | FI_REMOTE_WRITE), 0,
+			get_mr_key(), 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
 	}
 
-	// registers local data buffer that stores initial value of
-	// the remote buffer
+	// registers local data buffer that stores results
 	ret = fi_mr_reg(domain, result, buf_size,
-		FI_REMOTE_READ | FI_REMOTE_WRITE, 0,
-		get_mr_key(), 0, &mr_result, NULL);
+			FI_READ | FI_REMOTE_WRITE, 0,
+			get_mr_key(), 0, &mr_result, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", -ret);
 		return ret;
@@ -424,8 +424,8 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	// registers local data buffer that contains comparison data
 	ret = fi_mr_reg(domain, compare, buf_size,
-		FI_REMOTE_READ | FI_REMOTE_WRITE, 0,
-		get_mr_key(), 0, &mr_compare, NULL);
+			FI_WRITE | FI_REMOTE_READ, 0,
+			get_mr_key(), 0, &mr_compare, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -382,6 +382,7 @@ static uint64_t get_mr_key()
 static int alloc_ep_res(struct fi_info *fi)
 {
 	int ret;
+	int mr_local = !!(fi->domain_attr->mr_mode & FI_MR_LOCAL);
 
 	/* Prevent memory registration by ft_alloc_active_res() -> ft_alloc_msgs() */
 	ft_skip_mr = 1;
@@ -402,20 +403,24 @@ static int alloc_ep_res(struct fi_info *fi)
 		return -1;
 	}
 
-	// registers local data buffer buff that specifies
-	// the first operand of the atomic operation
+	// registers local data buffer buff that used for send/recv
+	// and local/remote RMA.
 	ret = fi_mr_reg(domain, buf, buf_size,
-			(FI_SEND | FI_RECV | FI_READ | FI_WRITE |
+			((mr_local ?
+			  FI_SEND | FI_RECV | FI_READ | FI_WRITE : 0) |
 			 FI_REMOTE_READ | FI_REMOTE_WRITE), 0,
 			get_mr_key(), 0, &mr, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);
 		return ret;
 	}
+	// Set global descriptor for FI_MR_LOCAL.
+	if (mr_local)
+		mr_desc = fi_mr_desc(mr);
 
 	// registers local data buffer that stores results
 	ret = fi_mr_reg(domain, result, buf_size,
-			FI_READ | FI_REMOTE_WRITE, 0,
+			(mr_local ? FI_READ : 0) | FI_REMOTE_WRITE, 0,
 			get_mr_key(), 0, &mr_result, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", -ret);
@@ -424,7 +429,7 @@ static int alloc_ep_res(struct fi_info *fi)
 
 	// registers local data buffer that contains comparison data
 	ret = fi_mr_reg(domain, compare, buf_size,
-			FI_WRITE | FI_REMOTE_READ, 0,
+			(mr_local ? FI_WRITE : 0)  | FI_REMOTE_READ, 0,
 			get_mr_key(), 0, &mr_compare, NULL);
 	if (ret) {
 		FT_PRINTERR("fi_mr_reg", ret);


### PR DESCRIPTION
If a provider requires FI_MR_LOCAL, then the three registered
buffers need different permissions. The first buffer is used for
send/recv and local/remote RMA, so it is easier to give it all
permissions. If the results buffer is written by hardware, it
needs FI_READ for the local HCA and, possibly, FI_REMOTE_WRITE
for the remote HCA; similarly the compare buffer needs FI_WRITE
for local and FI_REMOTE_READ for remote. I don't know of a fabric
that would actually access the results/compare data remotely ---
or with hardware for that matter --- but I'm leaving the
possibility open.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>