### PR TITLE
benchmarks: Use FI_THREAD_DOMAIN

### DIFF
--- a/benchmarks/dgram_pingpong.c
+++ b/benchmarks/dgram_pingpong.c
@@ -121,6 +121,7 @@ int main(int argc, char **argv)
 	hints->caps = FI_MSG;
 	hints->mode |= FI_CONTEXT;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
 	ret = run();
 

--- a/benchmarks/msg_bw.c
+++ b/benchmarks/msg_bw.c
@@ -110,6 +110,7 @@ int main(int argc, char **argv)
 	hints->caps = FI_MSG;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
 	ret = run();
 

--- a/benchmarks/msg_pingpong.c
+++ b/benchmarks/msg_pingpong.c
@@ -106,6 +106,7 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_MSG;
 	hints->caps = FI_MSG;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
 	ret = run();
 

--- a/benchmarks/rdm_cntr_pingpong.c
+++ b/benchmarks/rdm_cntr_pingpong.c
@@ -99,6 +99,7 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
 	ret = run();
 

--- a/benchmarks/rdm_pingpong.c
+++ b/benchmarks/rdm_pingpong.c
@@ -97,6 +97,7 @@ int main(int argc, char **argv)
 	hints->caps = FI_MSG;
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
 	ret = run();
 

--- a/benchmarks/rdm_tagged_bw.c
+++ b/benchmarks/rdm_tagged_bw.c
@@ -104,6 +104,7 @@ int main(int argc, char **argv)
 	hints->caps = FI_TAGGED;
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
 	ret = run();
 

--- a/benchmarks/rdm_tagged_pingpong.c
+++ b/benchmarks/rdm_tagged_pingpong.c
@@ -98,6 +98,7 @@ int main(int argc, char **argv)
 	hints->caps = FI_TAGGED;
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
 	ret = run();
 

--- a/benchmarks/rma_bw.c
+++ b/benchmarks/rma_bw.c
@@ -101,6 +101,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
 	while ((op = getopt(argc, argv, "ho:" CS_OPTS INFO_OPTS BENCHMARK_OPTS)) != -1) {
 		switch (op) {


### PR DESCRIPTION
The benchmarks are single threaded and can make use of provider
optimizations if we specify the right threading model.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>