### PR TITLE
eq_test: Set mode bits explicitly

### DIFF
--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -569,9 +569,13 @@ int main(int argc, char **argv)
 		}
 	}
 
-	hints->mode = ~0;
-	hints->domain_attr->mode = ~0;
-	hints->domain_attr->mr_mode = ~(FI_MR_BASIC | FI_MR_SCALABLE);
+	hints->mode = FI_CONTEXT | FI_CONTEXT2 | FI_MSG_PREFIX | FI_ASYNC_IOV |
+		FI_RX_CQ_DATA | FI_NOTIFY_FLAGS_ONLY | FI_RESTRICTED_COMP |
+		FI_BUFFERED_RECV;
+	hints->domain_attr->mode = FI_RESTRICTED_COMP;
+	hints->domain_attr->mr_mode = FI_MR_LOCAL| FI_MR_RAW | FI_MR_VIRT_ADDR |
+		FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_MMU_NOTIFY |
+		FI_MR_RMA_EVENT | FI_MR_ENDPOINT;
 
 	ret = fi_getinfo(FT_FIVERSION, NULL, 0, 0, hints, &fi);
 	if (ret) {


### PR DESCRIPTION
We can't arbitrarily set all mode bits to one, since we don't
know what future mode bits may require.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>