### PR TITLE
common: don't skip CQ read on EAGAIN for auto progress

### DIFF
--- a/common/shared.c
+++ b/common/shared.c
@@ -1518,8 +1518,6 @@ static int ft_inject_progress(uint64_t total)
 				return ret;					\
 			}							\
 										\
-			if (fi->domain_attr->data_progress == FI_PROGRESS_AUTO)	\
-				continue;					\
 			timeout_save = timeout;					\
 			timeout = 0;						\
 			rc = comp_fn(seq);					\


### PR DESCRIPTION
The libfabric man page (fi_msg.3) recommends that application check for
completions on EAGAIN from transmit and receive operations. So don't skip it
just because a provider supports auto progress.