### PR TITLE
Enable rdm_tagged_bw test only when comp_order enabled

### DIFF
--- a/benchmarks/rdm_tagged_bw.c
+++ b/benchmarks/rdm_tagged_bw.c
@@ -105,6 +105,7 @@ int main(int argc, char **argv)
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	hints->tx_attr->comp_order = FI_ORDER_STRICT;
 
 	ret = run();
 


### PR DESCRIPTION
rdm_tagged_bw implemented with assumption of strict
completion ordering, but hints doesn't reflect the
same.

Change-Id: I2c7a2595445e44fabe4f42acc2d814fae9d6c31d
Signed-off-by: Mohan Gandhi <mohgan@amazon.com>