### PR TITLE
shared: Support IPv6 for OOB connections

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -576,7 +576,7 @@ static int ft_init_oob(void)
 		opts.oob_port = default_oob_port;
 
 	if (!opts.dst_addr) {
-		ret = ft_sock_listen(opts.oob_port);
+		ret = ft_sock_listen(opts.src_addr, opts.oob_port);
 		if (ret)
 			return ret;
 
@@ -2803,16 +2803,15 @@ int ft_send_recv_greeting(struct fid_ep *ep)
 	return opts.dst_addr ? ft_send_greeting(ep) : ft_recv_greeting(ep);
 }
 
-int ft_sock_listen(char *service)
+int ft_sock_listen(char *node, char *service)
 {
 	struct addrinfo *ai, hints;
 	int val, ret;
 
 	memset(&hints, 0, sizeof hints);
 	hints.ai_flags = AI_PASSIVE;
-	hints.ai_family = AF_INET;
 
-	ret = getaddrinfo(NULL, service, &hints, &ai);
+	ret = getaddrinfo(node, service, &hints, &ai);
 	if (ret) {
 		fprintf(stderr, "getaddrinfo() %s\n", gai_strerror(ret));
 		return ret;

--- a/common/shared.c
+++ b/common/shared.c
@@ -614,7 +614,7 @@ static int ft_init_oob(void)
 
 	op = 1;
 	err = setsockopt(oob_sock, IPPROTO_TCP, TCP_NODELAY,
-			 &op, sizeof(op));
+			 (void *) &op, sizeof(op));
 	if (err)
 		perror("setsockopt"); /* non-fatal error */
 
@@ -2825,7 +2825,8 @@ int ft_sock_listen(char *node, char *service)
 	}
 
 	val = 1;
-	ret = setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof val);
+	ret = setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR,
+			 (void *) &val, sizeof val);
 	if (ret) {
 		perror("setsockopt SO_REUSEADDR");
 		goto out;

--- a/functional/cm_data.c
+++ b/functional/cm_data.c
@@ -394,7 +394,7 @@ static int run(void)
 		if (ret)
 			goto err2;
 	} else {
-		ret = ft_sock_listen(sock_service);
+		ret = ft_sock_listen(opts.src_addr, sock_service);
 		if (ret)
 			goto err2;
 		ret = ft_sock_accept();

--- a/functional/msg_sockets.c
+++ b/functional/msg_sockets.c
@@ -317,7 +317,6 @@ static int setup_handle(void)
 
 	memset(&aihints, 0, sizeof aihints);
 	aihints.ai_flags = AI_PASSIVE;
-	aihints.ai_family = AF_INET;
 	ret = getaddrinfo(opts.src_addr, opts.src_port, &aihints, &ai);
 	if (ret == EAI_SYSTEM) {
 		FT_ERR("getaddrinfo for %s:%s: %s",

--- a/functional/shared_ctx.c
+++ b/functional/shared_ctx.c
@@ -90,7 +90,13 @@ static int get_dupinfo(void)
 	hints_dup->src_addrlen = 0;
 	hints_dup->dest_addrlen = 0;
 
-	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints_dup, &fi_dup);
+	if (opts.dst_addr) {
+		ret = fi_getinfo(FT_FIVERSION, opts.dst_addr, NULL, 0,
+				 hints_dup, &fi_dup);
+	} else {
+		ret = fi_getinfo(FT_FIVERSION, opts.src_addr, NULL, FI_SOURCE,
+				 hints_dup, &fi_dup);
+	}
 	if (ret)
 		FT_PRINTERR("fi_getinfo", ret);
 	fi_freeinfo(hints_dup);

--- a/functional/shared_ctx.c
+++ b/functional/shared_ctx.c
@@ -63,7 +63,6 @@ static int rx_shared_ctx = 1;
 static int ep_cnt = 4;
 static struct fid_ep **ep_array, *srx_ctx;
 static struct fid_stx *stx_ctx;
-static char *local_addr, *remote_addr;
 static size_t addrlen = 0;
 static fi_addr_t *addr_array;
 
@@ -255,106 +254,71 @@ static int init_av(void)
 	int ret;
 	int i;
 
-	/* Get local address blob. Find the addrlen first. We set addrlen
-	 * as 0 and fi_getname will return the actual addrlen. */
-	addrlen = 0;
-	ret = fi_getname(&ep_array[0]->fid, local_addr, &addrlen);
-	if (ret != -FI_ETOOSMALL) {
-		FT_PRINTERR("fi_getname", ret);
-		return ret;
+	if (opts.dst_addr) {
+		ret = ft_av_insert(av, fi->dest_addr, 1, &addr_array[0], 0, NULL);
+		if (ret)
+			return ret;
 	}
 
-	local_addr = malloc(addrlen * ep_cnt);
-	remote_addr = malloc(addrlen * ep_cnt);
-
-	/* Get local addresses for all EPs */
 	for (i = 0; i < ep_cnt; i++) {
-		ret = fi_getname(&ep_array[i]->fid, local_addr + addrlen * i, &addrlen);
+		addrlen = tx_size;
+		ret = fi_getname(&ep_array[i]->fid, tx_buf + ft_tx_prefix_size(),
+				 &addrlen);
 		if (ret) {
 			FT_PRINTERR("fi_getname", ret);
 			return ret;
 		}
+
+		if (opts.dst_addr) {
+			ret = ft_tx(ep_array[0], addr_array[0], addrlen, &tx_ctx);
+			if (ret)
+				return ret;
+
+			if (rx_shared_ctx)
+				ret = ft_rx(srx_ctx, rx_size);
+			else
+				ret = ft_rx(ep_array[0], rx_size);
+			if (ret)
+				return ret;
+
+			/* Skip the first address since we already have it in AV */
+			if (i) {
+				ret = ft_av_insert(av, rx_buf + ft_rx_prefix_size(), 1,
+						   &addr_array[i], 0, NULL);
+				if (ret)
+					return ret;
+			}
+		} else {
+			if (rx_shared_ctx)
+				ret = ft_rx(srx_ctx, rx_size);
+			else
+				ret = ft_rx(ep_array[0], rx_size);
+			if (ret)
+				return ret;
+
+			ret = ft_av_insert(av, rx_buf + ft_rx_prefix_size(), 1,
+					   &addr_array[i], 0, NULL);
+			if (ret)
+				return ret;
+
+			ret = ft_tx(ep_array[0], addr_array[0], addrlen, &tx_ctx);
+			if (ret)
+				return ret;
+
+		}
 	}
 
+	/* ACK */
 	if (opts.dst_addr) {
-		memcpy(remote_addr, fi->dest_addr, addrlen);
-
-		ret = ft_av_insert(av, remote_addr, 1, &addr_array[0], 0, NULL);
-		if (ret)
-			return ret;
-
-		/* Send local EP addresses to one of the remote endpoints */
-		memcpy(tx_buf + ft_tx_prefix_size(), &addrlen, sizeof(size_t));
-		memcpy(tx_buf + ft_tx_prefix_size() + sizeof(size_t),
-				local_addr, addrlen * ep_cnt);
-		ret = ft_tx(ep_array[0], addr_array[0],
-				sizeof(size_t) + addrlen * ep_cnt, &tx_ctx);
-		if (ret)
-			return ret;
-
-		/* Get remote EP addresses */
-		if (rx_shared_ctx)
-			ret = ft_rx(srx_ctx, rx_size);
-		else
-			ret = ft_rx(ep_array[0], rx_size);
-		if (ret)
-			return ret;
-
-		memcpy(&addrlen, rx_buf + ft_rx_prefix_size(), sizeof(size_t));
-		memcpy(remote_addr, rx_buf + ft_rx_prefix_size() + sizeof(size_t),
-				addrlen * ep_cnt);
-
-		/* Insert remote addresses into AV
-		 * Skip the first address since we already have it in AV */
-		ret = ft_av_insert(av, remote_addr + addrlen, ep_cnt - 1,
-				addr_array + 1, 0, NULL);
-		if (ret)
-			return ret;
-
-		/* Send ACK */
 		ret = ft_tx(ep_array[0], addr_array[0], 1, &tx_ctx);
-		if (ret)
-			return ret;
-
 	} else {
-		/* Get remote EP addresses */
 		if (rx_shared_ctx)
 			ret = ft_rx(srx_ctx, rx_size);
 		else
 			ret = ft_rx(ep_array[0], rx_size);
-		if (ret)
-			return ret;
-
-		memcpy(&addrlen, rx_buf + ft_rx_prefix_size(), sizeof(size_t));
-		memcpy(remote_addr, rx_buf + ft_rx_prefix_size() + sizeof(size_t),
-				addrlen * ep_cnt);
-
-		/* Insert remote addresses into AV */
-		ret = ft_av_insert(av, remote_addr, ep_cnt, addr_array, 0, NULL);
-		if (ret)
-			return ret;
-
-		/* Send local EP addresses to one of the remote endpoints */
-		memcpy(tx_buf + ft_tx_prefix_size(), &addrlen, sizeof(size_t));
-		memcpy(tx_buf + ft_tx_prefix_size() + sizeof(size_t),
-				local_addr, addrlen * ep_cnt);
-		ret = ft_tx(ep_array[0], addr_array[0],
-				sizeof(size_t) + addrlen * ep_cnt, &tx_ctx);
-		if (ret)
-			return ret;
-
-		/* Receive ACK from client */
-		if (rx_shared_ctx)
-			ret = ft_rx(srx_ctx, rx_size);
-		else
-			ret = ft_rx(ep_array[0], rx_size);
-		if (ret)
-			return ret;
 	}
 
-	free(local_addr);
-	free(remote_addr);
-	return 0;
+	return ret;
 }
 
 static int init_fabric(void)

--- a/functional/unexpected_msg.c
+++ b/functional/unexpected_msg.c
@@ -233,7 +233,7 @@ static int run_test(void)
 		if (ret)
 			return ret;
 	} else {
-		ret = ft_sock_listen(sock_sync_port);
+		ret = ft_sock_listen(opts.src_addr, sock_sync_port);
 		if (ret)
 			return ret;
 		ret = ft_sock_accept();

--- a/include/shared.h
+++ b/include/shared.h
@@ -207,7 +207,7 @@ void ft_fill_buf(void *buf, int size);
 int ft_check_buf(void *buf, int size);
 int ft_check_opts(uint64_t flags);
 uint64_t ft_init_cq_data(struct fi_info *info);
-int ft_sock_listen(char *service);
+int ft_sock_listen(char *node, char *service);
 int ft_sock_connect(char *node, char *service);
 int ft_sock_accept();
 int ft_sock_send(int fd, void *msg, size_t len);

--- a/scripts/runfabtests.cmd
+++ b/scripts/runfabtests.cmd
@@ -4,8 +4,8 @@ setlocal EnableDelayedExpansion
 set PATH=%~dp0;%PATH%
 
 
-set S_INTERFACE=localhost
-set C_INTERFACE=localhost
+set S_INTERFACE=127.0.0.1
+set C_INTERFACE=127.0.0.1
 
 set TEST_FAIL_TIMEOUT=90
 

--- a/ubertest/uber.c
+++ b/ubertest/uber.c
@@ -825,7 +825,7 @@ int main(int argc, char **argv)
 			FT_PRINTERR("ft_fw_client", ret);
 		ft_sock_shutdown(sock);
 	} else {
-		ret = ft_sock_listen(service);
+		ret = ft_sock_listen(opts.src_addr, service);
 		if (ret)
 			goto out;
 


### PR DESCRIPTION
If a source address is specified, pass it into the OOB connection
setup.  This allows selecting an IPv6 address for the source address.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

This is a peer PR to https://github.com/ofiwg/libfabric/pull/4227