### PR TITLE
rdm_multi_recv: fix stack smashing

### DIFF
--- a/streaming/rdm_multi_recv.c
+++ b/streaming/rdm_multi_recv.c
@@ -85,7 +85,7 @@ static int repost_recv(int iteration) {
 int wait_for_recv_completion(int num_completions)
 {
 	int i, ret;
-	struct fi_cq_data_entry comp;
+	struct fi_cq_tagged_entry comp;
 
 	while (num_completions > 0) {
 		ret = fi_cq_read(rxcq, &comp, 1);


### PR DESCRIPTION
When running fi_rdm_multi_recv built with strong stack protector:

$ fi_rdm_multi_recv -I 5 -p "verbs" -s 192.168.20.106 192.168.20.107
*** stack smashing detected ***: <unknown> terminated
Aborted (core dumped)

Thread 1 "fi_rdm_multi_re" received signal SIGABRT, Aborted.
0x00007ffff77480d0 in raise () from /lib64/libc.so.6
(gdb) bt
 #0  0x00007ffff77480d0 in raise () from /lib64/libc.so.6
 #1  0x00007ffff77496b1 in abort () from /lib64/libc.so.6
 #2  0x00007ffff778b417 in __libc_message () from /lib64/libc.so.6
 #3  0x00007ffff781bd4e in __fortify_fail_abort () from /lib64/libc.so.6
 #4  0x00007ffff781bd12 in __stack_chk_fail_local () from /lib64/libc.so.6
 #5  0x0000000000402028 in wait_for_recv_completion (num_completions=0, num_completions@entry=1) at streaming/rdm_multi_recv.c:83
 #6  0x0000000000401c26 in init_av () at streaming/rdm_multi_recv.c:268
 #7  run () at streaming/rdm_multi_recv.c:288

This is due to fi_cq_read calling fi_ibv_rdm_tagged_cq_readfrom which assume the pointer passed
 is a fi_cq_tagged_entry which is larger than a fi_cq_data_entry but as the same layout for the common field.
Which explains while it works but the stach checker is complaining.

Fix by using the proper fi_cq_tagged_entry datatype

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>