### PR TITLE
ubertest: completion updates

### DIFF
--- a/test_configs/sockets/complete.test
+++ b/test_configs/sockets/complete.test
@@ -350,3 +350,146 @@
 	],
 	test_flags: FT_FLAG_QUICKTEST
 },
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	rx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	rx_op_flags: [
+		FI_COMPLETION,
+	],
+	msg_flags: [
+		FI_COMPLETION,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	rx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	msg_flags: [
+		FI_COMPLETION,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDDATA,
+		FT_FUNC_INJECT,
+		FT_FUNC_INJECTDATA,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	rx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	rx_op_flags: [
+		FI_COMPLETION,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sockets,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	av_type: [
+		FI_AV_TABLE,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	tx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	msg_flags: [
+		FI_COMPLETION,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},

--- a/ubertest/fabtest.h
+++ b/ubertest/fabtest.h
@@ -42,6 +42,7 @@
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 #include <shared.h>
+#include <assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -344,8 +345,10 @@ void ft_format_iov(struct iovec *iov, size_t cnt, char *buf, size_t len);
 void ft_format_iocs(struct iovec *iov, size_t *iov_count);
 void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt);
 int ft_get_ctx(struct ft_xcontrol *ctrl, struct fi_context **ctx);
-int ft_check_cq_completion(uint64_t cq_bind_flags, uint64_t op_flags,
-		enum ft_class_function class_function, uint64_t msg_flags);
+int ft_generates_rx_comp();
+int ft_generates_tx_comp();
+int ft_check_rx_completion();
+int ft_check_tx_completion();
 
 int ft_send_sync_msg();
 int ft_recv_n_msg();

--- a/ubertest/uber.c
+++ b/ubertest/uber.c
@@ -58,6 +58,7 @@ size_t recv_size, send_size;
 
 enum {
 	FT_SUCCESS,
+	FT_SKIP,
 	FT_ENODATA,
 	FT_ENOSYS,
 	FT_ERROR,
@@ -664,6 +665,7 @@ static int ft_fw_client(void)
 		if (!fts_info_is_valid()) {
 			printf("Skipping test %d (invalid):\n", test_info.test_index);
 			ft_show_test_info();
+			results[FT_SKIP]++;
 			continue;
 		}
 
@@ -700,6 +702,7 @@ static int ft_fw_client(void)
 static void ft_fw_show_results(void)
 {
 	printf("Success: %d\n", results[FT_SUCCESS]);
+	printf("Skipped: %d\n", results[FT_SKIP]);
 	printf("ENODATA: %d\n", results[FT_ENODATA]);
 	printf("ENOSYS : %d\n", results[FT_ENOSYS]);
 	printf("EIO    : %d\n", results[FT_EIO]);

--- a/ubertest/uber.c
+++ b/ubertest/uber.c
@@ -172,18 +172,24 @@ static char *ft_wait_obj_str(enum fi_wait_obj enum_str)
 	}
 }
 
-static char *ft_comp_type_str(enum ft_comp_type comp_type)
+static void ft_print_comp_flag(uint64_t bind, uint64_t op)
 {
-	switch (comp_type) {
-	case FT_COMP_QUEUE:
-		return "comp_queue";
-	case FT_COMP_CNTR:
-		return "comp_cntr";
-	case FT_COMP_ALL:
-		return "comp_all";
-	default:
-		return "comp_unspec";
-	} 
+	printf("(bind-%s, op-%s)", (bind & FI_SELECTIVE_COMPLETION) ?
+		"FI_SELECTIVE_COMPLETION" : "NONE",
+		op ? fi_tostr(&op, FI_TYPE_OP_FLAGS) : "NONE");
+}
+
+static void ft_print_comp(struct ft_info *test)
+{
+	if (ft_use_comp_cq(test->comp_type)) {
+		printf("comp_queue -- tx ");
+		ft_print_comp_flag(test->tx_cq_bind_flags, test->tx_op_flags);
+		printf(", rx: ");
+		ft_print_comp_flag(test->rx_cq_bind_flags, test->rx_op_flags);
+		printf(", ");
+	}
+	if (ft_use_comp_cntr(test->comp_type))
+		printf("comp_cntr, ");
 } 
 
 static void ft_show_test_info(void)
@@ -202,8 +208,8 @@ static void ft_show_test_info(void)
 	printf(" %s,", fi_tostr(&test_info.av_type, FI_TYPE_AV_TYPE));
 	printf(" eq_%s,", ft_wait_obj_str(test_info.eq_wait_obj));
 	printf(" cq_%s,", ft_wait_obj_str(test_info.cq_wait_obj));
-	printf(" cntr_%s,", ft_wait_obj_str(test_info.cq_wait_obj));
-	printf(" %s,", ft_comp_type_str(test_info.comp_type));
+	printf(" cntr_%s, ", ft_wait_obj_str(test_info.cq_wait_obj));
+	ft_print_comp(&test_info);
 	printf(" %s,", fi_tostr(&test_info.progress, FI_TYPE_PROGRESS));
 	printf(" [%s],", fi_tostr(&test_info.mr_mode, FI_TYPE_MR_MODE));
 	printf(" [%s],", fi_tostr(&test_info.mode, FI_TYPE_MODE));


### PR DESCRIPTION
Various ubertest updates to fix and test all completion scenarios:
- print/track skipped tests
- add bind/op flags to test info printing
- properly check for expected tx and rx completions
- make sure all completion scenarios are properly accounted for, especially with the use of cntrs/cqs
- manage all SELECTIVE_COMPLETION scenarios properly and use sync messages when necessary
- add credit asserts to ensure we don't find too many completions or improperly count completions
- add SELECTIVE_COMPLETION configs to sockets/complete.test (which tracks all combinations)

See individual commits for more information.

sockets/complete.test, sockets/verify.test, sockets/quick.test all passing
sockets/all.test hanging but is hanging without these patches as well - still investigating