### PR TITLE
simple/multi_mr.c: Don't segfault if fi_mr_bind() unimplemented.

### DIFF
--- a/simple/multi_mr.c
+++ b/simple/multi_mr.c
@@ -72,27 +72,14 @@ static int wait_cntr(struct fid_cntr *cntr, uint64_t *cntr_next)
 
 static int free_mr_res()
 {
-	int ret, i;
+	int i;
 
 	if (!mr_res_array)
 		return 0;
 
 	for (i = 0; i < mr_count; i++) {
-		if (mr_res_array[i].mr) {
-			ret = fi_close(&mr_res_array[i].mr->fid);
-			if (ret) {
-				FT_PRINTERR("fi_close", ret);
-				return ret;
-			}
-		}
-
-		if (mr_res_array[i].rcntr) {
-			ret = fi_close(&mr_res_array[i].rcntr->fid);
-			if (ret) {
-				FT_PRINTERR("fi_close", ret);
-				return ret;
-			}
-		}
+		FT_CLOSE_FID(mr_res_array[i].mr);
+		FT_CLOSE_FID(mr_res_array[i].rcntr);
 	}
 	free(mr_res_array);
 	free(remote_array);

--- a/simple/multi_mr.c
+++ b/simple/multi_mr.c
@@ -78,16 +78,20 @@ static int free_mr_res()
 		return 0;
 
 	for (i = 0; i < mr_count; i++) {
-		ret = fi_close(&mr_res_array[i].mr->fid);
-		if (ret) {
-			FT_PRINTERR("fi_close", ret);
-			return ret;
+		if (mr_res_array[i].mr) {
+			ret = fi_close(&mr_res_array[i].mr->fid);
+			if (ret) {
+				FT_PRINTERR("fi_close", ret);
+				return ret;
+			}
 		}
 
-		ret = fi_close(&mr_res_array[i].rcntr->fid);
-		if (ret) {
-			FT_PRINTERR("fi_close", ret);
-			return ret;
+		if (mr_res_array[i].rcntr) {
+			ret = fi_close(&mr_res_array[i].rcntr->fid);
+			if (ret) {
+				FT_PRINTERR("fi_close", ret);
+				return ret;
+			}
 		}
 	}
 	free(mr_res_array);


### PR DESCRIPTION
Check for NULL pointers in free_mr_res() before calling fi_close().

Signed-off-by: John Byrne <john.l.byrne@hpe.com>