### PR TITLE
Change macro FT_CLOSE_FID to function

### DIFF
--- a/benchmarks/dgram_pingpong.c
+++ b/benchmarks/dgram_pingpong.c
@@ -82,7 +82,7 @@ static int run(void)
 int main(int argc, char **argv)
 {
 	int ret, op;
-
+	int free_ret;
 	opts = INIT_OPTS;
 
 	timeout = 5;
@@ -124,7 +124,6 @@ int main(int argc, char **argv)
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
 	ret = run();
-
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/benchmarks/msg_bw.c
+++ b/benchmarks/msg_bw.c
@@ -79,7 +79,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_BW;
@@ -114,6 +114,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/benchmarks/msg_pingpong.c
+++ b/benchmarks/msg_pingpong.c
@@ -76,7 +76,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 
@@ -110,6 +110,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/benchmarks/rdm_cntr_pingpong.c
+++ b/benchmarks/rdm_cntr_pingpong.c
@@ -68,7 +68,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options = FT_OPT_RX_CNTR | FT_OPT_TX_CNTR;
@@ -103,6 +103,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/benchmarks/rdm_pingpong.c
+++ b/benchmarks/rdm_pingpong.c
@@ -66,7 +66,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 
@@ -101,6 +101,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/benchmarks/rdm_tagged_bw.c
+++ b/benchmarks/rdm_tagged_bw.c
@@ -72,7 +72,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_BW;
@@ -108,6 +108,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/benchmarks/rdm_tagged_pingpong.c
+++ b/benchmarks/rdm_tagged_pingpong.c
@@ -68,7 +68,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 
@@ -102,6 +102,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/benchmarks/rma_bw.c
+++ b/benchmarks/rma_bw.c
@@ -88,7 +88,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_BW;
@@ -131,6 +131,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return -ret;
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/av_xfer.c
+++ b/functional/av_xfer.c
@@ -238,5 +238,5 @@ int main(int argc, char **argv)
 		goto out;
 
 out:
-	return ft_exit_code(ret);
+	return ft_exit_code(ret, 0);
 }

--- a/functional/cm_data.c
+++ b/functional/cm_data.c
@@ -216,13 +216,28 @@ static int server_accept(size_t paramlen)
 	if (ret)
 		goto err;
 
-	FT_CLOSE_FID(ep);
-	FT_CLOSE_FID(rxcq);
-	FT_CLOSE_FID(txcq);
-	FT_CLOSE_FID(rxcntr);
-	FT_CLOSE_FID(txcntr);
-	FT_CLOSE_FID(av);
-	FT_CLOSE_FID(domain);
+
+	ret = ft_close_fid(ep);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(rxcq);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(txcq);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(rxcntr);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(txcntr);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(av);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(domain);
+	if (ret)
+		return ret;
 
 	return 0;
 
@@ -255,7 +270,9 @@ static int client_open_new_ep()
 	size_t opt_size;
 	int ret;
 
-	FT_CLOSE_FID(ep);
+	ret = ft_close_fid(ep);
+	if (ret)
+		return ret;
 
 	ret = fi_endpoint(domain, fi, &ep, NULL);
 	if (ret) {
@@ -443,7 +460,7 @@ err2:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -480,6 +497,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/cq_data.c
+++ b/functional/cq_data.c
@@ -103,7 +103,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -139,6 +139,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/dgram.c
+++ b/functional/dgram.c
@@ -47,7 +47,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -79,6 +79,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/dgram_waitset.c
+++ b/functional/dgram_waitset.c
@@ -153,7 +153,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret = 0;
+	int op, ret = 0, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -186,6 +186,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/inj_complete.c
+++ b/functional/inj_complete.c
@@ -152,6 +152,7 @@ int main(int argc, char **argv)
 {
 	int op;
 	int ret = 0;
+	int free_ret;
 
 	opts = INIT_OPTS;
 	use_sendmsg = 0;
@@ -205,6 +206,6 @@ int main(int argc, char **argv)
 
 	ret = run_test();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/mcast.c
+++ b/functional/mcast.c
@@ -71,7 +71,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -107,8 +107,8 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 usage:
 	ft_mcusage(argv[0], "A simple multicast example.");
 	return EXIT_FAILURE;

--- a/functional/msg.c
+++ b/functional/msg.c
@@ -59,7 +59,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -90,6 +90,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/msg_epoll.c
+++ b/functional/msg_epoll.c
@@ -189,7 +189,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -223,9 +223,9 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
+	free_ret = ft_free_res();
 	close(epfd);
-	return ft_exit_code(ret);
+	return ft_exit_code(ret, free_ret);
 }
 
 #else
@@ -234,6 +234,6 @@ int main(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-	return ft_exit_code(FI_ENODATA);
+	return ft_exit_code(FI_ENODATA, 0);
 }
 #endif

--- a/functional/msg_sockets.c
+++ b/functional/msg_sockets.c
@@ -263,7 +263,9 @@ static int client_connect(void)
 
 	/* Close the passive endpoint that we "stole" the source address
 	 * from */
-	FT_CLOSE_FID(pep);
+	ret = ft_close_fid(pep);
+	if (ret)
+		return ret;
 
 	ret = ft_enable_ep_recv();
 	if (ret)
@@ -456,7 +458,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -488,6 +490,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/multi_ep.c
+++ b/functional/multi_ep.c
@@ -83,13 +83,15 @@ static int alloc_multi_ep_res()
 	return 0;
 }
 
-static void free_ep_res()
+static int free_ep_res()
 {
-	int i;
+	int i, ret = 0;
 
-	for (i = 0; i < num_eps; i++)
-		FT_CLOSE_FID(eps[i]);
-
+	for (i = 0; i < num_eps; i++) {
+		ret = ft_close_fid(eps[i]);
+		if (ret)
+			return ret;
+	}
 	free(data_bufs);
 	free(send_bufs);
 	free(recv_bufs);
@@ -97,6 +99,7 @@ static void free_ep_res()
 	free(recv_ctx);
 	free(remote_addr);
 	free(eps);
+	return 0;
 }
 
 static int do_transfers(void)
@@ -274,6 +277,7 @@ int main(int argc, char **argv)
 {
 	int op;
 	int ret = 0;
+	int free_ret;
 
 	opts = INIT_OPTS;
 	opts.transfer_size = 256;
@@ -313,7 +317,8 @@ int main(int argc, char **argv)
 
 	ret = run_test();
 
-	free_ep_res();
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = free_ep_res();
+	if (!free_ret)
+		free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/multi_mr.c
+++ b/functional/multi_mr.c
@@ -72,14 +72,18 @@ static int wait_cntr(struct fid_cntr *cntr, uint64_t *cntr_next)
 
 static int free_mr_res()
 {
-	int i;
+	int i, ret;
 
 	if (!mr_res_array)
 		return 0;
 
 	for (i = 0; i < mr_count; i++) {
-		FT_CLOSE_FID(mr_res_array[i].mr);
-		FT_CLOSE_FID(mr_res_array[i].rcntr);
+		ret = ft_close_fid(mr_res_array[i].mr);
+		if (ret)
+			return ret;
+		ret = ft_close_fid(mr_res_array[i].rcntr);
+		if (ret)
+			return ret;
 	}
 	free(mr_res_array);
 	free(remote_array);
@@ -275,6 +279,7 @@ int main(int argc, char **argv)
 {
 	int op;
 	int ret = 0;
+	int free_ret;
 
 	opts = INIT_OPTS;
 	opts.transfer_size = 4096;
@@ -319,7 +324,9 @@ int main(int argc, char **argv)
 
 	ret = run_test();
 
-	free_mr_res();
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = free_mr_res();
+	if (free_ret)
+		return free_ret;
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/poll.c
+++ b/functional/poll.c
@@ -201,7 +201,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret = 0;
+	int op, ret = 0, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -235,6 +235,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/rdm.c
+++ b/functional/rdm.c
@@ -47,7 +47,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -79,6 +79,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/rdm_atomic.c
+++ b/functional/rdm_atomic.c
@@ -352,10 +352,15 @@ static int run_test(void)
 	return run_all_ops ? run_ops() : run_op();
 }
 
-static void free_res(void)
+static int free_res(void)
 {
-	FT_CLOSE_FID(mr_result);
-	FT_CLOSE_FID(mr_compare);
+	int ret;
+	ret = ft_close_fid(mr_result);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(mr_compare);
+	if (ret)
+		return ret;
 	if (result) {
 		free(result);
 		result = NULL;
@@ -364,6 +369,7 @@ static void free_res(void)
 		free(compare);
 		compare = NULL;
 	}
+	return 0;
 }
 
 static uint64_t get_mr_key()
@@ -486,7 +492,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 
@@ -541,7 +547,8 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	free_res();
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = free_res();
+	if (!free_ret)
+		free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/rdm_deferred_wq.c
+++ b/functional/rdm_deferred_wq.c
@@ -565,17 +565,23 @@ static int alloc_mr_res()
 	return 0;
 }
 
-static void free_mr_res()
+static int free_mr_res()
 {
-	FT_CLOSE_FID(mr_result);
-	FT_CLOSE_FID(mr_compare);
+	int ret;
+	ret = ft_close_fid(mr_result);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(mr_compare);
+	if (ret)
+		return ret;
 	free(result_buf);
 	free(compare_buf);
+	return 0;
 }
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options = FT_OPT_SIZE | FT_OPT_RX_CNTR | FT_OPT_TX_CNTR;
@@ -661,12 +667,14 @@ int main(int argc, char **argv)
 	if (ret)
 		return ret;
 
-	free_mr_res();
+	ret = free_mr_res();
+	if (ret)
+		return ret;
 
 	ret = fi_close(&test_cntr->fid);
 	if (ret)
 		FT_PRINTERR("fi_cntr_close", ret);
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/rdm_multi_recv.c
+++ b/functional/rdm_multi_recv.c
@@ -175,9 +175,10 @@ out:
 	return ret;
 }
 
-static void free_res(void)
+static int free_res(void)
 {
-	FT_CLOSE_FID(mr_multi_recv);
+	int ret;
+	ret = ft_close_fid(mr_multi_recv);
 	if (tx_buf) {
 		free(tx_buf);
 		tx_buf = NULL;
@@ -186,6 +187,7 @@ static void free_res(void)
 		free(rx_buf);
 		rx_buf = NULL;
 	}
+	return ret;
 }
 
 static int alloc_ep_res(struct fi_info *fi)
@@ -324,7 +326,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -363,7 +365,8 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	free_res();
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = free_res();
+	if (!free_ret)
+		free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/rdm_rma_simple.c
+++ b/functional/rdm_rma_simple.c
@@ -90,7 +90,7 @@ static int run_test(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options = FT_OPT_SIZE | FT_OPT_RX_CNTR | FT_OPT_TX_CNTR;
@@ -122,6 +122,6 @@ int main(int argc, char **argv)
 
 	ret = run_test();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/rdm_rma_trigger.c
+++ b/functional/rdm_rma_trigger.c
@@ -124,7 +124,7 @@ out:
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options = FT_OPT_SIZE | FT_OPT_RX_CNTR | FT_OPT_TX_CNTR;
@@ -157,6 +157,6 @@ int main(int argc, char **argv)
 
 	ret = run_test();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/rdm_shared_av.c
+++ b/functional/rdm_shared_av.c
@@ -151,7 +151,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -202,7 +202,6 @@ int main(int argc, char **argv)
 		}
 	}
 
-	ft_free_res();
-
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/rdm_tagged_peek.c
+++ b/functional/rdm_tagged_peek.c
@@ -225,7 +225,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int ret, op;
+	int ret, op, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -262,6 +262,6 @@ int main(int argc, char **argv)
 
 	ret = run();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/recv_cancel.c
+++ b/functional/recv_cancel.c
@@ -186,6 +186,7 @@ int main(int argc, char **argv)
 {
 	int op;
 	int ret = 0;
+	int free_ret;
 
 	opts = INIT_OPTS;
 
@@ -219,6 +220,6 @@ int main(int argc, char **argv)
 
 	ret = run_test();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/resmgmt_test.c
+++ b/functional/resmgmt_test.c
@@ -180,6 +180,7 @@ int main(int argc, char **argv)
 {
 	int op;
 	int ret = 0;
+	int free_ret;
 
 	opts = INIT_OPTS;
 	opts.tx_cq_size = max_opts;
@@ -267,6 +268,6 @@ int main(int argc, char **argv)
 
 	ret = run_test();
 
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/resource_freeing.c
+++ b/functional/resource_freeing.c
@@ -299,5 +299,5 @@ int main(int argc, char **argv)
 			i);
 	}
 
-	return ft_exit_code(exit_code);
+	return ft_exit_code(exit_code, 0);
 }

--- a/functional/scalable_ep.c
+++ b/functional/scalable_ep.c
@@ -350,7 +350,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int ret, op;
+	int ret, op, free_ret;
 
 	opts = INIT_OPTS;
 	opts.options = FT_OPT_SIZE;
@@ -383,7 +383,10 @@ int main(int argc, char **argv)
 
 	free_res();
 	/* Closes the scalable ep that was allocated in the test */
-	FT_CLOSE_FID(sep);
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_close_fid(&sep->fid);
+	if (free_ret)
+		return free_ret;
+
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/functional/shared_ctx.c
+++ b/functional/shared_ctx.c
@@ -592,7 +592,7 @@ static int run(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret = 0;
 	int option_index = 0;
 
 	struct option long_options[] = {
@@ -653,13 +653,19 @@ int main(int argc, char **argv)
 	ret = run();
 
 	FT_CLOSEV_FID(ep_array, ep_cnt);
-	if (rx_shared_ctx)
-		FT_CLOSE_FID(srx_ctx);
-	if (tx_shared_ctx)
-		FT_CLOSE_FID(stx_ctx);
-	ft_free_res();
+	if (rx_shared_ctx) {
+		free_ret = ft_close_fid(srx_ctx);
+		if (free_ret)
+			return free_ret;
+	}
+	if (tx_shared_ctx) {
+		free_ret = ft_close_fid(stx_ctx);
+		if (free_ret)
+			return free_ret;
+	}
+	free_ret = ft_free_res();
 	free(addr_array);
 	free(ep_array);
 	fi_freeinfo(fi_dup);
-	return ft_exit_code(ret);
+	return ft_exit_code(ret, free_ret);
 }

--- a/ubertest/fabtest.h
+++ b/ubertest/fabtest.h
@@ -362,7 +362,7 @@ int ft_send_dgram_flood();
 int ft_sendrecv_dgram();
 int ft_send_rma();
 
-void ft_cleanup(void);
+int ft_cleanup(void);
 int ft_open_res();
 int ft_init_test();
 int ft_run_test();

--- a/ubertest/test_ctrl.c
+++ b/ubertest/test_ctrl.c
@@ -965,19 +965,35 @@ static int ft_run_unit(void)
 	return fail;
 }
 
-void ft_cleanup(void)
+int ft_cleanup(void)
 {
-	FT_CLOSE_FID(ft_rx_ctrl.mr);
-	FT_CLOSE_FID(ft_tx_ctrl.mr);
-	FT_CLOSE_FID(ft_mr_ctrl.mr);
-	FT_CLOSE_FID(ft_atom_ctrl.res_mr);
-	FT_CLOSE_FID(ft_atom_ctrl.comp_mr);
-	ft_free_res();
+	int ret;
+	ret = ft_close_fid(ft_rx_ctrl.mr);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(ft_tx_ctrl.mr);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(ft_mr_ctrl.mr);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(ft_atom_ctrl.res_mr);
+	if (ret)
+		return ret;
+	ret = ft_close_fid(ft_atom_ctrl.comp_mr);
+	if (ret)
+		return ret;
+	if (ret)
+		return ret;
+	ret = ft_free_res();
+	if (ret)
+		return ret;
 	ft_cleanup_xcontrol(&ft_rx_ctrl);
 	ft_cleanup_xcontrol(&ft_tx_ctrl);
 	ft_cleanup_mr_control(&ft_mr_ctrl);
 	ft_cleanup_atomic_control(&ft_atom_ctrl);
 	memset(&ft_ctrl, 0, sizeof ft_ctrl);
+	return 0;
 }
 
 static int ft_exchange_mr_addr_key(void)
@@ -1080,7 +1096,7 @@ cleanup:
 
 int ft_run_test()
 {
-	int ret;
+	int ret, free_ret;
 
 	switch (test_info.test_type) {
 	case FT_TEST_UNIT:
@@ -1104,7 +1120,8 @@ int ft_run_test()
 	}
 
 	ft_sync_test(0);
-	ft_cleanup();
+	free_ret = ft_cleanup();
+	ret = ret ? ret : free_ret;
 
 	return ret ? ret : -ft_ctrl.error;
 }

--- a/ubertest/uber.c
+++ b/ubertest/uber.c
@@ -855,5 +855,5 @@ out:
 	if (opts.dst_addr)
 		fts_close(series);
 	ft_free();
-	return ft_exit_code(ret);
+	return ft_exit_code(ret, 0);
 }

--- a/unit/av_test.c
+++ b/unit/av_test.c
@@ -280,6 +280,7 @@ av_good_sync()
 {
 	int testret;
 	int ret;
+	int free_ret;
 	struct fid_av *av;
 	struct fi_av_attr attr;
 	uint8_t addrbuf[4096];
@@ -321,7 +322,8 @@ av_good_sync()
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(av);
+	free_ret = ft_close_fid(av);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -334,6 +336,7 @@ av_bad_sync()
 {
 	int testret;
 	int ret;
+	int free_ret;
 	struct fid_av *av;
 	struct fi_av_attr attr;
 	uint8_t addrbuf[4096];
@@ -377,7 +380,8 @@ av_bad_sync()
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(av);
+	free_ret = ft_close_fid(av);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -391,6 +395,7 @@ av_goodbad_vector_sync()
 	int testret;
 	int ret;
 	int i;
+	int free_ret;
 	struct fid_av *av;
 	struct fi_av_attr attr;
 	uint8_t addrbuf[4096];
@@ -448,7 +453,8 @@ av_goodbad_vector_sync()
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(av);
+	free_ret = ft_close_fid(av);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -462,6 +468,7 @@ av_good_vector_async()
 	int testret;
 	int ret;
 	int i;
+	int free_ret;
 	struct fid_av *av;
 	struct fi_av_attr attr;
 	uint8_t addrbuf[4096];
@@ -522,7 +529,8 @@ av_good_vector_async()
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(av);
+	free_ret = ft_close_fid(av);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -535,6 +543,7 @@ av_zero_async()
 {
 	int testret;
 	int ret;
+	int free_ret;
 	struct fid_av *av;
 	struct fi_av_attr attr;
 	uint8_t addrbuf[4096];
@@ -574,7 +583,8 @@ av_zero_async()
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(av);
+	free_ret = ft_close_fid(av);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -588,6 +598,7 @@ av_good_2vector_async()
 	int testret;
 	int ret;
 	int i;
+	int free_ret;
 	struct fid_av *av;
 	struct fi_av_attr attr;
 	uint8_t addrbuf[4096];
@@ -682,7 +693,8 @@ av_good_2vector_async()
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(av);
+	free_ret = ft_close_fid(av);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -696,6 +708,7 @@ av_goodbad_vector_async()
 	int testret;
 	int ret;
 	int i;
+	int free_ret;
 	struct fid_av *av;
 	struct fi_av_attr attr;
 	uint8_t addrbuf[4096];
@@ -780,7 +793,8 @@ av_goodbad_vector_async()
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(av);
+	free_ret = ft_close_fid(av);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -836,7 +850,7 @@ static void usage(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 	int failed;
 
 	opts = INIT_OPTS;
@@ -933,6 +947,6 @@ int main(int argc, char **argv)
 	}
 
 err:
-	ft_free_res();
-	return ret ? ft_exit_code(ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+	free_ret = ft_free_res();
+	return ret ? ft_exit_code(ret, free_ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/cntr_test.c
+++ b/unit/cntr_test.c
@@ -153,7 +153,7 @@ static void usage(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 	int failed = 0;
 
 	hints = fi_allocinfo();
@@ -198,6 +198,6 @@ int main(int argc, char **argv)
 		printf("Summary: all tests passed\n");
 
 out:
-	ft_free_res();
-	return ret ? ft_exit_code(ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+	free_ret = ft_free_res();
+	return ret ? ft_exit_code(ret, free_ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/cq_test.c
+++ b/unit/cq_test.c
@@ -192,7 +192,7 @@ cq_signal()
 
 	testret = PASS;
 fail2:
-	FT_CLOSE_FID(cq);
+	return ft_close_fid(cq);
 fail1:
 	cq = NULL;
 	return TEST_RET_VAL(ret, testret);
@@ -213,7 +213,7 @@ static void usage(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 	int failed;
 
 	hints = fi_allocinfo();
@@ -256,6 +256,6 @@ int main(int argc, char **argv)
 	}
 
 err:
-	ft_free_res();
-	return ret ? ft_exit_code(ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+	free_ret = ft_free_res();
+	return ret ? ft_exit_code(ret, free_ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/dom_test.c
+++ b/unit/dom_test.c
@@ -59,7 +59,7 @@ static void usage(void)
 int main(int argc, char **argv)
 {
 	unsigned long i;
-	int op, ret = 0;
+	int op, ret = 0, free_ret;
 	unsigned long num_domains = 1;
 	char *ptr;
 
@@ -129,6 +129,6 @@ int main(int argc, char **argv)
 
 	free(domain_vec);
 out:
-	ft_free_res();
-	return ft_exit_code(ret);
+	free_ret = ft_free_res();
+	return ft_exit_code(ret, free_ret);
 }

--- a/unit/eq_test.c
+++ b/unit/eq_test.c
@@ -109,6 +109,7 @@ eq_write_read_self()
 	int testret;
 	int ret;
 	int i;
+	int free_ret;
 
 	testret = FAIL;
 
@@ -172,7 +173,8 @@ eq_write_read_self()
 	testret = PASS;
 
 fail:
-	FT_CLOSE_FID(eq);
+	free_ret = ft_close_fid(&eq->fid);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -187,6 +189,7 @@ eq_size_verify()
 	int testret;
 	int ret;
 	int i;
+	int free_ret;
 
 	testret = FAIL;
 
@@ -210,7 +213,8 @@ eq_size_verify()
 	testret = PASS;
 
 fail:
-	FT_CLOSE_FID(eq);
+	free_ret = ft_close_fid(&eq->fid);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -229,6 +233,7 @@ eq_wait_fd_poll()
 	struct fid *fids[1];
 	int testret;
 	int ret;
+	int free_ret;
 
 	testret = FAIL;
 
@@ -285,7 +290,8 @@ eq_wait_fd_poll()
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(eq);
+	free_ret = ft_close_fid(&eq->fid);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -367,6 +373,7 @@ static int eq_wait_read_peek(void)
 {
 	int testret;
 	int ret;
+	int free_ret;
 
 	testret = FAIL;
 
@@ -391,7 +398,8 @@ static int eq_wait_read_peek(void)
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(eq);
+	free_ret = ft_close_fid(&eq->fid);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -402,6 +410,7 @@ static int eq_wait_sread_peek(void)
 {
 	int testret;
 	int ret;
+	int free_ret;
 
 	testret = FAIL;
 
@@ -439,7 +448,8 @@ static int eq_wait_sread_peek(void)
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(eq);
+	free_ret = ft_close_fid(&eq->fid);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -456,6 +466,7 @@ eq_wait_fd_sread()
 	int64_t elapsed;
 	int testret;
 	int ret;
+	int free_ret;
 
 	testret = FAIL;
 
@@ -528,7 +539,8 @@ eq_wait_fd_sread()
 
 	testret = PASS;
 fail:
-	FT_CLOSE_FID(eq);
+	free_ret = ft_close_fid(&eq->fid);
+	ret = ret ? ret : free_ret;
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -567,7 +579,6 @@ eq_readerr_ret_eagain()
 				fi_eq_strerror(eq, err_entry.prov_errno, err_entry.err_data, NULL, 0));
 
 fail:
-	FT_CLOSE_FID(eq);
 	return TEST_RET_VAL(ret, testret);
 }
 
@@ -590,7 +601,7 @@ static void usage(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 	int failed;
 
 	hints = fi_allocinfo();
@@ -638,7 +649,8 @@ int main(int argc, char **argv)
 		printf("Summary: all tests passed\n");
 	}
 
+
 err:
-	ft_free_res();
-	return ret ? ft_exit_code(ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+	free_ret = ft_free_res();
+	return ret ? ft_exit_code(ret, free_ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/getinfo_test.c
+++ b/unit/getinfo_test.c
@@ -700,6 +700,7 @@ int main(int argc, char **argv)
 {
 	int failed;
 	int op;
+	int ret;
 	size_t len;
 	const char *util_name;
 
@@ -800,6 +801,9 @@ int main(int argc, char **argv)
 		printf("\nSummary: all tests passed\n");
 	}
 
-	ft_free_res();
+	ret = ft_free_res();
+	if (ret)
+		return EXIT_FAILURE;
+
 	return (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/unit/mr_test.c
+++ b/unit/mr_test.c
@@ -202,7 +202,7 @@ static void usage(void)
 
 int main(int argc, char **argv)
 {
-	int op, ret;
+	int op, ret, free_ret;
 	int failed = 0;
 
 	buf = NULL;
@@ -268,6 +268,6 @@ int main(int argc, char **argv)
 	}
 
 out:
-	ft_free_res();
-	return ret ? ft_exit_code(ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+	free_ret = ft_free_res();
+	return ret ? ft_exit_code(ret, free_ret) : (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
This is done to preserve return code from teardown function.

There was possibility for test to pass even if there were problems with
freeing resources. To prevent this from happening, it's necessary to
check teardown return code.

Signed-off-by: Salnik, Marcin <marcin.salnik@intel.com>