### PR TITLE
ubertest, common: fix error reporting, progress updates, add UDP;ofi_rxd, and update gitignore

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,4 +29,5 @@ install:
 
 test_script:
   - set PATH=%CD%\x64\%CONFIGURATION%;%PATH%
+  - set FI_PROVIDER=sockets
   - scripts\runfabtests.cmd

--- a/.gitignore
+++ b/.gitignore
@@ -30,15 +30,10 @@ configure
 libtool
 fabtests.spec
 
-ported/libibverbs/fi_*
-ported/librdmacm/fi_*
-
-complex/fabtest
-complex/fi_ubertest
+ubertest/fabtest
+ubertest/fi_ubertest
 
 benchmarks/fi_*
-
-simple/fi_*
+functional/fi_*
 unit/fi_*
-streaming/fi_*
 pingpong/fi_*

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,7 @@ nobase_dist_config_DATA = \
 	test_configs/psm2/verify.test \
 	test_configs/psm2/psm2.exclude \
 	test_configs/ofi_rxm/ofi_rxm.exclude \
+	test_configs/ofi_rxd/udp.test \
 	test_configs/shm/all.test \
 	test_configs/shm/verify.test
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -277,12 +277,16 @@ size_t datatype_to_size(enum fi_datatype datatype);
 #endif
 
 #define FT_EQ_ERR(eq, entry, buf, len) \
-	FT_ERR("eq_readerr: %s", fi_eq_strerror(eq, entry.prov_errno, \
-				entry.err_data, buf, len))
+	FT_ERR("eq_readerr (Provider errno: %d) : %s",		 \
+		entry.prov_errno, fi_eq_strerror(eq, entry.err,	 \
+						 entry.err_data, \
+						 buf, len))	 \
 
 #define FT_CQ_ERR(cq, entry, buf, len) \
-	FT_ERR("cq_readerr: %s", fi_cq_strerror(cq, entry.prov_errno, \
-				entry.err_data, buf, len))
+	FT_ERR("cq_readerr (Provider errno: %d) : %s",		 \
+		entry.prov_errno, fi_cq_strerror(cq, entry.err,	 \
+						 entry.err_data, \
+						 buf, len))	 \
 
 #define FT_CLOSE_FID(fd)						\
 	do {								\

--- a/test_configs/ofi_rxd/udp.test
+++ b/test_configs/ofi_rxd/udp.test
@@ -1,0 +1,26 @@
+{
+	prov_name: UDP;ofi_rxd,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+		FT_FUNC_SENDDATA,
+	],
+	ep_type: [
+		FI_EP_RDM
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+},

--- a/ubertest/config.c
+++ b/ubertest/config.c
@@ -298,6 +298,12 @@ static struct key_t keys[] = {
 		.offset = offsetof(struct ft_set, mr_mode),
 		.val_type = VAL_NUM,
 		.val_size = sizeof(((struct ft_set *)0)->mr_mode) / FT_MAX_MR_MODES,
+	},
+	{
+		.str = "progress",
+		.offset = offsetof(struct ft_set, progress),
+		.val_type = VAL_NUM,
+		.val_size = sizeof(((struct ft_set *)0)->progress) / FT_MAX_PROGRESS,
 	}
 };
 
@@ -409,6 +415,11 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MR_ALLOCATED, uint64_t, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MR_PROV_KEY, uint64_t, buf);
 		FT_ERR("Unknown MR mode");
+	} else if (!strncmp(key->str, "progress", strlen("progress"))) {
+		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_MANUAL, uint64_t, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_AUTO, uint64_t, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_UNSPEC, uint64_t, buf);
+		FT_ERR("Unknown progress mode");
 	} else if (!strncmp(key->str, "constant_caps", strlen("constant_caps"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_RMA, uint64_t, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MSG, uint64_t, buf);
@@ -695,6 +706,7 @@ void fts_start(struct ft_series *series, int index)
 	series->cur_cntr_wait_obj = 0;
 	series->cur_mode = 0;
 	series->cur_class = 0;
+	series->cur_progress = 0;
 
 	series->test_index = 1;
 	if (index > 1) {
@@ -782,6 +794,10 @@ void fts_next(struct ft_series *series)
 		return;
 	series->cur_type = 0;
 
+	if (set->test_class[++series->cur_progress])
+		return;
+	series->cur_progress = 0;
+
 	series->cur_set++;
 }
 
@@ -809,6 +825,7 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->datatype = set->datatype[series->cur_datatype];
 	info->test_flags = set->test_flags;
 	info->test_class = set->test_class[series->cur_class];
+	info->progress = set->progress[series->cur_progress];
 
 	if (info->test_class) {
 		info->caps = set->test_class[series->cur_class];

--- a/ubertest/cq.c
+++ b/ubertest/cq.c
@@ -241,6 +241,7 @@ static int ft_comp_x(struct fid_cq *cq, struct ft_xcontrol *ft_x,
 	struct timespec s, e;
 	int poll_time = 0;
 	int ret, verify = (test_info.test_type == FT_TEST_UNIT && cq == rxcq);
+	size_t cur_credits = ft_x->credits;
 
 	switch(test_info.cq_wait_obj) {
 	case FI_WAIT_NONE:
@@ -255,7 +256,11 @@ static int ft_comp_x(struct fid_cq *cq, struct ft_xcontrol *ft_x,
 
 			clock_gettime(CLOCK_MONOTONIC, &e);
 			poll_time = get_elapsed(&s, &e, MILLI);
-		} while (ret == -FI_EAGAIN && poll_time < timeout);
+		} while (ret == -FI_EAGAIN && poll_time < timeout &&
+			 ft_x->credits == cur_credits);
+
+		if (ft_x->credits != cur_credits)
+			ret = 0;
 
 		break;
 	case FI_WAIT_UNSPEC:

--- a/ubertest/fabtest.h
+++ b/ubertest/fabtest.h
@@ -146,6 +146,7 @@ enum {
 	FT_DEFAULT_CREDITS	= 128,
 	FT_COMP_BUF_SIZE	= 256,
 	FT_MAX_FLAGS		= 64,
+	FT_MAX_PROGRESS		= 3,
 };
 
 enum ft_comp_type {
@@ -241,6 +242,7 @@ struct ft_set {
 	enum fi_wait_obj	eq_wait_obj[FT_MAX_WAIT_OBJ];
 	enum fi_wait_obj	cq_wait_obj[FT_MAX_WAIT_OBJ];
 	enum fi_wait_obj	cntr_wait_obj[FT_MAX_WAIT_OBJ];
+	enum fi_progress	progress[FT_MAX_PROGRESS];
 	uint64_t		mode[FT_MAX_PROV_MODES];
 	uint64_t		test_class[FT_MAX_CLASS];
 	uint64_t		constant_caps[FT_MAX_CAPS];
@@ -270,6 +272,7 @@ struct ft_series {
 	int			cur_cntr_wait_obj;
 	int			cur_mode;
 	int			cur_class;
+	int			cur_progress;
 };
 
 struct ft_info {
@@ -291,6 +294,7 @@ struct ft_info {
 	enum fi_wait_obj	eq_wait_obj;
 	enum fi_wait_obj	cq_wait_obj;
 	enum fi_wait_obj	cntr_wait_obj;
+	enum fi_progress	progress;
 	uint32_t		protocol;
 	uint32_t		protocol_version;
 	char			node[FI_NAME_MAX];

--- a/ubertest/uber.c
+++ b/ubertest/uber.c
@@ -203,6 +203,7 @@ static void ft_show_test_info(void)
 	printf(" cq_%s,", ft_wait_obj_str(test_info.cq_wait_obj));
 	printf(" cntr_%s,", ft_wait_obj_str(test_info.cq_wait_obj));
 	printf(" %s,", ft_comp_type_str(test_info.comp_type));
+	printf(" %s,", fi_tostr(&test_info.progress, FI_TYPE_PROGRESS));
 	printf(" [%s],", fi_tostr(&test_info.mr_mode, FI_TYPE_MR_MODE));
 	printf(" [%s],", fi_tostr(&test_info.mode, FI_TYPE_MODE));
 	printf(" [%s]]\n", fi_tostr(&test_info.caps, FI_TYPE_CAPS));
@@ -236,6 +237,7 @@ static void ft_fw_convert_info(struct fi_info *info, struct ft_info *test_info)
 
 	info->domain_attr->mr_mode = test_info->mr_mode;
 	info->domain_attr->av_type = test_info->av_type;
+	info->domain_attr->data_progress = test_info->progress;
 
 	info->ep_attr->type = test_info->ep_type;
 	info->ep_attr->protocol = test_info->protocol;
@@ -274,6 +276,9 @@ ft_fw_update_info(struct ft_info *test_info, struct fi_info *info, int subindex)
 				sizeof test_info->fabric_name - 1);
 		}
 	}
+
+	if (info->domain_attr)
+		test_info->progress = info->domain_attr->data_progress;
 }
 
 static int ft_fw_result_index(int fi_errno)


### PR DESCRIPTION
common:
- on CQ or EQ error, report cq_entry.err, not cq_entry.prov_errno

ubertest:
- fix progress bug
- add manual progress config option
- add manual progress sync support to continue to progress
- add UDP;ofi_rxd test_config

.gitignore
- remove old tests and update test names