### PR TITLE
AV insertion/removal test with data transfers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ os_excludes = -f ./test_configs/osx.exclude
 endif
 
 bin_PROGRAMS = \
+	simple/fi_av_xfer \
 	simple/fi_msg \
 	simple/fi_msg_sockets \
 	simple/fi_rdm \
@@ -110,6 +111,10 @@ if !HAVE_CLOCK_GETTIME
 libfabtests_la_SOURCES += common/osx/osd.c
 endif
 endif
+
+simple_fi_av_xfer_SOURCES = \
+	simple/av_xfer.c
+simple_fi_av_xfer_LDADD = libfabtests.la
 
 simple_fi_msg_sockets_SOURCES = \
 	simple/msg_sockets.c

--- a/common/shared.c
+++ b/common/shared.c
@@ -558,6 +558,14 @@ int ft_alloc_active_res(struct fi_info *fi)
 	return 0;
 }
 
+static void ft_init(void)
+{
+	tx_seq = 0;
+	rx_seq = 0;
+	tx_cq_cntr = 0;
+	rx_cq_cntr = 0;
+}
+
 int ft_init_oob()
 {
 	int ret, op, err;
@@ -660,6 +668,7 @@ int ft_start_server(void)
 {
 	int ret;
 
+	ft_init();
 	ret = ft_init_oob();
 	if (ret)
 		return ret;
@@ -820,6 +829,7 @@ int ft_client_connect(void)
 {
 	int ret;
 
+	ft_init();
 	ret = ft_init_oob();
 	if (ret)
 		return ret;
@@ -851,6 +861,7 @@ int ft_init_fabric(void)
 {
 	int ret;
 
+	ft_init();
 	ret = ft_init_oob();
 	if (ret)
 		return ret;

--- a/common/shared.c
+++ b/common/shared.c
@@ -566,12 +566,12 @@ static void ft_init(void)
 	rx_cq_cntr = 0;
 }
 
-int ft_init_oob()
+static int ft_init_oob(void)
 {
 	int ret, op, err;
 	struct addrinfo *ai = NULL;
 
-	if (!(opts.options & FT_OPT_OOB_SYNC))
+	if (!(opts.options & FT_OPT_OOB_SYNC) || oob_sock != -1)
 		return 0;
 
 	if (!opts.oob_port)
@@ -588,6 +588,8 @@ int ft_init_oob()
 			ret = oob_sock;
 			return ret;
 		}
+
+		close(listen_sock);
 	} else {
 
 		ret = getaddrinfo(opts.dst_addr, opts.oob_port, NULL, &ai);

--- a/common/shared.c
+++ b/common/shared.c
@@ -563,6 +563,12 @@ int ft_init_oob()
 	int ret, op, err;
 	struct addrinfo *ai = NULL;
 
+	if (!(opts.options & FT_OPT_OOB_SYNC))
+		return 0;
+
+	if (!opts.oob_port)
+		opts.oob_port = default_oob_port;
+
 	if (!opts.dst_addr) {
 		ret = ft_sock_listen(opts.oob_port);
 		if (ret)
@@ -654,11 +660,9 @@ int ft_start_server(void)
 {
 	int ret;
 
-	if (opts.oob_port) {
-		ret = ft_init_oob();
-		if (ret)
-			return ret;
-	}
+	ret = ft_init_oob();
+	if (ret)
+		return ret;
 
 	ret = ft_getinfo(hints, &fi_pep);
 	if (ret)
@@ -816,11 +820,9 @@ int ft_client_connect(void)
 {
 	int ret;
 
-	if (opts.oob_port) {
-		ret = ft_init_oob();
-		if (ret)
-			return ret;
-	}
+	ret = ft_init_oob();
+	if (ret)
+		return ret;
 
 	ret = ft_getinfo(hints, &fi);
 	if (ret)
@@ -849,11 +851,9 @@ int ft_init_fabric(void)
 {
 	int ret;
 
-	if (opts.oob_port) {
-		ret = ft_init_oob();
-		if (ret)
-			return ret;
-	}
+	ret = ft_init_oob();
+	if (ret)
+		return ret;
 
 	ret = ft_getinfo(hints, &fi);
 	if (ret)
@@ -2501,10 +2501,12 @@ void ft_parse_addr_opts(int op, char *optarg, struct ft_opts *opts)
 		opts->dst_port = optarg;
 		break;
 	case 'b':
+		opts->options |= FT_OPT_OOB_SYNC;
 		if (optarg && strlen(optarg) > 1)
 			opts->oob_port = optarg + 1;
 		else
 			opts->oob_port = default_oob_port;
+		break;
 	default:
 		/* let getopt handle unknown opts*/
 		break;

--- a/include/shared.h
+++ b/include/shared.h
@@ -114,6 +114,7 @@ enum {
 	FT_OPT_ALIGN		= 1 << 8,
 	FT_OPT_BW		= 1 << 9,
 	FT_OPT_CQ_SHARED	= 1 << 10,
+	FT_OPT_OOB_SYNC		= 1 << 11,
 };
 
 /* for RMA tests --- we want to be able to select fi_writedata, but there is no

--- a/simple/av_xfer.c
+++ b/simple/av_xfer.c
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#include <shared.h>
+
+
+static struct fi_info *base_hints;
+
+
+static int av_removal_test(void)
+{
+	int ret;
+
+	fprintf(stdout, "AV address removal: ");
+	hints = fi_dupinfo(base_hints);
+	if (!hints)
+		return -FI_ENOMEM;
+
+	ret = ft_init_fabric();
+	if (ret)
+		return ret;
+
+	if (opts.dst_addr) {
+		ret = ft_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+		if (ret) {
+			FT_PRINTERR("ft_tx", -ret);
+			goto out;
+		}
+
+		ret = fi_av_remove(av, &remote_fi_addr, 1, 0);
+		if (ret) {
+			FT_PRINTERR("fi_av_remove", ret);
+			goto out;
+		}
+
+		ret = ft_sync();
+		if (ret)
+			goto out;
+
+		ret = ft_init_av();
+		if (ret) {
+			FT_PRINTERR("ft_init_av", -ret);
+			goto out;
+		}
+
+		ret = ft_rx(ep, opts.transfer_size);
+		if (ret) {
+			FT_PRINTERR("ft_rx", -ret);
+			goto out;
+		}
+	} else {
+		ret = ft_rx(ep, opts.transfer_size);
+		if (ret) {
+			FT_PRINTERR("ft_rx", -ret);
+			goto out;
+		}
+
+		ret = fi_av_remove(av, &remote_fi_addr, 1, 0);
+		if (ret) {
+			FT_PRINTERR("fi_av_remove", ret);
+			goto out;
+		}
+
+		ret = ft_sync();
+		if (ret)
+			goto out;
+
+		ret = ft_init_av();
+		if (ret) {
+			FT_PRINTERR("ft_init_av", -ret);
+			goto out;
+		}
+
+		ret = ft_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+		if (ret) {
+			FT_PRINTERR("ft_tx", -ret);
+			goto out;
+		}
+	}
+
+	fprintf(stdout, "PASS\n");
+	(void) ft_sync();
+out:
+	ft_free_res();
+	return ret;
+}
+
+static int av_duplicate_test(void)
+{
+	fi_addr_t dup_addr;
+	int ret;
+
+	fprintf(stdout, "AV duplicate address: ");
+	hints = fi_dupinfo(base_hints);
+	if (!hints)
+		return -FI_ENOMEM;
+
+	ret = ft_init_fabric();
+	if (ret)
+		return ret;
+
+	ret = ft_init_av_addr(av, ep, &dup_addr);
+	if (ret)
+		goto out;
+
+	if (opts.dst_addr) {
+		ret = ft_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+		if (ret) {
+			FT_PRINTERR("ft_tx", -ret);
+			goto out;
+		}
+
+		ret = ft_tx(ep, dup_addr, opts.transfer_size, &tx_ctx);
+		if (ret) {
+			FT_PRINTERR("ft_tx", -ret);
+			goto out;
+		}
+
+		ret = fi_av_remove(av, &remote_fi_addr, 1, 0);
+		if (ret) {
+			FT_PRINTERR("fi_av_remove", ret);
+			goto out;
+		}
+
+		ret = ft_tx(ep, dup_addr, opts.transfer_size, &tx_ctx);
+		if (ret) {
+			FT_PRINTERR("ft_tx", -ret);
+			goto out;
+		}
+
+		ret = ft_sync();
+		if (ret)
+			goto out;
+
+		ret = ft_init_av();
+		if (ret) {
+			FT_PRINTERR("ft_init_av", -ret);
+			goto out;
+		}
+
+		ret = ft_rx(ep, opts.transfer_size);
+		if (ret) {
+			FT_PRINTERR("ft_rx", -ret);
+			goto out;
+		}
+	} else {
+		ret = ft_rx(ep, opts.transfer_size);
+		if (ret) {
+			FT_PRINTERR("ft_rx", -ret);
+			goto out;
+		}
+
+		ret = ft_rx(ep, opts.transfer_size);
+		if (ret) {
+			FT_PRINTERR("ft_rx", -ret);
+			goto out;
+		}
+
+		ret = fi_av_remove(av, &remote_fi_addr, 1, 0);
+		if (ret) {
+			FT_PRINTERR("fi_av_remove", ret);
+			goto out;
+		}
+
+		ret = ft_rx(ep, opts.transfer_size);
+		if (ret) {
+			FT_PRINTERR("ft_rx", -ret);
+			goto out;
+		}
+
+		ret = ft_sync();
+		if (ret)
+			goto out;
+
+		ret = ft_init_av();
+		if (ret) {
+			FT_PRINTERR("ft_init_av", -ret);
+			goto out;
+		}
+
+		ret = ft_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+		if (ret) {
+			FT_PRINTERR("ft_tx", -ret);
+			goto out;
+		}
+	}
+
+	fprintf(stdout, "PASS\n");
+	(void) ft_sync();
+out:
+	ft_free_res();
+	return ret;
+}
+
+/*
+ Test flow proposal for directed receive
+ client (dst_addr):
+	recvfrom
+ 	remove addr
+ 	insert addr
+ 	OOB sync
+	recvfrom
+ server (else):
+ 	tsend
+ 	OOB sync
+ 	tsend
+ */
+
+int main(int argc, char **argv)
+{
+	int op, ret;
+
+	opts = INIT_OPTS;
+	opts.options |= FT_OPT_SIZE | FT_OPT_OOB_SYNC;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	hints->ep_attr->type = FI_EP_RDM;
+
+	while ((op = getopt(argc, argv, "h" ADDR_OPTS INFO_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parseinfo(op, optarg, hints);
+			break;
+		case '?':
+		case 'h':
+			ft_usage(argv[0], "AV communication unit test.");
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	hints->caps = hints->ep_attr->type == FI_EP_RDM ?
+		      FI_TAGGED : FI_MSG;
+	hints->mode = FI_CONTEXT;
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+	base_hints = hints;
+
+	ret = av_removal_test();
+	if (ret && ret != -FI_ENODATA)
+		goto out;
+
+	ret = av_duplicate_test();
+	if (ret && ret != -FI_ENODATA)
+		goto out;
+
+out:
+	return ft_exit_code(ret);
+}


### PR DESCRIPTION
MPI recently hit into an issue dealing with AV removal breaking communication between peers.  To avoid a similar situation in the future, this adds a new test to fabtests to validate proper behavior by the providers.  The test currently executes two separate test situations in a loop, with each loop creating and destroying all fabric resources.  To support that 3 smaller additional patches are added to handle re-initialization of test variables and OOB synchronization.

The sockets provider passes both of these test cases, but I did not validate other providers.  The test has not yet been added to the runfabtests script.  Comments in the code describe how a third test case can be constructed, but I have not had time to complete that.