### PR TITLE
common: Move initialization of OOB socket

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -611,6 +611,7 @@ static int ft_init_oob(void)
 			close(oob_sock);
 			goto free;
 		}
+		sleep(1);
 	}
 
 	op = 1;

--- a/include/windows/unistd.h
+++ b/include/windows/unistd.h
@@ -1,2 +1,3 @@
-
 #pragma once
+
+#define sleep(x) Sleep(x * 1000)

--- a/simple/av_xfer.c
+++ b/simple/av_xfer.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
+#include <unistd.h>
 
 #include <shared.h>
 
@@ -230,6 +231,8 @@ int main(int argc, char **argv)
 	if (ret && ret != -FI_ENODATA)
 		goto out;
 
+	if (opts.dst_addr)
+		sleep(1);
 	ret = av_reinsert_test();
 	if (ret && ret != -FI_ENODATA)
 		goto out;


### PR DESCRIPTION
Connecting out of band sockets for address exchange ends up
impacting providers that use an internal name service for
address resolution (mostly done in order to support fabtests).
Because the OOB connection is occuring at the start of any
test that uses it, it halts program execution until the OOB
connection completes.  This causes an issue that the provider
name service cannot start and register local addresses until
both the server and client apps are running.  This ends up
creating a race condition where the client may attempt to
contact the name server prior to it running or having any
addresses registered to it.

The simplest fix is to defer the connection of the OOB socket
until right before it is needed for communication.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>