### PR TITLE
Makefile.am: add test_config/shm/verify.test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,7 +87,8 @@ nobase_dist_config_DATA = \
 	test_configs/psm2/verify.test \
 	test_configs/psm2/psm2.exclude \
 	test_configs/ofi_rxm/ofi_rxm.exclude \
-	test_configs/shm/all.test
+	test_configs/shm/all.test \
+	test_configs/shm/verify.test
 
 noinst_LTLIBRARIES = libfabtests.la
 libfabtests_la_SOURCES = \

--- a/test_configs/shm/verify.test
+++ b/test_configs/shm/verify.test
@@ -27,6 +27,7 @@
 	mr_mode: [
 		FI_MR_VIRT_ADDR,
 	],
+	test_flags: FT_FLAG_QUICKTEST
 },
 {
 	prov_name: shm,
@@ -59,6 +60,7 @@
 	mr_mode: [
 		FI_MR_VIRT_ADDR,
 	],
+	test_flags: FT_FLAG_QUICKTEST
 },
 {
 	prov_name: shm,
@@ -88,6 +90,7 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
+	test_flags: FT_FLAG_QUICKTEST
 },
 {
 	prov_name: shm,


### PR DESCRIPTION
- add verify.test script to Makefile
- also add quick test flag to verification tests because it takes way too long to verify 10k iterations of 3000 tests

Signed-off-by: aingerson <alexia.ingerson@intel.com>