### PR TITLE
streaming/fi_rdm_atomic, test_configs/shm: various shm testing updates

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1702,6 +1702,39 @@ ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, struct fid_ep *ep, size_t siz
 	return 0;
 }
 
+ssize_t ft_post_atomic(enum ft_atomic_opcodes opcode, struct fid_ep *ep,
+		       void *compare, void *compare_desc, void *result,
+		       void *result_desc, struct fi_rma_iov *remote,
+		       enum fi_datatype datatype, enum fi_op atomic_op,
+		       void *context)
+{
+	size_t count = opts.transfer_size / datatype_to_size(datatype);
+	switch (opcode) {
+	case FT_ATOMIC_BASE:
+		FT_POST(fi_atomic, ft_get_tx_comp, tx_seq, "fi_atomic", ep,
+			buf, count, mr_desc, remote_fi_addr, remote->addr,
+			remote->key, datatype, atomic_op, context);
+		break;
+	case FT_ATOMIC_FETCH:
+		FT_POST(fi_fetch_atomic, ft_get_tx_comp, tx_seq,
+			"fi_fetch_atomic", ep, buf, count, mr_desc, result,
+			result_desc, remote_fi_addr, remote->addr, remote->key,
+			datatype, atomic_op, context);
+		break;
+	case FT_ATOMIC_COMPARE:
+		FT_POST(fi_compare_atomic, ft_get_tx_comp, tx_seq,
+			"fi_compare_atomic", ep, buf, count, mr_desc, compare,
+			compare_desc, result, result_desc, remote_fi_addr,
+			remote->addr, remote->key, datatype, atomic_op, context);
+		break;
+	default:
+		FT_ERR("Unknown atomic opcode\n");
+		return EXIT_FAILURE;
+	}
+
+	return 0;
+}
+
 static int check_atomic_attr(enum fi_op op, enum fi_datatype datatype,
 			     uint64_t flags)
 {

--- a/include/shared.h
+++ b/include/shared.h
@@ -125,6 +125,12 @@ enum ft_rma_opcodes {
 	FT_RMA_WRITEDATA,
 };
 
+enum ft_atomic_opcodes {
+	FT_ATOMIC_BASE,
+	FT_ATOMIC_FETCH,
+	FT_ATOMIC_COMPARE,
+};
+
 struct ft_opts {
 	int iterations;
 	int warmup_iterations;
@@ -410,6 +416,12 @@ ssize_t ft_rma(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
 ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
 		struct fi_rma_iov *remote);
 
+
+ssize_t ft_post_atomic(enum ft_atomic_opcodes opcode, struct fid_ep *ep,
+		       void *compare, void *compare_desc, void *result,
+		       void *result_desc, struct fi_rma_iov *remote,
+		       enum fi_datatype datatype, enum fi_op atomic_op,
+		       void *context);
 int check_base_atomic_op(struct fid_ep *endpoint, enum fi_op op,
 			 enum fi_datatype datatype, size_t *count);
 int check_fetch_atomic_op(struct fid_ep *endpoint, enum fi_op op,

--- a/streaming/rdm_atomic.c
+++ b/streaming/rdm_atomic.c
@@ -228,13 +228,12 @@ static inline int execute_base_atomic_op(enum fi_op op)
 {
 	int ret;
 
-	ret = fi_atomic(ep, buf, 1, mr_desc, remote_fi_addr, remote.addr,
-		       	remote.key, datatype, op, &fi_ctx_atomic);
-	if (ret) {
-		FT_PRINTERR("fi_atomic", ret);
-	} else {
-		ret = ft_get_tx_comp(++tx_seq);
-	}
+	ret = ft_post_atomic(FT_ATOMIC_BASE, ep, NULL, NULL, NULL, NULL,
+			     &remote, datatype, op, &fi_ctx_atomic);
+	if (ret)
+		return ret;
+
+	ret = ft_get_tx_comp(tx_seq);
 
 	return ret;
 }
@@ -243,14 +242,13 @@ static inline int execute_fetch_atomic_op(enum fi_op op)
 {
 	int ret;
 
-	ret = fi_fetch_atomic(ep, buf, 1, mr_desc, result,
-			fi_mr_desc(mr_result), remote_fi_addr, remote.addr,
-			remote.key, datatype, op, &fi_ctx_atomic);
-	if (ret) {
-		FT_PRINTERR("fi_fetch_atomic", ret);
-	} else {
-		ret = ft_get_tx_comp(++tx_seq);
-	}
+	ret = ft_post_atomic(FT_ATOMIC_FETCH, ep, NULL, NULL, result,
+			     fi_mr_desc(mr_result), &remote, datatype,
+			     op, &fi_ctx_atomic);
+	if (ret)
+		return ret;
+
+	ret = ft_get_tx_comp(tx_seq);
 
 	return ret;
 }
@@ -259,15 +257,13 @@ static inline int execute_compare_atomic_op(enum fi_op op)
 {
 	int ret;
 
-	ret = fi_compare_atomic(ep, buf, 1, mr_desc, compare,
-			fi_mr_desc(mr_compare), result, fi_mr_desc(mr_result),
-			remote_fi_addr, remote.addr, remote.key, datatype, op,
-			&fi_ctx_atomic);
-	if (ret) {
-		FT_PRINTERR("fi_compare_atomic", ret);
-	} else {
-		ret = ft_get_tx_comp(++tx_seq);
-	}
+	ret = ft_post_atomic(FT_ATOMIC_COMPARE, ep, compare, fi_mr_desc(mr_compare),
+			     result, fi_mr_desc(mr_result), &remote, datatype,
+			     op, &fi_ctx_atomic);
+	if (ret)
+		return ret;
+
+	ret = ft_get_tx_comp(tx_seq);
 
 	return ret;
 }

--- a/test_configs/shm/verify.test
+++ b/test_configs/shm/verify.test
@@ -1,8 +1,7 @@
 {
 	prov_name: shm,
 	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT,
 	],
 	class_function: [
 		FT_FUNC_SEND,
@@ -32,8 +31,7 @@
 {
 	prov_name: shm,
 	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT,
 	],
 	class_function: [
 		FT_FUNC_WRITE,
@@ -65,8 +63,7 @@
 {
 	prov_name: shm,
 	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT,
 	],
 	class_function: [
 		FT_FUNC_WRITE,
@@ -95,8 +92,7 @@
 {
 	prov_name: shm,
 	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT,
 	],
 	class_function: [
 		FT_FUNC_ATOMIC,
@@ -156,8 +152,7 @@
 {
 	prov_name: shm,
 	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT,
 	],
 	class_function: [
 		FT_FUNC_FETCH_ATOMIC,
@@ -203,8 +198,7 @@
 {
 	prov_name: shm,
 	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT,
 	],
 	class_function: [
 		FT_FUNC_COMPARE_ATOMIC,
@@ -256,8 +250,7 @@
 {
 	prov_name: shm,
 	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT,
 	],
 	class_function: [
 		FT_FUNC_ATOMIC,
@@ -314,8 +307,7 @@
 {
 	prov_name: shm,
 	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT,
 	],
 	class_function: [
 		FT_FUNC_FETCH_ATOMIC,
@@ -358,8 +350,7 @@
 {
 	prov_name: shm,
 	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT,
 	],
 	class_function: [
 		FT_FUNC_COMPARE_ATOMIC,


### PR DESCRIPTION
- move atomic calls in streaming/fi_rdm_atomic test to common code (modeled after rma_opcodes) to use FT_POST function, enabling manual progress support needed for shm provider
- add test_config combinations in shm/all.test to test with and without MR_VIRT_ADDR (to test both shm protocols)
- add shm/verify.test for unit testing and for use with -t verify option in runfabtests.sh

Signed-off-by: aingerson <alexia.ingerson@intel.com>