### PR TITLE
config/rxm: Remove rdm_cntr_pingpong test from exclude list

### DIFF
--- a/test_configs/ofi_rxm/ofi_rxm.exclude
+++ b/test_configs/ofi_rxm/ofi_rxm.exclude
@@ -16,7 +16,6 @@ shared_av
 multi_mr
 atomic
 inj_complete
-rdm_cntr_pingpong
 cmatose
 rc_pingpong
 


### PR DESCRIPTION
This patch removes `rdm_cntr_pingpong` test from RxM provider's exclude list

Please,  merge this patch when ofiwg/libfabric#3744 will be got merged

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>