### PR TITLE
config/rxm: Remove rdm_multi_recv test from exclude list

### DIFF
--- a/test_configs/ofi_rxm/ofi_rxm.exclude
+++ b/test_configs/ofi_rxm/ofi_rxm.exclude
@@ -17,7 +17,6 @@ multi_mr
 atomic
 inj_complete
 rdm_cntr_pingpong
-rdm_multi_recv
 cmatose
 rc_pingpong
 


### PR DESCRIPTION
This patch removes `rdm_multi_recv` test from RxM provider's exclude list

Please,  merge this patch when ofiwg/libfabric#3742 will be got merged

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>